### PR TITLE
Changing the data frequency for Updates and other changes.

### DIFF
--- a/installer/conf/omsagent.d/patch_management.conf
+++ b/installer/conf/omsagent.d/patch_management.conf
@@ -4,12 +4,23 @@
   command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/patch_management_inventory.mof --OutXML /etc/opt/omi/conf/omsconfig/configuration/CompletePackageInventory.xml > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/CompletePackageInventory.xml
   format tsv
   keys xml
-  run_interval 12h
+  run_interval 3h
+</source>
+
+<source>
+  type exec
+  tag oms.patch_management_immediate_run
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/patch_management_inventory.mof --OutXML /etc/opt/omi/conf/omsconfig/configuration/CompletePackageInventory.xml > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/CompletePackageInventory.xml
+  format tsv
+  keys xml
 </source>
 
 <filter oms.patch_management>
   type filter_patch_management 
-  # Force upload even if the data has not changed
-  force_send_run_interval 24h
+  log_level warn
+</filter>
+
+<filter oms.patch_management_immediate_run>
+  type filter_patch_management
   log_level warn
 </filter>

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -26,6 +26,7 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/change_tracking_inventory.mof;    installer/conf/omsagent.d/change_tracking_inventory.mof;    644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/monitor.conf;            installer/conf/omsagent.d/monitor.conf;                644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/patch_management.conf;      installer/conf/omsagent.d/patch_management.conf;          644; root; root
+/etc/opt/microsoft/omsagent/sysconf/omsagent.d/patch_management_immediate_run.conf;      installer/conf/omsagent.d/patch_management_immediate_run.conf;          644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/patch_management_inventory.mof;  installer/conf/omsagent.d/patch_management_inventory.mof;        644; root; root
 
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/oms.conf;                installer/conf/oms.conf;                               644; root; root

--- a/source/code/plugins/patch_management_lib.rb
+++ b/source/code/plugins/patch_management_lib.rb
@@ -150,9 +150,13 @@ class LinuxUpdates
         ret["CollectionName"] = availableUpdatesHash["Name"] + @@delimiter + 
                                 availableUpdatesHash["Version"] + @@delimiter + os_short_name
         ret["PackageName"] = availableUpdatesHash["Name"]
+        ret["Architecture"] = availableUpdatesHash.key?("Architecture") ? availableUpdatesHash["Architecture"] : nil
         ret["PackageVersion"] = availableUpdatesHash["Version"]
-        ret["Timestamp"] = OMS::Common.format_time(availableUpdatesHash["BuildDate"].to_i)
-        ret["Repository"] = availableUpdatesHash.key?("Repository") ? availableUpdatesHash["Repository"] : ""
+        ret["Timestamp"] = (availableUpdatesHash["BuildDate"].nil? or 
+                            availableUpdatesHash["BuildDate"].strip == "" or
+                            availableUpdatesHash["BuildDate"].strip == "BuildDate") ? nil :
+                                OMS::Common.format_time(availableUpdatesHash["BuildDate"].to_i)
+        ret["Repository"] = availableUpdatesHash.key?("Repository") ? availableUpdatesHash["Repository"] : nil
         ret["Installed"] = false
         ret
     end
@@ -164,10 +168,14 @@ class LinuxUpdates
         ret["CollectionName"] = packageHash["Name"] + @@delimiter + 
                                 packageHash["Version"] + @@delimiter + os_short_name
         ret["PackageName"] = packageHash["Name"]
-        ret["PackageVersion"] = packageHash["Version"]
-        ret["Timestamp"] = OMS::Common.format_time(packageHash["InstalledOn"].to_i)
+        ret["Architecture"] = packageHash.key?("Architecture") ? packageHash["Architecture"] : nil
+        ret["PackageVersion"] = packageHash["Version"]  
+        ret["Timestamp"] = (packageHash["InstalledOn"].nil? or 
+                            packageHash["InstalledOn"].strip == "" or
+                            packageHash["InstalledOn"].strip == "Unknown") ? nil : 
+                                OMS::Common.format_time(packageHash["InstalledOn"].to_i)
         ret["Size"] = packageHash["Size"]
-        ret["Repository"] = packageHash.key?("Repository") ? packageHash["Repository"] : "" 
+        ret["Repository"] = packageHash.key?("Repository") ? packageHash["Repository"] : nil
         ret["Installed"] = true
         ret
     end
@@ -206,16 +214,7 @@ class LinuxUpdates
 
         # Do not send duplicate data if we are not forced to
         hash = Digest::SHA256.hexdigest(inventoryXMLstr)
