### PR TITLE
Remove the extra dot when calling msg.length

### DIFF
--- a/source/code/plugins/out_oms_blob.rb
+++ b/source/code/plugins/out_oms_blob.rb
@@ -121,7 +121,7 @@ module Fluent
       # concatenate the messages
       msg = ''
       msgs.each { |s| msg << "#{s}\r\n" if s.to_s.length > 0 }
-      dataSize = msg..length
+      dataSize = msg.length
 
       if dataSize == 0
         return 0


### PR DESCRIPTION
@Microsoft/omsagent-devs 