### PR TITLE
Removing installed packages info and unittest fixes

### DIFF
--- a/installer/conf/omsagent.d/patch_management_inventory.mof
+++ b/installer/conf/omsagent.d/patch_management_inventory.mof
@@ -2,14 +2,6 @@
 @TargetNode='Localhost'
 */
 
-instance of MSFT_nxPackageResource
-{
-    Name = "*";
-    ResourceId = "[MSFT_nxPackageResource]Inventory";
-    ModuleName = "PSDesiredStateConfiguration";
-    ModuleVersion = "1.0";
-};
-
 instance of MSFT_nxAvailableUpdatesResource
 {
     Name = "*";

--- a/source/code/plugins/patch_management_lib.rb
+++ b/source/code/plugins/patch_management_lib.rb
@@ -12,28 +12,65 @@ class LinuxUpdates
     @@delimiter = "_"
     @@force_send_last_upload = Time.now
     MAJOR_MINOR_VERSION_REGEX = /([^\.]+)\.([^\.]+).*/
+    OMS_ADMIN_FILE = "/etc/opt/microsoft/omsagent/conf/omsadmin.conf"
+    SCX_RELEASE_FILE = "/etc/opt/microsoft/scx/conf/scx-release"
 
-    @@agentDetailsMap = Hash[(`cat /etc/opt/microsoft/omsagent/conf/omsadmin.conf`.split(/\r?\n/).map {|s| 
-                                s.split("=")}).map {|key, value| 
-                                    [key, value]
-                                }
-                            ]
+    def self.getAgentDetails()
+        ret = {}
 
-    @@hostOSDetailsMap = Hash[(`cat /etc/opt/microsoft/scx/conf/scx-release`.split(/\r?\n/).map {|s|
-                               s.split("=")}).map {|key, value|
-                                    [key, value]
-                                }
-                            ]
-    
-    @os_major_version = @@hostOSDetailsMap["OSVersion"][MAJOR_MINOR_VERSION_REGEX, 1] unless @@hostOSDetailsMap["OSVersion"].nil?
-    @os_minor_version = @@hostOSDetailsMap["OSVersion"][MAJOR_MINOR_VERSION_REGEX, 2] unless @@hostOSDetailsMap["OSVersion"].nil?
+        if File.exist?(OMS_ADMIN_FILE) # If file exists
+            File.open(OMS_ADMIN_FILE, "r") do |f| # Open file
+                f.each_line do |line|       # Split each line and
+                    line.split(/\r?\n/).reject{ |l|  # reject all those line
+                        !l.include? "=" }.map {|s|    # which do not
+                            s.split("=")}.map {|key, value| # have "="; split
+                                ret[key] = value     # by "=" and add to ret.
+                        }
+                end
+            end
+        else
+            @@log.debug "Could not find the file #{OMS_ADMIN_FILE}"
+        end
+        return ret
+    end
+
+    def self.getHostOSDetails()
+        ret = {}
+
+        if File.exist?(SCX_RELEASE_FILE) # If file exists
+            File.open(SCX_RELEASE_FILE, "r") do |f| # Open file
+                f.each_line do |line|       # Split each line and
+                    line.split(/\r?\n/).reject{ |l|  # reject all those line
+                        !l.include? "=" }.map {|s|    # which do not
+                            s.split("=")}.map {|key, value| # have "="; split
+                                ret[key] = value     # by "=" and add to ret.
+                        }
+                end
+            end
+        else
+            @@log.debug "Could not find the file #{SCX_RELEASE_FILE}"
+        end
+        return ret
+    end
 
     # This temporary fix is for version management for cache lookup.                        
-    def self.getOSShortName()
-        # match string of the form (1 or more non . chars)- followed by a . - (1 or more non . chars) - followed by anything
+    def self.getOSShortName(os_short_name = nil, os_version=nil)
         version = ""
+        hostOSDetailsMap = getHostOSDetails()
 
-        case @@hostOSDetailsMap["OSShortName"].split("_")[0]
+        # match string of the form (1 or more non . chars)- followed by a . - (1 or more non . chars) - followed by anything
+        osName = (os_short_name == nil) ? hostOSDetailsMap["OSShortName"].split("_")[0] : os_short_name.split("_")[0]
+        if (os_version == nil)
+            @os_major_version = hostOSDetailsMap["OSVersion"][MAJOR_MINOR_VERSION_REGEX, 1] unless hostOSDetailsMap["OSVersion"].nil?
+            @os_minor_version = hostOSDetailsMap["OSVersion"][MAJOR_MINOR_VERSION_REGEX, 2] unless hostOSDetailsMap["OSVersion"].nil?
+            @default_version = hostOSDetailsMap["OSVersion"]
+        else
+            @os_major_version = os_version[MAJOR_MINOR_VERSION_REGEX, 1] unless os_version.nil?
+            @os_minor_version = os_version[MAJOR_MINOR_VERSION_REGEX, 2] unless os_version.nil?
+            @default_version = os_version
+        end 
+        
+        case osName
         when "Ubuntu"
             if @os_major_version == "12" || @os_major_version == "13"
                 version = "12.04"
@@ -42,7 +79,7 @@ class LinuxUpdates
             elsif  @os_major_version == "16" || @os_major_version == "17"
                 version = "16.04"
             else
-                version = @@hostOSDetailsMap["OSVersion"]
+                version = @default_version
             end
         when "CentOS"
             if @os_major_version == "5"
@@ -52,7 +89,7 @@ class LinuxUpdates
             elsif  @os_major_version == "7"
                 version = "7.0"
             else
-                version = @@hostOSDetailsMap["OSVersion"]
+                version = @default_version
             end
         when "RHEL"
             if @os_major_version == "5"
@@ -62,7 +99,7 @@ class LinuxUpdates
             elsif  @os_major_version == "7"
                 version = "7.0"
             else
-                version = @@hostOSDetailsMap["OSVersion"]
+                version = @default_version
             end
         when "SUSE"
             if @os_major_version == "11"
@@ -70,13 +107,13 @@ class LinuxUpdates
             elsif  @os_major_version == "12"
                 version = "12.0"
             else
-                version = @@hostOSDetailsMap["OSVersion"]
+                version = @default_version
             end
         else
-            version = @@hostOSDetailsMap["OSVersion"]
+            version = @default_version
         end
 
-        return @@hostOSDetailsMap["OSShortName"].split("_")[0] + @@delimiter + version
+        return osName + @@delimiter + version
     end
 
     def self.log= (value)
@@ -107,10 +144,9 @@ class LinuxUpdates
         ret
     end
 
-    def self.availableUpdatesXMLtoHash(availableUpdatesXML, os_short_name = nil)
+    def self.availableUpdatesXMLtoHash(availableUpdatesXML, os_short_name)
         availableUpdatesHash = instanceXMLtoHash(availableUpdatesXML)
         ret = {}
-        
         ret["CollectionName"] = availableUpdatesHash["Name"] + @@delimiter + 
                                 availableUpdatesHash["Version"] + @@delimiter + os_short_name
         ret["PackageName"] = availableUpdatesHash["Name"]
@@ -121,13 +157,12 @@ class LinuxUpdates
         ret
     end
 
-    def self.installedPackageXMLtoHash(packageXML, os_short_name = nil)
+    def self.installedPackageXMLtoHash(packageXML, os_short_name)
         packageHash = instanceXMLtoHash(packageXML)
         ret = {}
         
         ret["CollectionName"] = packageHash["Name"] + @@delimiter + 
-                                packageHash["Version"] + @@delimiter + 
-                                os_short_name
+                                packageHash["Version"] + @@delimiter + os_short_name
         ret["PackageName"] = packageHash["Name"]
         ret["PackageVersion"] = packageHash["Version"]
         ret["Timestamp"] = OMS::Common.format_time(packageHash["InstalledOn"].to_i)
@@ -160,12 +195,14 @@ class LinuxUpdates
     def self.transform_and_wrap(inventoryXMLstr, host, time, force_send_run_interval = 86400,
                                 agentIdParam = nil, osNameParam = nil, osFullNameParam = nil, 
                                 osVersionParam = nil, osShortNameParam = nil)
+        agentDetailsMap = getAgentDetails()
+        hostOSDetailsMap = getHostOSDetails()
         # Taking the parameters - Helps in mocking, in the case of tests.
-        agentId = (agentIdParam == nil) ? @@agentDetailsMap["AGENT_GUID"] : agentIdParam
-        osName =  (osNameParam == nil) ? @@hostOSDetailsMap["OSName"] : osNameParam
-        osVersion = (osVersionParam == nil) ? @@hostOSDetailsMap["OSVersion"] : osVersionParam
-        osFullName = (osFullNameParam == nil) ? @@hostOSDetailsMap["OSFullName"] : osFullNameParam
-        osShortNameParam = (osShortNameParam == nil) ? getOSShortName() : osShortNameParam
+        agentId = (agentIdParam == nil) ? agentDetailsMap["AGENT_GUID"] : agentIdParam
+        osName =  (osNameParam == nil) ? hostOSDetailsMap["OSName"] : osNameParam
+        osVersion = (osVersionParam == nil) ? hostOSDetailsMap["OSVersion"] : osVersionParam
+        osFullName = (osFullNameParam == nil) ? hostOSDetailsMap["OSFullName"] : osFullNameParam
+        osShortName = getOSShortName(osShortNameParam, osVersion)
 
         # Do not send duplicate data if we are not forced to
         hash = Digest::SHA256.hexdigest(inventoryXMLstr)
@@ -189,8 +226,8 @@ class LinuxUpdates
         availableUpdatesXML = instancesXML.select { |instanceXML| isAvailableUpdateInstanceXML(instanceXML) }
 
         # Convert to xml to hash/json representation
-        installedPackages = installedPackagesXML.map { |installedPackage|  installedPackageXMLtoHash(installedPackage, osShortNameParam)}
-        availableUpdates = availableUpdatesXML.map { |availableUpdate|  availableUpdatesXMLtoHash(availableUpdate, osShortNameParam)}
+        installedPackages = installedPackagesXML.map { |installedPackage|  installedPackageXMLtoHash(installedPackage, osShortName)}
+        availableUpdates = availableUpdatesXML.map { |availableUpdate|  availableUpdatesXMLtoHash(availableUpdate, osShortName)}
 
         # Remove duplicate services because duplicate CollectionNames are not supported. TODO implement ordinal solution
         installedPackages = removeDuplicateCollectionNames(installedPackages)
@@ -225,4 +262,3 @@ class LinuxUpdates
           return wrapper
     end
 end
-

--- a/test/code/plugins/patch_management_lib_test.rb
+++ b/test/code/plugins/patch_management_lib_test.rb
@@ -12,7 +12,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
   def setup
     @installed_packages_xml_str = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxPackageResource&quot;&gt;&lt;PROPERTY NAME=&quot;Publisher&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu Developers &amp;lt;ubuntu-devel-discuss@lists.ubuntu.com&amp;gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;ReturnCode&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;0&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;autotools-dev&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;FilePath&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageGroup&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;false&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Installed&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;true&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;InstalledOn&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Unknown&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;20150820.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Ensure&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;present&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;all&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Arguments&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageManager&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageDescription&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Update infrastructure for config.{guess,sub} files&amp;#10; This package installs an up-to-date version of config.guess and&amp;#10; config.sub, used by the automake and libtool packages.  It provides&amp;#10; the canonical copy of those files for other packages as well.&amp;#10; .&amp;#10; It also documents in /usr/share/doc/autotools-dev/README.Debian.gz&amp;#10; best practices and guidelines for using autoconf, automake and&amp;#10; friends on Debian packages.  This is a must-read for any developers&amp;#10; packaging software that uses the GNU autotools, or GNU gettext.&amp;#10; .&amp;#10; Additionally this package provides seamless integration into Debhelper&amp;#10; or CDBS, allowing maintainers to easily update config.{guess,sub} files&amp;#10; in their packages.&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Size&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;151&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
     
-    @available_updates_xml_str = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxAvailableUpdatesResource&quot;&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;dpkg&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;1.18.4ubuntu1.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;amd64&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Repository&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu:16.04/xenial-updates&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;BuildDate&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;BuildDate&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
+    @available_updates_xml_str = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxAvailableUpdatesResource&quot;&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;dpkg&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;1.18.4ubuntu1.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;amd64&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Repository&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu:15.04/xenial-updates&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;BuildDate&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;BuildDate&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
     @inventoryPath = File.join(File.dirname(__FILE__), 'InventoryWithUpdates.xml')
     LinuxUpdates.prev_hash = nil
     LinuxUpdates.log = OMS::MockLog.new
@@ -65,7 +65,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
       </INSTANCE>'
     
     expectedHash = {
-      "CollectionName"=> "dpkg" + @@delimiter + "1.18.4ubuntu1.1" + @@delimiter + "Ubuntu",
+      "CollectionName"=> "dpkg" + @@delimiter + "1.18.4ubuntu1.1" + @@delimiter + "Ubuntu_14.04",
       "PackageName"=>"dpkg",
       "PackageVersion"=>"1.18.4ubuntu1.1",
       "Timestamp"=> "1970-01-01T00:00:00.000Z",
@@ -76,7 +76,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
     instanceXML = LinuxUpdates::strToXML(instanceXMLstr).root
     assert_equal("INSTANCE", instanceXML.name)
     assert_equal("MSFT_nxAvailableUpdatesResource", instanceXML.attributes['CLASSNAME'])
-    instanceHash = LinuxUpdates::availableUpdatesXMLtoHash(instanceXML, "Ubuntu")
+    instanceHash = LinuxUpdates::availableUpdatesXMLtoHash(instanceXML, "Ubuntu_14.04")
     assert_equal(expectedHash, instanceHash)
   end
 
@@ -151,7 +151,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
               </INSTANCE>'    
 
     expectedHash = {
-      "CollectionName"=> "autotools-dev" + @@delimiter + "20150820.1" + @@delimiter + "Ubuntu",
+      "CollectionName"=> "autotools-dev" + @@delimiter + "20150820.1" + @@delimiter + "Ubuntu_14.04",
       "PackageName"=> "autotools-dev",
       "PackageVersion"=>"20150820.1",
       "Timestamp"=> "1970-01-01T00:00:00.000Z",
@@ -163,7 +163,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
     instanceXML = LinuxUpdates::strToXML(instanceXMLstr).root
     assert_equal("INSTANCE", instanceXML.name)
     assert_equal("MSFT_nxPackageResource", instanceXML.attributes['CLASSNAME'])
-    instanceHash = LinuxUpdates::installedPackageXMLtoHash(instanceXML, "Ubuntu")
+    instanceHash = LinuxUpdates::installedPackageXMLtoHash(instanceXML, "Ubuntu_14.04")
     assert_equal(expectedHash, instanceHash)
   end
 
@@ -204,25 +204,25 @@ class LinuxUpdatesTest < Test::Unit::TestCase
             "DataItems" => [{
                 "Host" => "HostName",
                 "AgentId" => "AgentId-123",
-                "OSFullName" => "Ubuntu 16.04",
+                "OSFullName" => "Ubuntu 15.04",
                 "OSName" => "Ubuntu",
                 "OSType" => "Linux",
-                "OSVersion" => "16.04",
+                "OSVersion" => "15.04",
                 "Timestamp" => "2016-03-15T19:02:38.577Z",
                 "Collections" => [{
-                    "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_16.04",
+                    "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_14.04",
                     "Installed" => false,
                     "PackageName" => "dpkg",
                     "PackageVersion" => "1.18.4ubuntu1.1",
-                    "Repository" => "Ubuntu:16.04/xenial-updates",
+                    "Repository" => "Ubuntu:15.04/xenial-updates",
                     "Timestamp" => "1970-01-01T00:00:00.000Z"
                 }]
             }]
         }
     expectedTime = Time.utc(2016,3,15,19,2,38.5776)
     wrappedHash = LinuxUpdates::transform_and_wrap(@available_updates_xml_str, "HostName", expectedTime,
-                                                   86400, "AgentId-123", "Ubuntu", "Ubuntu 16.04",
-                                                   "16.04", "Ubuntu_16.04")
+                                                   86400, "AgentId-123", "Ubuntu", "Ubuntu 15.04",
+                                                   "15.04", "Ubuntu_15.04")
     assert_equal(expectedHash, wrappedHash)
   end
   


### PR DESCRIPTION
Changed the way to use ruby rather than using `cat` to read the 
release file and host details. Also, cleaned the way shortname is created
to help the unit-test now pass the os name and version for testing.