-
-        # 24 hour period.
-        if force_send_run_interval > 0 and Time.now - @@force_send_last_upload > force_send_run_interval
-            @@log.debug "LinuxUpdates : Force sending inventory data"
-            @@force_send_last_upload = Time.now
-        elsif hash == @@prev_hash
-            @@log.debug "LinuxUpdates : Discarding duplicate inventory data. Hash=#{hash[0..5]}"
-            return {}
-        end
-        @@prev_hash = hash
+        @@log.debug "LinuxUpdates : Sending available updates information data. Hash=#{hash[0..5]}"
 
         # Extract the instances in xml format
         inventoryXML = strToXML(inventoryXMLstr)

--- a/test/code/plugins/patch_management_lib_test.rb
+++ b/test/code/plugins/patch_management_lib_test.rb
@@ -11,8 +11,17 @@ class LinuxUpdatesTest < Test::Unit::TestCase
 
   def setup
     @installed_packages_xml_str = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxPackageResource&quot;&gt;&lt;PROPERTY NAME=&quot;Publisher&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu Developers &amp;lt;ubuntu-devel-discuss@lists.ubuntu.com&amp;gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;ReturnCode&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;0&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;autotools-dev&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;FilePath&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageGroup&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;false&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Installed&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;true&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;InstalledOn&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Unknown&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;20150820.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Ensure&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;present&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;all&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Arguments&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageManager&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageDescription&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Update infrastructure for config.{guess,sub} files&amp;#10; This package installs an up-to-date version of config.guess and&amp;#10; config.sub, used by the automake and libtool packages.  It provides&amp;#10; the canonical copy of those files for other packages as well.&amp;#10; .&amp;#10; It also documents in /usr/share/doc/autotools-dev/README.Debian.gz&amp;#10; best practices and guidelines for using autoconf, automake and&amp;#10; friends on Debian packages.  This is a must-read for any developers&amp;#10; packaging software that uses the GNU autotools, or GNU gettext.&amp;#10; .&amp;#10; Additionally this package provides seamless integration into Debhelper&amp;#10; or CDBS, allowing maintainers to easily update config.{guess,sub} files&amp;#10; in their packages.&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Size&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;151&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
+
+    @installed_packages_xml_str_with_installed_on_date = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxPackageResource&quot;&gt;&lt;PROPERTY NAME=&quot;Publisher&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu Developers &amp;lt;ubuntu-devel-discuss@lists.ubuntu.com&amp;gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;ReturnCode&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;0&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;autotools-dev&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;FilePath&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageGroup&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;false&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Installed&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;true&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;InstalledOn&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;1468202536&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;20150820.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Ensure&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;present&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;all&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Arguments&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageManager&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageDescription&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Update infrastructure for config.{guess,sub} files&amp;#10; This package installs an up-to-date version of config.guess and&amp;#10; config.sub, used by the automake and libtool packages.  It provides&amp;#10; the canonical copy of those files for other packages as well.&amp;#10; .&amp;#10; It also documents in /usr/share/doc/autotools-dev/README.Debian.gz&amp;#10; best practices and guidelines for using autoconf, automake and&amp;#10; friends on Debian packages.  This is a must-read for any developers&amp;#10; packaging software that uses the GNU autotools, or GNU gettext.&amp;#10; .&amp;#10; Additionally this package provides seamless integration into Debhelper&amp;#10; or CDBS, allowing maintainers to easily update config.{guess,sub} files&amp;#10; in their packages.&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Size&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;151&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
     
+    @installed_packages_xml_str_with_nil_installed_on_date = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxPackageResource&quot;&gt;&lt;PROPERTY NAME=&quot;Publisher&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu Developers &amp;lt;ubuntu-devel-discuss@lists.ubuntu.com&amp;gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;ReturnCode&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;0&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;autotools-dev&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;FilePath&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageGroup&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;false&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Installed&quot; TYPE=&quot;boolean&quot;&gt;&lt;VALUE&gt;true&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;InstalledOn&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;20150820.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Ensure&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;present&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;all&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Arguments&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageManager&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;PackageDescription&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Update infrastructure for config.{guess,sub} files&amp;#10; This package installs an up-to-date version of config.guess and&amp;#10; config.sub, used by the automake and libtool packages.  It provides&amp;#10; the canonical copy of those files for other packages as well.&amp;#10; .&amp;#10; It also documents in /usr/share/doc/autotools-dev/README.Debian.gz&amp;#10; best practices and guidelines for using autoconf, automake and&amp;#10; friends on Debian packages.  This is a must-read for any developers&amp;#10; packaging software that uses the GNU autotools, or GNU gettext.&amp;#10; .&amp;#10; Additionally this package provides seamless integration into Debhelper&amp;#10; or CDBS, allowing maintainers to easily update config.{guess,sub} files&amp;#10; in their packages.&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Size&quot; TYPE=&quot;uint32&quot;&gt;&lt;VALUE&gt;151&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
+
     @available_updates_xml_str = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxAvailableUpdatesResource&quot;&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;dpkg&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;1.18.4ubuntu1.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;amd64&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Repository&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu:15.04/xenial-updates&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;BuildDate&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;BuildDate&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
