### PR TITLE
Fix createbundle to work with multiple packages present

### DIFF
--- a/installer/bundle/create_bundle.sh
+++ b/installer/bundle/create_bundle.sh
@@ -89,10 +89,10 @@ INTERMEDIATE_DIR=`(cd $INTERMEDIATE; pwd -P)`
 # Switch to one of the output directories to avoid directory prefixes
 cd $INTERMEDIATE/098
 
-SCX_PACKAGE=`ls scx-*.rpm | sed 's/.rpm$//'`
-OMI_PACKAGE=`ls omi-*.rpm | sed 's/.rpm$//'`
-OMS_PACKAGE=`ls omsagent-*.rpm | sed 's/.rpm$//'`
-DSC_PACKAGE=`ls omsconfig-*.rpm | sed 's/.rpm$//'`
+SCX_PACKAGE=`ls scx-*.rpm | sed 's/.rpm$//' | tail -1`
+OMI_PACKAGE=`ls omi-*.rpm | sed 's/.rpm$//' | tail -1`
+OMS_PACKAGE=`ls omsagent-*.rpm | sed 's/.rpm$//' | tail -1`
+DSC_PACKAGE=`ls omsconfig-*.rpm | sed 's/.rpm$//' | tail -1`
 
 # TODO : Add verification to insure all flavors exist
 


### PR DESCRIPTION
The sed commands fails otherwise because they are invalid when we expand a variable with a multiline string. `sed: -e expression #1, char 59: unterminated 's' command`
`ls` sorts the names alphabetically so `tail -1` will use the latest kit present.

Diagnostic : There are multiple versions of the same package in the same directory.
```
✔ ~/git/bld-omsagent/omsagent/build [master|✔]
$ find ../ -name *.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/098/omsconfig-1.1.1-114.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/098/omi-1.0.8-4.universal.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/098/omsagent-1.1.0-77.universal.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/098/scx-cimprov-1.6.2-218.universal.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/098/omsagent-1.1.0-80.universal.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/100/omsconfig-1.1.1-114.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/100/omi-1.0.8-4.universal.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/100/omsagent-1.1.0-77.universal.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/100/scx-cimprov-1.6.2-218.universal.x64.rpm
../intermediate/Linux_ULINUX_1.0_x64_64_Release/100/omsagent-1.1.0-80.universal.x64.rpm
```

Manual fix : Remove the old versions.
```
rm ../intermediate/Linux_ULINUX_1.0_x64_64_Release/098/omsagent-1.1.0-77.universal.x64.rpm
rm ../intermediate/Linux_ULINUX_1.0_x64_64_Release/100/omsagent-1.1.0-77.universal.x64.rpm
```

@Microsoft/omsagent-devs 