### PR TITLE
Restart omsagent service after upgrade

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -801,6 +801,7 @@ case "$installMode" in
                 fi
             fi
             /opt/omi/bin/service_control restart
+            /opt/microsoft/omsagent/bin/service_control restart
         fi
 
         # Upgrade bundled providers

--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -784,6 +784,7 @@ case "$installMode" in
         fi
 
         if [ $KIT_STATUS -eq 0 ]; then
+            # These conditionals exist due to some upgrade bugs in the postuninstall scripts of previous kits. These can be removed after GA.
             if [ -d /opt/microsoft/omsconfig ]; then
                 if [ ! -f /opt/microsoft/omsconfig/Scripts/2.6x-2.7x/Scripts/nxOMSAgent.py ]; then
                     if ! su - omsagent -c "/opt/microsoft/omsconfig/Scripts/InstallModule.py /opt/microsoft/omsconfig/module_packages/nxOMSAgent_1.0.zip 0"; then
@@ -797,11 +798,11 @@ case "$installMode" in
                         KIT_STATUS=1
                     else
                         chown omsagent /etc/opt/microsoft/omsagent/conf/omsagent.d/omsconfig.consistencyinvoker.conf
+                        /opt/microsoft/omsagent/bin/service_control reload
                     fi
                 fi
             fi
             /opt/omi/bin/service_control restart
-            /opt/microsoft/omsagent/bin/service_control restart
         fi
 
         # Upgrade bundled providers


### PR DESCRIPTION
omsagent is not restarted after a successful upgrade, but it likely should be for future releases of the omsagent bundle (and definitely in this release of the bundle, as not restarting omsagent caused a bug when the omsconfig.consistencyinvoker.conf file was deleted and then immediately replaced after an upgrade).

However, I don't know the reasoning as to why omsagent wasn't previously restarted after an upgrade, perhaps it was intentional, so I'd like to get @jeffaco and @niroyb to review this!