### PR TITLE
Fix the buffer_path for out_oms plugin to avoid race condition

### DIFF
--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -90,7 +90,7 @@
 
   buffer_chunk_limit 5m
   buffer_type file
-  buffer_path /var/opt/microsoft/omsagent/state/out_oms*.buffer
+  buffer_path /var/opt/microsoft/omsagent/state/out_oms_common*.buffer
   buffer_queue_limit 10
   buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s


### PR DESCRIPTION
There is a potential bug in the file buffer plugin.
It uses the part before * as prefix and after * as suffix
of the buffer_path to find the existing buffer files on start.
It causes a race condition issue, since we use
.../out_oms*.buffer as the buffer_path of out_oms plugin.
The plugin will also find the .../out_oms_blob.xxx.buffer
and .../out_oms_api.xxx.buffer, which are designed to be
processed by out_oms_blob and out_oms_api plugin.
The fix is to make the prefix of buffer_path of out_oms plugin
not the prefix of the other buffer_path

@Microsoft/omsagent-devs 