### PR TITLE
Update max_retry_wait

### DIFF
--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -88,6 +88,7 @@
   flush_interval 20s
   retry_limit 10
   retry_wait 30s
+  max_retry_wait 9m
 </match>
 
 <match oms.** docker.**>
@@ -103,6 +104,7 @@
   flush_interval 20s
   retry_limit 10
   retry_wait 30s
+  max_retry_wait 9m
 </match>
 
 # Catch all unprocessed data and output it


### PR DESCRIPTION
The total time we want to wait for a buffer chunk is 1h. Working backwards, with 10 retry attempts starting at 30s, the max we can wait between attempts is 534s (8m 54s). (30 + 60 + 120 + 240 + 480 + x*5) = 3600, so x = 534. Round off to 9 minutes for simplicity (adds only 30s to total wait time)