### PR TITLE
Fix exception type for buffer retry logic

### DIFF
--- a/source/code/plugins/out_oms.rb
+++ b/source/code/plugins/out_oms.rb
@@ -58,7 +58,7 @@ module Fluent
       @log.info "Encountered retryable exception. Will retry sending data later."
       @log.debug "Error:'#{e}'"
       # Re-raise the exception to inform the fluentd engine we want to retry sending this chunk of data later.
-      raise e
+      raise e.message
     rescue => e
       # We encountered something unexpected. We drop the data because
       # if bad data caused the exception, the engine will continuously


### PR DESCRIPTION
It turns out that the fluentd engine does not handle custom exceptions properly.
By rethrowing the message, we are creating a Runtime exception instead of a RetryRequest Exception.
This is what fluend expects.
@Microsoft/omsagent-devs 