### PR TITLE
Input plugin that allows ruby script to tail files using sudo

### DIFF
--- a/installer/conf/sudoers
+++ b/installer/conf/sudoers
@@ -21,4 +21,6 @@ omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsagent/bin/service_control
 #Inspect Docker containers (filter_docker_log.rb)
 omsagent ALL=(ALL) NOPASSWD: /usr/bin/docker inspect *
 
+#run tailfilereader.rb
+omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/bin/tailfilereader.rb *
 # End sudo configuration for omsagent

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -37,6 +37,7 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/bin/omsadmin.sh;                                installer/scripts/omsadmin.sh;                         755; root; root
 /opt/microsoft/omsagent/bin/service_control;                            installer/scripts/service_control;                     755; root; root
 /opt/microsoft/omsagent/bin/uninstall;                                  installer/scripts/uninstall.sh;                        755; root; root
+/opt/microsoft/omsagent/bin/tailfilereader.rb;                          installer/scripts/tailfilereader.rb;                   744; root; root
 
 /opt/microsoft/omsagent/plugin/filter_syslog.rb;                        source/code/plugins/filter_syslog.rb;                  744; root; root
 /opt/microsoft/omsagent/plugin/out_oms.rb;                              source/code/plugins/out_oms.rb;                        744; root; root
@@ -57,6 +58,7 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/oms_configuration.rb;                    source/code/plugins/oms_configuration.rb;              744; root; root
 /opt/microsoft/omsagent/plugin/out_oms_blob.rb;                         source/code/plugins/out_oms_blob.rb;                   744; root; root
 /opt/microsoft/omsagent/plugin/out_oms_api.rb;                          source/code/plugins/out_oms_api.rb;                    744; root; root
+/opt/microsoft/omsagent/plugin/in_sudo_tail.rb;                         source/code/plugins/in_sudo_tail.rb;                   744; root; root
 
 /opt/microsoft/omsagent/plugin/security_lib.rb;                         source/code/plugins/security_lib.rb;                   744; root; root
 /opt/microsoft/omsagent/plugin/filter_syslog_security.rb;               source/code/plugins/filter_syslog_security.rb;         744; root; root
@@ -189,3 +191,4 @@ ${{SHELL_HEADER}}
 ${{SHELL_HEADER}}
 %Postuninstall_0
 ${{SHELL_HEADER}}
+

