### PR TITLE
Removed the onetime config and merged with original conf file

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -26,7 +26,6 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/change_tracking_inventory.mof;    installer/conf/omsagent.d/change_tracking_inventory.mof;    644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/monitor.conf;            installer/conf/omsagent.d/monitor.conf;                644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/patch_management.conf;      installer/conf/omsagent.d/patch_management.conf;          644; root; root
-/etc/opt/microsoft/omsagent/sysconf/omsagent.d/patch_management_immediate_run.conf;      installer/conf/omsagent.d/patch_management_immediate_run.conf;          644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/patch_management_inventory.mof;  installer/conf/omsagent.d/patch_management_inventory.mof;        644; root; root
 
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/oms.conf;                installer/conf/oms.conf;                               644; root; root


### PR DESCRIPTION
I had added a new configuration file, but now merged it with the installer/conf/omsagent.d/patch_management.conf now. The build was looking for this file but it now does not exist. Fixes the broken build.

Sorry for the trouble. Please review the change.

@Microsoft/omsagent-devs  @stasku 