### PR TITLE
Mark shared Microsoft folders as sysdir

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -64,17 +64,17 @@ MAINTAINER:              'Microsoft Corporation'
 /var;                                                   755; root; root; sysdir
 /var/opt;                                               755; root; root; sysdir
 
-/etc/opt/microsoft;                                     755; root; root
+/etc/opt/microsoft;                                     755; root; root; sysdir
 /etc/opt/microsoft/omsagent;                            755; root; root
 /etc/opt/microsoft/omsagent/sysconf;                    755; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d;         755; root; root
 
-/opt/microsoft;                                         755; root; root
+/opt/microsoft;                                         755; root; root; sysdir
 /opt/microsoft/omsagent;                                755; root; root
 /opt/microsoft/omsagent/bin;                            755; root; root
 /opt/microsoft/omsagent/plugin;                         755; root; root
 
-/var/opt/microsoft;                                     755; root; root
+/var/opt/microsoft;                                     755; root; root; sysdir
 
 %Dependencies
 


### PR DESCRIPTION
In certain install scenarios, the package manager detects a conflict with these files and installation fails.
```
----- Updating package: omsagent (omsagent-1.1.0-138.universal.x64) -----
        file /etc/opt/microsoft from install of omsagent-1.1.0-138.x86_64 conflicts with file from package scx-1.6.2-274.x86_64
        file /opt/microsoft from install of omsagent-1.1.0-138.x86_64 conflicts with file from package scx-1.6.2-274.x86_64
        file /var/opt/microsoft from install of omsagent-1.1.0-138.x86_64 conflicts with file from package scx-1.6.2-274.x86_64
Checking for ctypes python module ...
----- Updating package: omsconfig (omsconfig-1.1.1-158.x64) -----
error: Failed dependencies:
        omsagent >= 1.0.0 is needed by omsconfig-1.1.1-158.x86_64
```

@Microsoft/omsagent-devs 