### PR TITLE
Heartbeat input plugin

### DIFF
--- a/installer/conf/omsagent.d/monitor.conf
+++ b/installer/conf/omsagent.d/monitor.conf
@@ -5,16 +5,21 @@
 # emit_config true
 </source>
 
+<source>
+  type oms_heartbeat
+  interval 5m
+</source>
+
 <filter oms.operation.**>
   type filter_operation
 </filter>
 
-<match oms.operation.**>
+<match oms.operation.** oms.heartbeat.**>
   type out_oms
   log_level info
   buffer_chunk_limit 1m
   buffer_type file
-  buffer_path /var/opt/microsoft/omsagent/state/out_oms_operation*.buffer
+  buffer_path /var/opt/microsoft/omsagent/state/out_oms_health*.buffer
   buffer_queue_limit 5
   flush_interval 20s
   retry_limit 10

--- a/source/code/plugins/heartbeat_lib.rb
+++ b/source/code/plugins/heartbeat_lib.rb
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+module HeartbeatModule
+  class LoggingBase
+    def log_error(text)
+    end
+  end
+
+  class RuntimeError < LoggingBase
+    def log_error(text)
+      $log.error "RuntimeError: #{text}"
+    end
+  end
+
+  class Heartbeat
+    require 'json'
+    require_relative 'oms_common'
+  
+    def initialize(error_handler)
+      @error_handler = error_handler
+    end
+
+    # match string of the form (1 or more non . chars)- followed by a . - (1 or more non . chars) - followed by anything
+    MAJOR_MINOR_VERSION_REGEX = /([^\.]+)\.([^\.]+).*/
+
+    def get_heartbeat_data_item(time, os_conf_file_path, agent_install_conf_file_path)
+      record = {}
+      record["Timestamp"] = OMS::Common.format_time(time)
+
+      fqdn = OMS::Common.get_fully_qualified_domain_name
+      if fqdn.nil?
+        record["Device"] = OMS::Common.get_hostname
+      else 
+        record["Device"] = fqdn
+      end
+
+      record["OSType"] = "Linux"
+      os_name = OMS::Common.get_os_name(os_conf_file_path)
+      record["OSName"] = os_name unless os_name.nil?
+      os_version = OMS::Common.get_os_version(os_conf_file_path)
+      os_major_version = os_version[MAJOR_MINOR_VERSION_REGEX, 1] unless os_version.nil?
+      os_minor_version = os_version[MAJOR_MINOR_VERSION_REGEX, 2] unless os_version.nil?
+      record["OSMajorVersion"] = os_major_version unless os_major_version.nil?
+      record["OSMinorVersion"] = os_minor_version unless os_minor_version.nil?
+
+      record["Category"] = "Agent"
+      record["SCAgentChannel"] = "Direct"
+
+      installed_date = OMS::Common.get_installed_date(agent_install_conf_file_path)
+      record["InstalledDate"] = installed_date unless installed_date.nil?
+      agent_version = OMS::Common.get_agent_version(agent_install_conf_file_path)
+      record["Version"] = agent_version unless agent_version.nil?
+
+      return record
+    end
+
+    def enumerate(time, os_conf_file_path = "/etc/opt/microsoft/scx/conf/scx-release", agent_install_conf_file_path = "/etc/opt/microsoft/omsagent/sysconf/installinfo.txt")
+      data_item = get_heartbeat_data_item(time, os_conf_file_path, agent_install_conf_file_path)
+      wrapper = {
+         "DataType"=>"HEALTH_ASSESSMENT_BLOB",
+         "IPName"=>"LogManagement",
+         "DataItems"=>[data_item]
+      }
+      return wrapper
+    end
+
+  end
+
+end

--- a/source/code/plugins/in_oms_heartbeat.rb
+++ b/source/code/plugins/in_oms_heartbeat.rb
@@ -1,0 +1,68 @@
+#!/usr/local/bin/ruby
+
+module Fluent
+
+  class OMS_Heartbeat_Input < Input
+    Plugin.register_input('oms_heartbeat', self)
+
+    def initialize
+      super
+      require_relative 'heartbeat_lib'
+    end
+
+    config_param :interval, :time, :default => nil
+    config_param :tag, :string, :default => "oms.heartbeat"  
+
+    def configure (conf)
+      super
+    end
+
+    def start
+      @heartbeat_lib = HeartbeatModule::Heartbeat.new(HeartbeatModule::RuntimeError.new)
+
+      if @interval
+        @finished = false
+        @condition = ConditionVariable.new
+        @mutex = Mutex.new
+        @thread = Thread.new(&method(:run_periodic))
+      else
+        enumerate
+      end
+    end
+
+    def shutdown
+      if @interval
+        @mutex.synchronize {
+          @finished = true
+          @condition.signal
+        }
+        @thread.join
+      end
+    end
+
+    def enumerate
+      time = Time.now.to_f
+    
+      wrapper = @heartbeat_lib.enumerate(time)
+      router.emit(@tag, time, wrapper) if wrapper
+    end
+
+    def run_periodic
+      @mutex.lock
+      done = @finished
+      until done
+        @condition.wait(@mutex, @interval)
+        done = @finished
+        @mutex.unlock
+        if !done
+          enumerate
+        end
+        @mutex.lock
+      end
+      @mutex.unlock
+    end
+
+  end # OMS_Heartbeat_Input
+
+end # module
+

