### PR TITLE
ChangeTracking config call PerformInventory.py with params

### DIFF
--- a/installer/conf/omsagent.d/change_tracking.conf
+++ b/installer/conf/omsagent.d/change_tracking.conf
@@ -1,7 +1,7 @@
 <source>
   type exec
   tag oms.changetracking
-  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/Inventory.xml
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/change_tracking_inventory.mof --OutXML /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml
   format tsv
   keys xml
   run_interval 300s

--- a/installer/conf/omsagent.d/change_tracking_inventory.mof
+++ b/installer/conf/omsagent.d/change_tracking_inventory.mof
@@ -1,0 +1,38 @@
+/*
+@TargetNode='Localhost'
+*/
+
+instance of MSFT_nxPackageResource
+{
+                Name = "*";
+                ResourceId = "[MSFT_nxPackageResource]Inventory";
+                ModuleName = "PSDesiredStateConfiguration";
+                ModuleVersion = "1.0";
+
+
+};
+
+instance of MSFT_nxServiceResource
+{
+                Name = "*";
+                Controller = "*";
+                ResourceId = "[MSFT_nxServiceResource]Inventory";
+                ModuleName = "PSDesiredStateConfiguration";
+                ModuleVersion = "1.0";
+
+
+};
+
+
+instance of OMI_ConfigurationDocument
+{
+  DocumentType = "inventory";
+
+     Version="2.0.0";
+     MinimumCompatibleVersion = "2.0.0";
+     Name="InventoryConfig";
+
+
+};
+
+


### PR DESCRIPTION
Update the ChangeTracking configuration to call the
PerformInventory.py with --InMOF and --OutXML parameters.
Add the ChangeTracking inventory mof into the installer.
@Microsoft/omsagent-devs @johnkord @KrisBash 