### PR TITLE
Fix the bundle upgrade issue in DPKG

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -315,7 +315,7 @@ getInstalledVersion()
     if check_if_pkg_is_installed $1; then
         if [ "$INSTALLER" = "DPKG" ]; then
             local version=`dpkg -s $1 2> /dev/null | grep "Version: "`
-            getVersionNumber $version "Version: "
+            getVersionNumber "$version" "Version: "
         else
             local version=`rpm -q $1 2> /dev/null`
             getVersionNumber $version ${1}-


### PR DESCRIPTION
In DPKG, the $version string contains whitespace, which will be regarded as 2 parameters for the getVersionNumber.
@Microsoft/omsagent-devs 