### PR TITLE
Update the default set of Performance Counters

### DIFF
--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -14,17 +14,9 @@
 
 <source>
   type oms_omi
-  object_name "Physical Disk"
-  instance_regex ".*"
-  counter_name_regex ".*"
-  interval 5m
-</source>
-
-<source>
-  type oms_omi
   object_name "Logical Disk"
   instance_regex ".*"
-  counter_name_regex ".*"
+  counter_name_regex "(% Used Inodes|Free Megabytes|% Used Space|Disk Reads/sec|Disk Transfers/sec|Disk Writes/sec)"
   interval 5m
 </source>
 
@@ -32,7 +24,7 @@
   type oms_omi
   object_name "Processor"
   instance_regex ".*"
-  counter_name_regex ".*"
+  counter_name_regex "(% Privileged Time|% Processor Time)"
   interval 30s
 </source>
 
@@ -40,7 +32,7 @@
   type oms_omi
   object_name "Memory"
   instance_regex ".*"
-  counter_name_regex ".*"
+  counter_name_regex "(% Used Memory|% Used Swap Space|Available MBytes Memory)"
   interval 30s
 </source>
 


### PR DESCRIPTION
@Microsoft/omsagent-devs @KrisBash 
To be consistent with Windows load,
only collect the following counters by default.

Logical Disk
  % Used Inodes
  Free Megabytes
  % Used Space
  Disk Transfers/sec
  Disk Reads/sec
  Disk Writes/sec

Processor
  % Processor Time
  % Privileged Time

Memory
  Available MBytes Memory
  % Used Memory
  % Used Swap Space