### PR TITLE
Change test_time_skew source of official time

### DIFF
--- a/test/installer/scripts/time_systest.rb
+++ b/test/installer/scripts/time_systest.rb
@@ -3,32 +3,23 @@ require 'rexml/document'
 require 'open-uri'
 
 class Time_Test < Test::Unit::TestCase
-  
+
   def test_time_skew()
-    # Get the real time from nist
-    url = "http://nist.time.gov/actualtime.cgi"
-    source = open(url, &:read)
-    doc = REXML::Document.new source
-    nanosec_date_str = doc.root.attributes["time"]
-    assert(nanosec_date_str.size >= 16)
-    real_epoch = nanosec_date_str.to_i/1000/1000
-    real_time = Time.at(real_epoch)
-    
-    system_epoch = Time.now.to_i
-    
+    output = `ntpdate -q pool.ntp.org`
+    assert_equal(0, $?, "ntpdate command failed with error code : #{$?}")
+    offset_line = output[/offset (.*) sec/]
+    assert(offset_line != nil, "Could not find the offset line in '#{output}'")
+    offset = offset_line.gsub(/offset (.*) sec/, '\1').to_f
+
     err_msg = %(
 Large system time offset detected.
 Onboarding may fail with a 403 code.
 System : #{Time.now}
-Real   : #{real_time}
-Use 'sudo date -s @#{real_epoch}'
+Offset : #{offset}
 )
-    
-    # Allow a max difference of 5 minutes
-    max_delta = 5 * 60
-    
-    assert(real_epoch - max_delta < system_epoch, err_msg)
-    assert(system_epoch < real_epoch + max_delta, err_msg)
+    # Allow a max difference of 5 minutes between the computer time and the real time
+    max_offset = 5 * 60
+    assert(offset.abs < max_offset, err_msg)
   end
 
 end


### PR DESCRIPTION
We used to parse nist.gov but it was not reliable. Instead we use ntp servers.
@Microsoft/omsagent-devs 