### PR TITLE
Adding a new field - UpdateState to be sent for reporting

### DIFF
--- a/source/code/plugins/patch_management_lib.rb
+++ b/source/code/plugins/patch_management_lib.rb
@@ -158,6 +158,7 @@ class LinuxUpdates
                                 OMS::Common.format_time(availableUpdatesHash["BuildDate"].to_i)
         ret["Repository"] = availableUpdatesHash.key?("Repository") ? availableUpdatesHash["Repository"] : nil
         ret["Installed"] = false
+        ret["UpdateState"] = "Needed"
         ret
     end
 
@@ -177,6 +178,7 @@ class LinuxUpdates
         ret["Size"] = packageHash["Size"]
         ret["Repository"] = packageHash.key?("Repository") ? packageHash["Repository"] : nil
         ret["Installed"] = true
+        ret["UpdateState"] = "NotNeeded"
         ret
     end
 

--- a/test/code/plugins/patch_management_lib_test.rb
+++ b/test/code/plugins/patch_management_lib_test.rb
@@ -81,6 +81,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
       "Timestamp"=> nil,
       "Repository"=>"Ubuntu:16.04/xenial-updates",
       "Installed"=>false,
+      "UpdateState"=>"Needed"
     }
     
     instanceXML = LinuxUpdates::strToXML(instanceXMLstr).root
@@ -168,7 +169,8 @@ class LinuxUpdatesTest < Test::Unit::TestCase
       "Timestamp"=> nil,
       "Repository"=> nil,
       "Size"=>"151",
-      "Installed"=>true
+      "Installed"=>true,
+      "UpdateState"=>"NotNeeded"
     }
     
     instanceXML = LinuxUpdates::strToXML(instanceXMLstr).root
@@ -193,6 +195,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "autotools-dev_20150820.1_Ubuntu_16.04",
                     "Installed" => true,
+                    "UpdateState"=>"NotNeeded",
                     "Architecture"=>"all",
                     "PackageName" => "autotools-dev",
                     "PackageVersion" => "20150820.1",
@@ -224,6 +227,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "autotools-dev_20150820.1_Ubuntu_16.04",
                     "Installed" => true,
+                    "UpdateState"=>"NotNeeded",
                     "Architecture"=>"all",
                     "PackageName" => "autotools-dev",
                     "PackageVersion" => "20150820.1",
@@ -255,6 +259,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "autotools-dev_20150820.1_Ubuntu_16.04",
                     "Installed" => true,
+                    "UpdateState"=>"NotNeeded",
                     "Architecture"=>"all",
                     "PackageName" => "autotools-dev",
                     "PackageVersion" => "20150820.1",
@@ -286,6 +291,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_14.04",
                     "Installed" => false,
+                    "UpdateState"=>"Needed",
                     "Architecture"=>"amd64",
                     "PackageName" => "dpkg",
                     "PackageVersion" => "1.18.4ubuntu1.1",
@@ -316,6 +322,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_14.04",
                     "Installed" => false,
+                    "UpdateState"=>"Needed",
                     "Architecture"=>"amd64",
                     "PackageName" => "dpkg",
                     "PackageVersion" => "1.18.4ubuntu1.1",
@@ -346,6 +353,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                 "Collections" => [{
                     "CollectionName" => "dpkg_1.18.4ubuntu1.1_Ubuntu_14.04",
                     "Installed" => false,
+                    "UpdateState"=>"Needed",
                     "Architecture"=>"amd64",
                     "PackageName" => "dpkg",
                     "PackageVersion" => "1.18.4ubuntu1.1",


### PR DESCRIPTION
Adding a new field "UpdateState". This is required for using CxP
processing of the the update data. Updated the unittests as well.

"UpdateState"=>"Needed" when reporting available updates.
"UpdateState"=>"NotNeeded" when reporting installed packages.

@Microsoft/omsagent-devs @stasku Could you please review the changes.

Thanks