+
+    @available_updates_xml_str_with_build_date = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxAvailableUpdatesResource&quot;&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;dpkg&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;1.18.4ubuntu1.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;amd64&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Repository&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu:15.04/xenial-updates&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;BuildDate&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;1468202536&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
+
+    @available_updates_xml_str_with_nil_build_date = '<INSTANCE CLASSNAME="Inventory"><PROPERTY.ARRAY NAME="Instances" TYPE="string" EmbeddedObject="object"><VALUE.ARRAY><VALUE>&lt;INSTANCE CLASSNAME=&quot;MSFT_nxAvailableUpdatesResource&quot;&gt;&lt;PROPERTY NAME=&quot;Name&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;dpkg&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Version&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;1.18.4ubuntu1.1&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Architecture&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;amd64&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;Repository&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;Ubuntu:15.04/xenial-updates&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;PROPERTY NAME=&quot;BuildDate&quot; TYPE=&quot;string&quot;&gt;&lt;VALUE&gt;&lt;/VALUE&gt;&lt;/PROPERTY&gt;&lt;/INSTANCE&gt;</VALUE></VALUE.ARRAY></PROPERTY.ARRAY></INSTANCE>'
+
     @inventoryPath = File.join(File.dirname(__FILE__), 'InventoryWithUpdates.xml')
     LinuxUpdates.prev_hash = nil
     LinuxUpdates.log = OMS::MockLog.new
@@ -66,9 +75,10 @@ class LinuxUpdatesTest < Test::Unit::TestCase
     
     expectedHash = {
       "CollectionName"=> "dpkg" + @@delimiter + "1.18.4ubuntu1.1" + @@delimiter + "Ubuntu_14.04",
+      "Architecture"=>"amd64",
       "PackageName"=>"dpkg",
       "PackageVersion"=>"1.18.4ubuntu1.1",
-      "Timestamp"=> "1970-01-01T00:00:00.000Z",
+      "Timestamp"=> nil,
       "Repository"=>"Ubuntu:16.04/xenial-updates",
       "Installed"=>false,
     }
@@ -152,10 +162,11 @@ class LinuxUpdatesTest < Test::Unit::TestCase
 
     expectedHash = {
       "CollectionName"=> "autotools-dev" + @@delimiter + "20150820.1" + @@delimiter + "Ubuntu_14.04",
+      "Architecture"=>"all",
       "PackageName"=> "autotools-dev",
       "PackageVersion"=>"20150820.1",
-      "Timestamp"=> "1970-01-01T00:00:00.000Z",
-      "Repository"=> "",
+      "Timestamp"=> nil,
+      "Repository"=> nil,
       "Size"=>"151",
       "Installed"=>true
     }
@@ -182,16 +193,79 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "autotools-dev_20150820.1_Ubuntu_16.04",
                     "Installed" => true,
+                    "Architecture"=>"all",
                     "PackageName" => "autotools-dev",
                     "PackageVersion" => "20150820.1",
-                    "Repository" => "",
+                    "Repository" => nil,
                     "Size" => "151",
