### PR TITLE
Do not copy the change tracking config into the omsagent.d folder

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -111,7 +111,7 @@ fi
 mkdir -m 755 ${{CONF_DIR}}/omsagent.d 2> /dev/null || true
 
 # Copy over standalone plugin configurations
-cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/* ${{CONF_DIR}}/omsagent.d
+#cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/* ${{CONF_DIR}}/omsagent.d
 
 # The real conf directory has to be owned by omsagent to be readable by the omsagent daemon
 chown -R omsagent:omsagent ${{CONF_DIR}}


### PR DESCRIPTION
@Microsoft/omsagent-devs @niroyb 
We should not copy the change tracking config into the omsagent.d in the installation. It should be added by the nxOMSPlugin module based on whether the customer enables the change tracking solution.
I still binplace the file into the /etc/opt/microsoft/omsagent/sysconf/omsagent.d folder, so that customer can copy them manually.