--- a/installer/scripts/tailfilereader.rb
+++ b/installer/scripts/tailfilereader.rb
@@ -1,0 +1,397 @@
+require 'optparse'
+require 'logger'
+
+module Tailscript
+
+  class NewTail  
+    def initialize(paths)
+      @paths = paths
+      @tails = {}
+      @pos_file = $options[:pos_file] 
+      @read_from_head = $options[:read_from_head]
+      @pf = nil
+      @pf_file = nil
+
+      @log = Logger.new(STDERR)
+      @log.formatter = proc do |severity, time, progname, msg|
+        "#{severity} #{msg}\n"
+      end
+    end
+
+    attr_reader :paths
+
+    def start
+      target_paths = expand_paths(@paths)
+      start_watchers(target_paths) unless target_paths.empty?
+    end
+
+    def shutdown
+      @pf_file.close if @pf_file
+    end
+
+    def expand_paths(given_paths)
+      date = Time.now      
+      paths = []
+
+      given_paths.each { |path|
+        path = date.strftime(path)
+        if path.include?('*')
+          paths += Dir.glob(path).select { |p|
+            if File.readable?(p)
+              true
+            else
+              @log.warn "#{p} is unreadable. It is excluded and would be examined next time."
+              false
+            end
+          }
+        elsif !File.readable?(path)
+          @log.error "#{path} is unreadable. Cannot tail the file."
+        else
+          # When file is not created yet, Dir.glob returns an empty array. So just add when path is static.
+          paths << path
+        end
+      }
+    end
+
+    def setup_watcher(path, pe)
+      tw = TailWatcher.new(path, pe, @read_from_head, @log, &method(:receive_lines))
+      tw.on_notify
+      tw
+    end
+
+    def start_watchers(paths)
+      if @pos_file
+        @pf_file = File.open(@pos_file, File::RDWR|File::CREAT)
+        @pf_file.sync = true
+        @pf = PositionFile.parse(@pf_file)
+      end
+
+      paths.each { |path|
+        pe = nil
+        if @pf
+          pe = @pf[path]    #pe is FilePositionEntry instance
+          if @read_from_head && pe.read_inode.zero?
+            begin
+              pe.update(File::Stat.new(path).ino, 0)
+            rescue Errno::ENOENT
+              @log.warn "#{path} not found. Continuing without tailing it."
+            end
+          end
+        end
+        
+        @tails[path] = setup_watcher(path, pe)
+      }
+    end
+
+    def receive_lines(lines, tail_watcher)
+      unless lines.empty?
+        puts lines 
+      end
+      return true
+    end
+
+    class TailWatcher
+      def initialize(path, pe, read_from_head, log, &receive_lines)
+        @path = path
+        @pe = pe || MemoryPositionEntry.new
+        @read_from_head = read_from_head
+        @log = log
+        @receive_lines = receive_lines
+        @rotate_handler = RotateHandler.new(path, log, &method(:on_rotate))
+        @io_handler = nil
+      end
+
+      attr_reader :path
+
+      def wrap_receive_lines(lines)
+        @receive_lines.call(lines, self)
+      end
+
+      def on_notify
+        @rotate_handler.on_notify if @rotate_handler
+        return unless @io_handler
+        @io_handler.on_notify
+      end
+
+      def on_rotate(io)
+        if io
+          # first time
+          stat = io.stat
+          fsize = stat.size
+          inode = stat.ino
+
+          last_inode = @pe.read_inode
+          if @read_from_head
+            pos = 0
+            @pe.update(inode, pos)
+          elsif inode == last_inode 
+            # rotated file has the same inode number as the pos_file.
+            # seek to the saved position
+            pos = @pe.read_pos 
+          elsif last_inode != 0
+            # read data from the head of the rotated file.
+            pos = 0
+            @pe.update(inode, pos)
+          else
+            # this is the first MemoryPositionEntry for the first time fluentd started.
+            # seeks to the end of the file to know where to start tailing
+            pos = fsize
+            @pe.update(inode, pos)
+          end
+          io.seek(pos)
+          @io_handler = IOHandler.new(io, @pe, @log, &method(:wrap_receive_lines))
+        else
+          @io_handler = NullIOHandler.new
+        end
+      end
+
+      class IOHandler
+        def initialize(io, pe, log, &receive_lines)
+          @log = log
+          @io = io
+          @pe = pe
+          @log = log
+          @read_lines_limit = 1000 
+          @receive_lines = receive_lines
+          @buffer = ''.force_encoding('ASCII-8BIT')
+          @iobuf = ''.force_encoding('ASCII-8BIT')
+          @lines = []
+        end
+
+        attr_reader :io
+
+        def on_notify
+          begin
+            read_more = false
+            if @lines.empty?
+              begin
+                while true
+                  if @buffer.empty?
+                    @io.readpartial(2048, @buffer)
+                  else
+                    @buffer << @io.readpartial(2048, @iobuf)
+                  end
+                  while line = @buffer.slice!(/.*?\n/m)
+                    @lines << line
+                  end
+                  if @lines.size >= @read_lines_limit
+                    # not to use too much memory in case the file is very large
+                    read_more = true
+                    break
+                  end
+                end
+              rescue EOFError
+              end
+            end
+
+            unless @lines.empty?
+              if @receive_lines.call(@lines)
+                @pe.update_pos(@io.pos - @buffer.bytesize)
+                @lines.clear
+              else
+                read_more = false
+              end
+            end
+          end while read_more
+
+        rescue
+          @log.error "#{$!.to_s}"
+          close
+        end
+
+        def close
+          @io.close unless @io.closed?
+        end
+      end
+
+      class NullIOHandler
+        def initialize
+        end
+
+        def io
+        end
+
+        def on_notify
+        end
+
+        def close
+        end
+      end
+
+      class RotateHandler
+        def initialize(path, log, &on_rotate)
+          @path = path
+          @inode = nil
+          @fsize = -1  # first
+          @on_rotate = on_rotate
+          @log = log
+        end
+
+        def on_notify
+          begin
+            stat = File.stat(@path) #returns a File::Stat object for the file named @path
+            inode = stat.ino
+            fsize = stat.size
+          rescue Errno::ENOENT
+            # moved or deleted
+            inode = nil
+            fsize = 0
+          end
+
+          begin
+            if @inode != inode || fsize < @fsize
+              # rotated or truncated
+              begin
+                io = File.open(@path)
+              rescue Errno::ENOENT
+              end
+              @on_rotate.call(io)
+            end
+            @inode = inode
+            @fsize = fsize
+          end
+
+        rescue
+          @log.error "#{$!.to_s}"
+        end
+      end
+    end
+
+
+    class PositionFile
+      UNWATCHED_POSITION = 0xffffffffffffffff
+
+      def initialize(file, map, last_pos)
+        @file = file
+        @map = map
+        @last_pos = last_pos
+      end
+
+      def [](path)
+        if m = @map[path]
+          return m
+        end
+
+        @file.pos = @last_pos
+        @file.write path
+        @file.write "\t"
+        seek = @file.pos
+        @file.write "0000000000000000\t0000000000000000\n"
+        @last_pos = @file.pos
+
+        @map[path] = FilePositionEntry.new(@file, seek)
+      end
+
+      def self.parse(file)
+        compact(file)
+
+        map = {}
+        file.pos = 0
+        file.each_line {|line|
+          m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
+          next unless m
+          path = m[1]
+          seek = file.pos - line.bytesize + path.bytesize + 1
+          map[path] = FilePositionEntry.new(file, seek)
+        }
+        new(file, map, file.pos)
+      end
+
+      # Clean up unwatched file entries
+      def self.compact(file)
+        file.pos = 0
+        existent_entries = file.each_line.map { |line|
+          m = /^([^\t]+)\t([0-9a-fA-F]+)\t([0-9a-fA-F]+)/.match(line)
+          next unless m
+          path = m[1]
+          pos = m[2].to_i(16)
+          ino = m[3].to_i(16)
+          # 32bit inode converted to 64bit at this phase
+          pos == UNWATCHED_POSITION ? nil : ("%s\t%016x\t%016x\n" % [path, pos, ino])
+        }.compact
+
+        file.pos = 0
+        file.truncate(0)
+        file.write(existent_entries.join)
+      end
+    end
+
+    # pos               inode
+    # ffffffffffffffff\tffffffffffffffff\n
+    class FilePositionEntry
+      POS_SIZE = 16
+      INO_OFFSET = 17
+      INO_SIZE = 16
+      LN_OFFSET = 33
+      SIZE = 34
+
+      def initialize(file, seek)
+        @file = file
+        @seek = seek
+      end
+
+      def update(ino, pos)
+        @file.pos = @seek
+        @file.write "%016x\t%016x" % [pos, ino]
+      end
+
+      def update_pos(pos)
+        @file.pos = @seek
+        @file.write "%016x" % pos
+      end
+
+      def read_inode
+        @file.pos = @seek + INO_OFFSET
+        raw = @file.read(INO_SIZE)
+        raw ? raw.to_i(16) : 0
+      end
+
+      def read_pos
+        @file.pos = @seek
+        raw = @file.read(POS_SIZE)
+        raw ? raw.to_i(16) : 0
+      end
+    end
+
+    class MemoryPositionEntry
+      def initialize
+        @pos = 0
+        @inode = 0
+      end
+
+      def update(ino, pos)
+        @inode = ino
+        @pos = pos
+      end
+
+      def update_pos(pos)
+        @pos = pos
+      end
+
+      def read_pos
+        @pos
+      end
+
+      def read_inode
+        @inode
+      end
+    end
+  end
+end
+
+if __FILE__ == $0
+  $options = {:read_from_head => false}
+  OptionParser.new do |opts|
+    opts.on("-p", "--posfile [POSFILE]") do |p|
+      $options[:pos_file] = p
+    end
+    opts.on("-h", "--[no-]readfromhead") do |h|
+      $options[:read_from_head] = h 
+    end
+  end.parse!
+
+  a = Tailscript::NewTail.new(ARGV)
+  a.start
+  a.shutdown
+end
+

