### PR TITLE
Changing method name to get rid of log error message

### DIFF
--- a/source/code/plugins/omslog.rb
+++ b/source/code/plugins/omslog.rb
@@ -14,7 +14,7 @@ module OMS
         log_once(@@error_proc, @@debug_proc, message, tag)
       end
 
-      def warning_once(message, tag=nil)
+      def warn_once(message, tag=nil)
         log_once(@@warn_proc, @@debug_proc, message, tag)
       end
 


### PR DESCRIPTION
This is referenced by in line 40 of filter_syslog.rb as warn_once, changing the method name to be the same

```ruby
host_ip = @ip_cache.get_ip(hostname)
      if host_ip.nil?
          OMS::Log.warn_once("Failed to get the IP for #{hostname}.")
      else
```