-                    "Timestamp" => "1970-01-01T00:00:00.000Z"
+                    "Timestamp" => nil
                 }]
             }]
         }
     expectedTime = Time.utc(2016,3,15,19,2,38.5776)
     wrappedHash = LinuxUpdates::transform_and_wrap(@installed_packages_xml_str, "HostName", expectedTime, 
+                                                   86400, "AgentId-123", "Ubuntu", "Ubuntu 16.04",
+                                                   "16.04", "Ubuntu_16.04")
+    assert_equal(expectedHash, wrappedHash)
+  end
+  
+  def test_installed_packages_transform_and_wrap_with_installed_on_date
+    expectedHash = {
+            "DataType" => "LINUX_UPDATES_SNAPSHOT_BLOB",
+            "IPName" => "Updates",
+            "DataItems" => [{
+                "Host" => "HostName",
+                "AgentId" => "AgentId-123",
+                "OSFullName" => "Ubuntu 16.04",
+                "OSName" => "Ubuntu",
+                "OSType" => "Linux",
+                "OSVersion" => "16.04",
+                "Timestamp" => "2016-03-15T19:02:38.577Z",
+                "Collections" => [{
+                    "CollectionName" => "autotools-dev_20150820.1_Ubuntu_16.04",
+                    "Installed" => true,
+                    "Architecture"=>"all",
+                    "PackageName" => "autotools-dev",
+                    "PackageVersion" => "20150820.1",
+                    "Repository" => nil,
+                    "Size" => "151",
+                    "Timestamp" => "2016-07-11T02:02:16.000Z"
+                }]
+            }]
+        }
+    expectedTime = Time.utc(2016,3,15,19,2,38.5776)
+    wrappedHash = LinuxUpdates::transform_and_wrap(@installed_packages_xml_str_with_installed_on_date, "HostName", expectedTime, 
+                                                   86400, "AgentId-123", "Ubuntu", "Ubuntu 16.04",
+                                                   "16.04", "Ubuntu_16.04")
+    assert_equal(expectedHash, wrappedHash)
+  end
+
+  def test_installed_packages_transform_and_wrap_with_nil_installed_on_date
+    expectedHash = {
+            "DataType" => "LINUX_UPDATES_SNAPSHOT_BLOB",
+            "IPName" => "Updates",
+            "DataItems" => [{
+                "Host" => "HostName",
+                "AgentId" => "AgentId-123",
+                "OSFullName" => "Ubuntu 16.04",
+                "OSName" => "Ubuntu",
+                "OSType" => "Linux",
+                "OSVersion" => "16.04",
+                "Timestamp" => "2016-03-15T19:02:38.577Z",
+                "Collections" => [{
+                    "CollectionName" => "autotools-dev_20150820.1_Ubuntu_16.04",
+                    "Installed" => true,
+                    "Architecture"=>"all",
+                    "PackageName" => "autotools-dev",
+                    "PackageVersion" => "20150820.1",
+                    "Repository" => nil,
+                    "Size" => "151",
+                    "Timestamp" => nil
+                }]
+            }]
+        }
+    expectedTime = Time.utc(2016,3,15,19,2,38.5776)
+    wrappedHash = LinuxUpdates::transform_and_wrap(@installed_packages_xml_str_with_nil_installed_on_date, "HostName", expectedTime, 
                                                    86400, "AgentId-123", "Ubuntu", "Ubuntu 16.04",
                                                    "16.04", "Ubuntu_16.04")
     assert_equal(expectedHash, wrappedHash)
@@ -212,15 +286,76 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_14.04",
                     "Installed" => false,
+                    "Architecture"=>"amd64",
                     "PackageName" => "dpkg",
                     "PackageVersion" => "1.18.4ubuntu1.1",
                     "Repository" => "Ubuntu:15.04/xenial-updates",