--- a/test/code/plugins/heartbeat_lib_test.rb
+++ b/test/code/plugins/heartbeat_lib_test.rb
@@ -1,0 +1,93 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+require 'test/unit'
+require 'tempfile'
+require_relative 'omstestlib'
+require_relative '../../../source/code/plugins/heartbeat_lib'
+
+class HeartbeatTestRuntimeError < HeartbeatModule::LoggingBase
+  def log_error(text)
+    raise text
+  end
+end
+
+class HeartbeatLib_Test < Test::Unit::TestCase
+  class << self
+    def startup
+      @@heartbeat_lib = HeartbeatModule::Heartbeat.new(HeartbeatTestRuntimeError.new)
+    end
+
+    def shutdown
+      #no op
+    end
+  end
+
+  def setup
+    @tmp_os_conf_file = Tempfile.new('os_conf_file')
+    @tmp_agent_install_conf_file = Tempfile.new('agent_install_conf_file')
+  end
+
+  def teardown
+    tmp_path = @tmp_os_conf_file.path
+    assert_equal(true, File.file?(tmp_path))
+    @tmp_os_conf_file.unlink
+    assert_equal(false, File.file?(tmp_path))
+    tmp_path = @tmp_agent_install_conf_file.path
+    assert_equal(true, File.file?(tmp_path))
+    @tmp_agent_install_conf_file.unlink
+    assert_equal(false, File.file?(tmp_path))
+  end
+
+  def test_heartbeat_non_existent_conf_files
+    heartbeat_data_item = call_get_heartbeat('/etc/nonexistentos.conf', '/etc/nonexistentagentinstall.conf')
+    verify_invalid_heartbeat_data(heartbeat_data_item)
+  end
+
+  def test_heartbeat_empty_conf_files
+    heartbeat_data_item = call_get_heartbeat(@tmp_os_conf_file.path, @tmp_agent_install_conf_file.path)
+    verify_invalid_heartbeat_data(heartbeat_data_item)
+  end
+
+  def test_heartbeat_malformed_conf_files
+    $log = OMS::MockLog.new
+    File.write(@tmp_os_conf_file.path, "Malformed OS Name\nMalformed OS Version\n")
+    File.write(@tmp_agent_install_conf_file.path, "Agent Version\nInstalledDate\n")
+    heartbeat_data_item = call_get_heartbeat(@tmp_os_conf_file.path, @tmp_agent_install_conf_file.path)
+    assert_equal(1, $log.logs.size, "Unexpected error logs: #{$log.logs}")
+    verify_invalid_heartbeat_data(heartbeat_data_item)
+  end
+
+  def test_heartbeat_valid_conf_files
+    File.write(@tmp_os_conf_file.path, "OSName=Ubuntu\nOSVersion=14.04\nOSFullName=Ubuntu 14.04 (x86_64)\nOSAlias=UniversalD\nOSManufacturer=Canonical Group Limited\n")
+    File.write(@tmp_agent_install_conf_file.path, "1.1.0-124 20160412 Release_Build\n2016-05-24T00:27:55.0Z\n")
+    heartbeat_data_item = call_get_heartbeat(@tmp_os_conf_file.path, @tmp_agent_install_conf_file.path)
+    assert(heartbeat_data_item.has_key?("Timestamp"))
+    assert(heartbeat_data_item.has_key?("Device"))
+    assert(heartbeat_data_item.has_key?("OSType"))
+    assert(heartbeat_data_item.has_key?("Category"))
+    assert(heartbeat_data_item.has_key?("SCAgentChannel"))
+    assert_equal("Ubuntu", heartbeat_data_item["OSName"], "OSName does not match")
+    assert_equal("14", heartbeat_data_item["OSMajorVersion"], "OSMajorVersion does not match")
+    assert_equal("04", heartbeat_data_item["OSMinorVersion"], "OSMinorVersion does not match")
+    assert_equal("2016-05-24T00:27:55.0Z", heartbeat_data_item["InstalledDate"], "InstalledDate does not match")
+    assert_equal("1.1.0-124", heartbeat_data_item["Version"], "AgentVersion does not match")
+  end
+
+  def verify_invalid_heartbeat_data(heartbeat_data_item)
+    assert(heartbeat_data_item.has_key?("Timestamp"))
+    assert(heartbeat_data_item.has_key?("Device"))
+    assert(heartbeat_data_item.has_key?("OSType"))
+    assert(heartbeat_data_item.has_key?("Category"))
+    assert(heartbeat_data_item.has_key?("SCAgentChannel"))
+    assert(!heartbeat_data_item.has_key?("OSName"))
+    assert(!heartbeat_data_item.has_key?("OSMajorVersion"))
+    assert(!heartbeat_data_item.has_key?("OSMinorVersion"))
+    assert(!heartbeat_data_item.has_key?("InstalledDate"))
+    assert(!heartbeat_data_item.has_key?("Version"))
+  end
+
+  # wrapper to call get heartbeat
+  def call_get_heartbeat(os_conf_file_path, agent_install_conf_file_path)
+    @@heartbeat_lib.get_heartbeat_data_item(Time.now, os_conf_file_path, agent_install_conf_file_path)
+  end
+end
+


### PR DESCRIPTION
-- Add new heartbeat input plugin and lib
-- Update conf (Both operation and heartbeat will use the same output plugin)
-- Updates to oms_common to support get_os_name, get_os_version, get_fqdn, get_installed_date and get_agent_version. Also fix newline handling
-- Add tests for oms_common and heartbeat_lib

@Microsoft/omsagent-devs 
