### PR TITLE
Fix the bug in the encode before sending the request

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -111,7 +111,12 @@ module OMS
         rescue => error 
           # failed encoding, encode to utf-8, iso-8859-1 and try again
           begin
-            msg = JSON.dump(record.encode('utf-8', 'iso-8859-1'))
+            if !record["DataItems"].nil?
+              record["DataItems"].each do |item|
+                item["Message"] = item["Message"].encode('utf-8', 'iso-8859-1')
+              end
+            end
+            msg = JSON.dump(record)
           rescue => error
             # at this point we've given up up, we don't recognize
             # the encode, so return nil and log_warning for the 

--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -122,11 +122,12 @@ module OMS
     def test_parse_json_record_encoding
       record = "syslog record"
       parsed_record = Common.parse_json_record_encoding(record);
-      assert_equal(record.to_json,parsed_record, "parse json record no encoding failed");
+      assert_equal(record.to_json, parsed_record, "parse json record no encoding failed");
       
-      record = "iPhone\xAE";
+      record = {}
+      record["DataItems"] = [ {"Message" => "iPhone\xAE"} ];
       parsed_record = Common.parse_json_record_encoding(record);
-      assert_equal("iPhone®".to_json,parsed_record, "parse json record utf-8 encoding failed");
+      assert_equal("{\"DataItems\":[{\"Message\":\"iPhone®\"}]}", parsed_record, "parse json record utf-8 encoding failed");
     end	
   end
 end # Module OMS


### PR DESCRIPTION
we should expect record to be: {"DataItems" => [ {"Message" => 'message1'}, {"Message" => 'message2'}] }
@Microsoft/omsagent-devs @sw47 