### PR TITLE
Monitor agent health

### DIFF
--- a/installer/conf/omsagent.d/monitor.conf
+++ b/installer/conf/omsagent.d/monitor.conf
@@ -1,0 +1,24 @@
+<source>
+  type monitor_agent
+  tag oms.operation
+  emit_interval 5m
+# emit_config true
+</source>
+
+<filter oms.operation.**>
+  type filter_operation
+</filter>
+
+<match oms.operation.**>
+  type out_oms
+  log_level info
+  buffer_chunk_limit 1m
+  buffer_type file
+  buffer_path /var/opt/microsoft/omsagent/state/out_oms_operation*.buffer
+  buffer_queue_limit 5
+  flush_interval 20s
+  retry_limit 10
+  retry_wait 30s
+  max_retry_wait 5m
+</match>
+

--- a/source/code/plugins/filter_operation.rb
+++ b/source/code/plugins/filter_operation.rb
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+module Fluent
+  class OperationFilter < Filter
+
+    Plugin.register_filter('filter_operation', self)
+
+    require_relative 'operation_lib'
+
+    def start
+      super
+      @operation_lib = OperationModule::Operation.new(OperationModule::RuntimeError.new)
+    end
+			
+    def filter(tag, time, record)
+      records = @operation_lib.filter_and_wrap(record, time)
+      # only return non empty records
+      if !records.empty?
+        return records
+      end
+    end
+
+  end
+end
+

--- a/source/code/plugins/operation_lib.rb
+++ b/source/code/plugins/operation_lib.rb
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+module OperationModule
+  class LoggingBase
+    def log_error(text)
+    end
+  end
+  
+  class RuntimeError < LoggingBase
+    def log_error(text)
+      $log.info "RuntimeError: #{text}"
+    end
+  end
+  
+  class Operation
+    require_relative 'oms_common'
+
+    BUFFER_QUEUE_WARNING_THRESHOLD_PERCENTAGE = 90
+
+    def initialize(error_handler)
+      @error_handler = error_handler
+    end
+    
+    def filter(record, time)
+      if record.is_a?(Hash) && record['type'] == 'out_oms' && record['config'].is_a?(Hash) && record['config']['buffer_queue_limit'].is_a?(String) && record['buffer_queue_length'].is_a?(Integer)
+        buffer_queue_limit = record['config']['buffer_queue_limit'].to_i
+        buffer_queue_length = record['buffer_queue_length']
+        if buffer_queue_limit != 0 && (buffer_queue_length * 100 / buffer_queue_limit) >= BUFFER_QUEUE_WARNING_THRESHOLD_PERCENTAGE
+          return {
+            "Timestamp"=>OMS::Common.format_time(time),
+            "OperationStatus"=>"Warning",
+            "Computer"=>`hostname`.strip,
+            "Detail"=>"OMS Agent for Linux buffer queue is 90% full - adjust agent configuration for higher throughput.",
+            "Category"=>"OMS Agent for Linux buffer is 90% full",
+            "Solution"=>"Log Management",
+            "HelpLink"=>""
+          }
+        end
+      end
+
+      return {}
+    end
+ 
+    def filter_and_wrap(record, time)
+      data_item = filter(record, time)
+      if (data_item != nil and data_item.size > 0)
+        wrapper = {
+         "DataType"=>"OPERATION_BLOB",
+         "IPName"=>"LogManagement",
+         "DataItems"=>[data_item]
+        }
+        return wrapper
+      else
+        return {}
+      end
+    end
+
+  end
+end
+

--- a/test/code/plugins/operation_lib_test.rb
+++ b/test/code/plugins/operation_lib_test.rb
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+require 'test/unit'
+require_relative '../../../source/code/plugins/operation_lib'
+
+class OperationTestRuntimeError < OperationModule::LoggingBase
+  def log_error(text)
+    raise text
+  end
+end
+
+class OperationLib_Test < Test::Unit::TestCase
+  class << self
+    def startup
+      @@operation_lib = OperationModule::Operation.new(OperationTestRuntimeError.new)
+    end
+
+    def shutdown
+      #no op
+    end
+  end
+
+  def test_filter_null_empty
+    assert_equal({}, call_filter(nil), "null record fails")
+    assert_equal({}, call_filter(""), "empty string record fails")
+    assert_equal({}, call_filter(10), "int record fails")
+    assert_equal({}, call_filter({}), "empty hash record fails")
+  end
+
+  def test_filter_invalid_hash
+    assert_equal({}, call_filter({"name"=>"value"}), "invalid operation record - no type - fails")
+    assert_equal({}, call_filter({"type"=>"oms"}), "invalid operation record - invalid type - fails")
+    assert_equal({}, call_filter({"type"=>"out_oms"}), "invalid operation record - no config - fails")
+    assert_equal({}, call_filter({"type"=>"out_oms", "config"=>"10"}), "invalid operation record - config not hash - fails")
+    assert_equal({}, call_filter({"type"=>"out_oms", "config"=>{}}), "invalid operation record - config empty hash - fails")
+    assert_equal({}, call_filter({"type"=>"out_oms", "config"=>{"buffer_queue_limit"=>10}}), "invalid operation record - config bufqlim not str - fails")
+    assert_equal({}, call_filter({"type"=>"out_oms", "config"=>{"buffer_queue_limit"=>"10"}}), "invalid operation record - no bufqlen - fails")
+    assert_equal({}, call_filter({"type"=>"out_oms", "config"=>{"buffer_queue_limit"=>"10"}, "buffer_queue_length"=>"10"}), "invalid operation record - bufqlen string - fails")
+    assert_equal({}, call_filter({"type"=>"out_oms", "config"=>{"buffer_queue_limit"=>"str"}, "buffer_queue_length"=>10}), "invalid operation record - bufqlim not really int - fails")
+  end 
+
+  def test_filter_valid_hash
+    assert_equal({}, call_filter({"type"=>"out_oms", "config"=>{"buffer_queue_limit"=>"10"}, "buffer_queue_length"=>8}), "valid record - bufq below limit - fails")
+    data_item = call_filter({"type"=>"out_oms", "config"=>{"buffer_queue_limit"=>"10"}, "buffer_queue_length"=>9})
+    assert(data_item.has_key?("Timestamp") && data_item.has_key?("OperationStatus") && data_item.has_key?("Computer") && data_item.has_key?("Detail") && data_item.has_key?("Category") && data_item.has_key?("Solution") && data_item.has_key?("HelpLink"))
+  end
+
+  # wrapper to call filter
+  def call_filter(record)
+    @@operation_lib.filter(record, Time.now)
+  end
+end
+


### PR DESCRIPTION
- Add standard monitor_agent input plugin (emit_config is commented out which is supported as part of https://github.com/fluent/fluentd/pull/963)
- Add filter plugin which will return a record when output plugin's buffer queue is more than 90% full
- Add new instance of out_oms plugin for oms.operation tag only
- Add unit test

Waiting on Anurag to provide field details (operationstatus, detail, category. solution, helplink)

@Microsoft/omsagent-devs 