--- a/source/code/plugins/in_sudo_tail.rb
+++ b/source/code/plugins/in_sudo_tail.rb
@@ -1,0 +1,137 @@
+require 'yajl'
+require 'fluent/input'
+require 'fluent/event'
+require 'fluent/config/error'
+require 'fluent/parser'
+require 'open3'
+
+module Fluent
+  class SudoTail < Input
+    Plugin.register_input('sudo_tail', self)
+
+    def initialize
+      super
+      @command = nil
+    end
+
+    attr_accessor :command
+
+    #The command (program) to execute.
+    config_param :path, :string
+
+    #The format used to map the program output to the incoming event.
+    config_param :format, :string, default: 'none'
+
+    #Tag of the event.
+    config_param :tag, :string, default: nil
+
+    #Fluentd will record the position it last read into this file.
+    config_param :pos_file, :string, default: nil
+
+    #The interval time between periodic program runs.
+    config_param :run_interval, :time, default: nil
+
+    #Start to read the log from the head of file.  
+    config_param :read_from_head, :bool, default: false
+
+    BASE_DIR = File.dirname(File.expand_path('..', __FILE__))
+    RUBY_DIR = BASE_DIR + '/ruby/bin/ruby '
+    TAILSCRIPT = BASE_DIR + '/bin/tailfilereader.rb '
+
+    def configure(conf)
+      super
+      unless @path
+        raise ConfigError, "'path' parameter is not set to a 'tail' source."
+      end
+      
+      unless @pos_file
+        raise ConfigError, "'pos_file' is required to keep track of file"
+      end 
+
+      unless @tag 
+        raise ConfigError, "'tag' is required on sudo tail"
+      end
+
+      unless @run_interval
+        raise ConfigError, "'run_interval' is required for periodic tailing"      
+      end
+ 
+      @parser = Plugin.new_parser(conf['format'])
+      @parser.configure(conf)
+
+      @command = "sudo " << RUBY_DIR << TAILSCRIPT << @path <<  " -p #{@pos_file}" 
+    end
+
+    def start
+      #$log.info "Sudo tail command is #{@command}"
+      @finished = false
+      @thread = Thread.new(&method(:run_periodic))
+    end
+
+    def shutdown
+      @finished = true 
+      @thread.join
+    end
+
+    def receive_data(line) 
+      es = MultiEventStream.new
+      begin
+        line.chomp!  # remove \n
+        @parser.parse(line) { |time, record|
+          if time && record
+            es.add(time, record)
+          else
+            $log.warn "pattern doesn't match: #{line.inspect}"
+          end
+          unless es.empty?
+            tag=@tag
+            router.emit_stream(tag, es)
+          end
+        }
+      rescue => e
+        $log.warn line.dump, error: e.to_s
+        $log.debug_backtrace(e.backtrace)
+      end
+    end
+
+    def receive_log(line)
+      $log.warn "#{line}" if line.start_with?('WARN')
+      $log.error "#{line}" if line.start_with?('ERROR')
+      $log.info "#{line}" if line.start_with?('INFO')
+    end
+ 
+    def run_periodic
+      if @read_from_head
+        sleep @run_interval
+        Open3.popen3(@command + " --readfromhead") {|writeio, readio, errio, wait_thread|
+          writeio.close
+          readio.each {|line| receive_data(line)}
+          errio.each {|line| receive_log(line)}
+          wait_thread.value
+        }
+      end
+      until @finished
+        begin
+          sleep @run_interval
+          Open3.popen3(@command) {|writeio, readio, errio, wait_thread|
+            writeio.close
+            while line = readio.gets
+              receive_data(line)
+            end
+
+            while line = errio.gets
+              receive_log(line)
+            end
+            
+            wait_thread.value #wait until child process terminates
+          }
+        rescue
+          $log.error "sudo_tail failed to run or shutdown child proces", error => $!.to_s, :error_class => $!.class.to_s
+          $log.warn_backtrace $!.backtrace
+        end
+      end
+    end
+  end
+
+end
+