-                    "Timestamp" => "1970-01-01T00:00:00.000Z"
+                    "Timestamp" => nil
                 }]
             }]
         }
     expectedTime = Time.utc(2016,3,15,19,2,38.5776)
     wrappedHash = LinuxUpdates::transform_and_wrap(@available_updates_xml_str, "HostName", expectedTime,
+                                                   86400, "AgentId-123", "Ubuntu", "Ubuntu 15.04",
+                                                   "15.04", "Ubuntu_15.04")
+    assert_equal(expectedHash, wrappedHash)
+  end
+
+  def test_available_updates_transform_and_wrap_with_build_date
+    expectedHash = {
+            "DataType" => "LINUX_UPDATES_SNAPSHOT_BLOB",
+            "IPName" => "Updates",
+            "DataItems" => [{
+                "Host" => "HostName",
+                "AgentId" => "AgentId-123",
+                "OSFullName" => "Ubuntu 15.04",
+                "OSName" => "Ubuntu",
+                "OSType" => "Linux",
+                "OSVersion" => "15.04",
+                "Timestamp" => "2016-03-15T19:02:38.577Z",
+                "Collections" => [{
+                    "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_14.04",
+                    "Installed" => false,
+                    "Architecture"=>"amd64",
+                    "PackageName" => "dpkg",
+                    "PackageVersion" => "1.18.4ubuntu1.1",
+                    "Repository" => "Ubuntu:15.04/xenial-updates",
+                    "Timestamp" => "2016-07-11T02:02:16.000Z"
+                }]
+            }]
+        }
+    expectedTime = Time.utc(2016,3,15,19,2,38.5776)
+    wrappedHash = LinuxUpdates::transform_and_wrap(@available_updates_xml_str_with_build_date, "HostName", expectedTime,
+                                                   86400, "AgentId-123", "Ubuntu", "Ubuntu 15.04",
+                                                   "15.04", "Ubuntu_15.04")
+    assert_equal(expectedHash, wrappedHash)
+  end
+
+  def test_available_updates_transform_and_wrap_with_nil_build_date
+    expectedHash = {
+            "DataType" => "LINUX_UPDATES_SNAPSHOT_BLOB",
+            "IPName" => "Updates",
+            "DataItems" => [{
+                "Host" => "HostName",
+                "AgentId" => "AgentId-123",
+                "OSFullName" => "Ubuntu 15.04",
+                "OSName" => "Ubuntu",
+                "OSType" => "Linux",
+                "OSVersion" => "15.04",
+                "Timestamp" => "2016-03-15T19:02:38.577Z",
+                "Collections" => [{
+                    "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_14.04",
+                    "Installed" => false,
+                    "Architecture"=>"amd64",
+                    "PackageName" => "dpkg",
+                    "PackageVersion" => "1.18.4ubuntu1.1",
+                    "Repository" => "Ubuntu:15.04/xenial-updates",
+                    "Timestamp" => nil
+                }]
+            }]
+        }
+    expectedTime = Time.utc(2016,3,15,19,2,38.5776)
+    wrappedHash = LinuxUpdates::transform_and_wrap(@available_updates_xml_str_with_nil_build_date, "HostName", expectedTime,
                                                    86400, "AgentId-123", "Ubuntu", "Ubuntu 15.04",
                                                    "15.04", "Ubuntu_15.04")
     assert_equal(expectedHash, wrappedHash)
@@ -241,26 +376,6 @@ class LinuxUpdatesTest < Test::Unit::TestCase
       warn("Method transform_and_wrap too slow, it took #{time_spent.round(2)}s to complete. The current time set is 5s")
     end
   end
-
-  # The forced send is not tested now as the current feature of forec sending the data is still under discussion. In the mean time it is kept commented.
-  #
-  # def test_force_send_true
-  #   inventoryXMLstr = File.read(@inventoryPath)
-  #   t = Time.now
-  #   wrappedHash = LinuxUpdates::transform_and_wrap(inventoryXMLstr, "HostName", t, "AgentId-123", "Ubuntu", "Ubuntu 16.04", "16.04", "Ubuntu_16.04")
-  #   wrappedHash2 = LinuxUpdates::transform_and_wrap(inventoryXMLstr, "HostName", t, "AgentId-123", "Ubuntu", "Ubuntu 16.04", "16.04", "Ubuntu_16.04")
-  #   assert_equal(wrappedHash, wrappedHash2)
-  #   assert_not_equal({}, wrappedHash2)
-  # end
-
-  # def test_force_send_false
-  #   # If we don't force to send up the inventory data and it doesn't change, discard it.
-  #   inventoryXMLstr = File.read(@inventoryPath)
-  #   wrappedHash = LinuxUpdates::transform_and_wrap(inventoryXMLstr, "HostName", Time.now, "AgentId-123", "Ubuntu", "Ubuntu 16.04", "16.04", "Ubuntu_16.04")
-  #   wrappedHash2 = LinuxUpdates::transform_and_wrap(inventoryXMLstr, "HostName", Time.now, "AgentId-123", "Ubuntu", "Ubuntu 16.04", "16.04", "Ubuntu_16.04")
-  #   assert_not_equal({}, wrappedHash)
-  #   assert_equal({}, wrappedHash2)
-  # end
   
   # Test if it removes the duplicate installed package.
   def test_remove_duplicates_installed_packages
@@ -297,5 +412,4 @@ class LinuxUpdatesTest < Test::Unit::TestCase
     data_items_dedup = LinuxUpdates::removeDuplicateCollectionNames(availableUpdates)
     assert_equal(collectionNamesSet.size, data_items_dedup.size, "Deduplication failed")
   end
-
 end


### PR DESCRIPTION
Changed the following:
1. Changing the run_interval to 3h, and removed the forcefully sending.
2. Adding patch_management_immediate_run.conf file which is a copy
of the patch_management.conf without run_interval to start as soon as
agent starts. Different tag used for the same.
3. If _BuildDate_ and _InstalledOn_ is either nil or **BuildDate**, **InstalelledOn**, 
then send nil.
4. Also made changes in the tests.

@Microsoft/omsagent-devs @stasku Could you please review the changes?