### PR TITLE
Running omsagent as group omiusers

### DIFF
--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -196,6 +196,9 @@ if [ $? -ne 0 ]; then
     useradd -r -c "OMS agent" -d /var/opt/microsoft/omsagent/run -g omsagent -s /bin/bash omsagent
 fi
 
+# Ensure omsagent is in the omiusers group, but leave omsagent as a group
+/usr/sbin/usermod -g omiusers omsagent 1> /dev/null 2> /dev/null
+
 %Postinstall_200
 #include Syslog_Services
 #include Sudoer_Functions
@@ -243,7 +246,7 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
 
     # Remove the service account
     echo "Deleting omsagent service account ..."
-    userdel omsagent
+    userdel omsagent 2> /dev/null
 
     if [ $? -eq 0 ]; then
         # Depending on system settings, the group may not have been deleted

--- a/installer/scripts/omsagent.systemd
+++ b/installer/scripts/omsagent.systemd
@@ -6,7 +6,7 @@ Wants=omid.service
 [Service]
 Type=simple
 User=omsagent
-Group=omsagent
+Group=omiusers
 PIDFile=/var/opt/microsoft/omsagent/run/omsagent.pid
 ExecStart=/opt/microsoft/omsagent/bin/omsagent \
   -d /var/opt/microsoft/omsagent/run/omsagent.pid \


### PR DESCRIPTION
Setting the omsagent user to have the omiusers group, and silencing stderr messages from userdel that would sometimes warn that the group that was created to go with this user was not being deleted.