### PR TITLE
Set syslog event time

### DIFF
--- a/source/code/plugins/filter_syslog.rb
+++ b/source/code/plugins/filter_syslog.rb
@@ -30,6 +30,7 @@ module Fluent
       # Use Time.now, because it is the only way to get subsecond precision in version 0.12.
       # The time may be slightly in the future from the ingestion time.
       record["Timestamp"] = OMS::Common.format_time(Time.now.to_f)
+      record["EventTime"] = OMS::Common.format_time(time)
       hostname = record["host"]
       record["Host"] = hostname
       record.delete "host"

--- a/source/code/plugins/filter_syslog_security.rb
+++ b/source/code/plugins/filter_syslog_security.rb
@@ -35,6 +35,7 @@ module Fluent
       # Use Time.now, because it is the only way to get subsecond precision in version 0.12.
       # The time may be slightly in the future from the ingestion time.
       record['Timestamp'] = OMS::Common.format_time(Time.now.to_f)
+      record['EventTime'] = OMS::Common.format_time(time)
 
       record['Message'] = record['message']
       record.delete 'message'


### PR DESCRIPTION
Today we populate the syslog event time (in the workflow) from the TimeGenerated. Instead, add a new field with the actual event time (rounded to second - best that fluent v0.12 can do) and populate it from that.

@Microsoft/omsagent-devs 
@mgladi 