### PR TITLE
Restarting omiserver to deal with postuninstall issue

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -800,6 +800,7 @@ case "$installMode" in
                     fi
                 fi
             fi
+            /opt/omi/bin/service_control restart
         fi
 
         # Upgrade bundled providers


### PR DESCRIPTION
We have to restart omiserver (again) after the upgrade process because of a bug in a previous omi version's PostUninstall script which removed the omiserver.sock file, which gets run after the new kit's scripts are invoked (on RPM systems).

This can be removed after the next release of the shell bundle, but is harmless if it isn't.