--- a/test/Rakefile.rb
+++ b/test/Rakefile.rb
@@ -3,13 +3,20 @@
 require 'rake/testtask'
 require 'rake/clean'
 
-task :test => [:base_test]
+task :test => [:base_test, :plugintest]
 
 desc 'Run test_unit based test'
 Rake::TestTask.new(:base_test) do |t|
   t.test_files = Dir["#{ENV['BASE_DIR']}/test/**/*_test.rb"].sort
   t.verbose = true
   t.warning = true
+end
+
+desc 'Run test_unit based plugin tests'
+Rake::TestTask.new(:plugintest) do |t|
+  t.test_files = Dir["#{ENV['BASE_DIR']}/test/**/*_plugintest.rb"].sort
+  t.verbose = true
+  #t.warning = true
 end
 
 desc 'Run test_unit based system tests'

--- a/test/code/plugins/in_sudo_tail_plugintest.rb
+++ b/test/code/plugins/in_sudo_tail_plugintest.rb
@@ -1,0 +1,64 @@
+require_relative '../../../source/ext/fluentd/test/helper'
+require 'fluent/test'
+require_relative '../../../source/code/plugins/in_sudo_tail'
+
+class SudoTailTest < Test::Unit::TestCase
+  TMP_DIR = File.dirname(__FILE__) + "/../tmp/tail#{ENV['TEST_ENV_NUMBER']}"
+
+  def setup
+    Fluent::Test.setup
+    FileUtils.rm_rf(TMP_DIR)
+    FileUtils.mkdir_p(TMP_DIR)
+  end
+
+  def teardown
+    #super
+    if TMP_DIR
+      FileUtils.rm_rf(TMP_DIR)
+    end
+    Fluent::Engine.stop
+  end
+
+  CONFIG = %[
+    path #{TMP_DIR}/tail.txt
+    tag t1
+    pos_file #{TMP_DIR}/tail.pos
+    read_from_head true
+    format /(?<message>.*)/
+    run_interval 1s
+  ]
+
+  def create_driver(conf=CONFIG)
+    Fluent::Test::InputTestDriver.new(Fluent::SudoTail).configure(conf)
+  end
+
+  def test_configure
+    d = create_driver
+    assert_equal("#{TMP_DIR}/tail.txt", d.instance.path)
+    assert_equal("t1", d.instance.tag)
+    assert_equal("#{TMP_DIR}/tail.pos", d.instance.pos_file)
+    assert_equal(true, d.instance.read_from_head)
+    assert_equal('/(?<message>.*)/', d.instance.format)
+    assert_equal(1, d.instance.run_interval)
+  end
+
+
+  def test_emit
+    File.open("#{TMP_DIR}/tail.rb", "w") {|f|
+      f.puts "puts \"test1\""
+      f.puts "puts \"test2\""
+    }
+
+    d = create_driver
+    d.instance.command = "ruby #{TMP_DIR}/tail.rb "
+    d.run
+    emits = d.emits
+
+    assert_equal(true, emits.length > 0)
+    assert_equal({"message"=>"test1"}, emits[0][2])
+    assert_equal({"message"=>"test2"}, emits[1][2])
+    assert_equal(2, d.emit_streams.size)
+  end
+
+end
+

