### PR TITLE
Make output plugin compression configurable

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -75,9 +75,10 @@ module OMS
       # parameters:
       #   path: string. path of the request
       #   record: Hash. body of the request
+      #   compress: bool. Whether the body of the request should be compressed
       # returns:
       #   HTTPRequest. request to ODS
-      def create_ods_request(path, record, compress=true)
+      def create_ods_request(path, record, compress)
         headers = {}
         headers["Content-Type"] = "application/json"
         if compress == true

--- a/source/code/plugins/out_oms.rb
+++ b/source/code/plugins/out_oms.rb
@@ -22,6 +22,7 @@ module Fluent
     config_param :cert_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.crt'
     config_param :key_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.key'
     config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/proxy.conf'
+    config_param :compress, :bool, :default => true
 
     def configure(conf)
       s = conf.add_element("secondary")
@@ -39,7 +40,7 @@ module Fluent
     end
 
     def handle_record(tag, record)
-      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record)
+      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record, @compress)
       unless req.nil?
         http = OMS::Common.create_ods_http(OMS::Configuration.ods_endpoint, @proxy_config)
         start = Time.now


### PR DESCRIPTION
This allows to turn off the compression in the omsagent.conf file.
Compression is enabled by default.
@Microsoft/omsagent-devs 