### PR TITLE
Change log level of retryable exception message

### DIFF
--- a/source/code/plugins/out_oms.rb
+++ b/source/code/plugins/out_oms.rb
@@ -54,7 +54,8 @@ module Fluent
         @log.debug "Success sending #{tag} x #{count} in #{time.round(2)}s"
       end
     rescue OMS::RetryRequestException => e
-      @log.debug "Encountered retryable exception. Will retry sending data later. Error:'#{e}'"
+      @log.info "Encountered retryable exception. Will retry sending data later."
+      @log.debug "Error:'#{e}'"
       # Re-raise the exception to inform the fluentd engine we want to retry sending this chunk of data later.
       raise e
     rescue => e


### PR DESCRIPTION
In reply to [this comment ](https://github.com/Microsoft/OMS-Agent-for-Linux/commit/0cb36e71dd6d5c7da0104220c26b86cba660aca8#commitcomment-16920041) by @agup006 
Moved the actual printing of the error to a separate debug message because the error detail is not interesting at the info level.
@Microsoft/omsagent-devs