--- a/test/installer/scripts/tailfilereader_test.rb
+++ b/test/installer/scripts/tailfilereader_test.rb
@@ -1,0 +1,109 @@
+require 'test/unit'
+require_relative '../../../installer/scripts/tailfilereader.rb'
+require 'stringio'
+
+class TailFileReaderTest < Test::Unit::TestCase
+  TMP_DIR = File.dirname(__FILE__) + "/../tmp/test_tailfilereader"
+  def setup
+    FileUtils.rm_rf(TMP_DIR)
+    FileUtils.mkdir_p(TMP_DIR)
+    @pos_file = "#{TMP_DIR}/tail.pos"
+  end
+
+  def teardown
+    if TMP_DIR
+      FileUtils.rm_rf(TMP_DIR)
+    end
+  end
+
+  def create(opt={}, file)
+    $options = opt
+    Tailscript::NewTail.new(file)
+  end
+
+  def test_initialize
+    file = ["#{TMP_DIR}/tail.txt"]
+    File.open(file[0], "w") 
+    tailreader = create({}, file)
+    assert_equal(tailreader.paths, ["#{TMP_DIR}/tail.txt"])
+  end
+  
+  def test_rotate
+    file = ["#{TMP_DIR}/tail.txt"]
+    tailreader = create({:pos_file => @pos_file}, file)
+    $stdout = StringIO.new
+
+    input = File.open(file[0], "w")
+    input.puts "test 1"
+    input.puts "test 2"
+    input.flush
+
+    tailreader.start    
+    
+    input.puts "test 3"
+    input.puts "test 4"
+    input.flush
+    
+    tailreader.start
+ 
+    output = $stdout.string.split("\n")
+    assert_equal(2, output.length)
+    assert_equal("test 3", output[0])
+    assert_equal("test 4", output[1])
+  end 
+
+  def test_rotate_readfromhead
+    file = ["#{TMP_DIR}/tail.txt"]
+    tailreader = create({:pos_file => @pos_file, :read_from_head => true}, file)
+    $stdout = StringIO.new
+
+    input = File.open(file[0], "w")
+    input.puts "test 1"
+    input.puts "test 2"
+    input.flush
+
+    input.puts "test 3"
+    input.puts "test 4"
+    input.flush
+
+    tailreader.start
+    output = $stdout.string.split("\n")
+
+    assert_equal(4, output.length)
+    assert_equal("test 1", output[0])
+    assert_equal("test 2", output[1])
+    assert_equal("test 3", output[2])
+    assert_equal("test 4", output[3])
+  end 
+
+  def test_mulitple_paths
+    files = ["#{TMP_DIR}/tail1.txt", "#{TMP_DIR}/tail2.txt"]
+    tailreader = create({:pos_file => @pos_file}, files)
+    $stdout = StringIO.new
+
+    input1 = File.open(files[0], 'w') 
+    input1.puts "test 1"
+    input1.puts "test 2"
+    input1.flush 
+
+    input2 = File.open(files[1], 'w')
+    input2.puts "test a"
+    input2.puts "test b"
+    input2.flush
+    tailreader.start
+
+    input1.puts "test 3"
+    input1.flush
+    input2.puts "test c"
+    input2.flush
+     
+    tailreader.start
+    output = $stdout.string.split("\n")
+
+    assert_equal(tailreader.paths, files)
+    assert_equal(2, output.length)
+    assert_equal("test 3", output[0])
+    assert_equal("test c", output[1])
+  end
+end
+


### PR DESCRIPTION
Tailfilereader.rb is a ruby script that takes command line arguments to read the specified logfile from last position read to EOF.
It keeps track of the last position read in a position file.
in_sudo_tail.rb plugin calls the tailfilereader script using sudo after every run_interval period specified.
Conf to be included in documentation. 
Sample:
<source>
  type sudo_tail
  tag oms.log.audit
  path /var/log/audit/audit.log
  pos_file /var/opt/microsoft/omsagent/state/audit.log.pos
  run_interval 1m
  format none
</source>

@Microsoft/omsagent-devs 