### PR TITLE
Preserve Case in Http Request

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -729,4 +729,13 @@ module OMS
 
   end
 
+  class CaseSensitiveString < String
+    def downcase
+        self
+    end
+    def capitalize
+        self
+    end
+  end
+
 end # module OMS

--- a/source/code/plugins/out_oms_blob.rb
+++ b/source/code/plugins/out_oms_blob.rb
@@ -70,7 +70,7 @@ module Fluent
     def create_blob_put_request(uri, msg)
       headers = {}
 
-      headers["x-ms-meta-timezoneid"] = OMS::Common.get_current_timezone
+      headers[OMS::CaseSensitiveString.new("x-ms-meta-timezoneid")] = OMS::Common.get_current_timezone
       headers["Content-Type"] = "application/octet-stream"
       headers["Content-Length"] = msg.bytesize.to_s
 


### PR DESCRIPTION
Create CaseSensitiveString < String class (override the downcase and capitalize method to return self) and use it in the Http Request header to preserve the case in header name. This is a workaround that Ruby library converts the header name (http://stackoverflow.com/questions/10258893/stop-ruby-http-request-modifying-header-name) while the OMS workflow is case sensitive.
@Microsoft/omsagent-devs 