### PR TITLE
StatsD aggregator for FluentD

### DIFF
--- a/installer/conf/omsagent.d/statsd.conf
+++ b/installer/conf/omsagent.d/statsd.conf
@@ -1,0 +1,19 @@
+<source>
+  type udp
+  tag oms.statsd.raw
+  format none
+  port 8125
+  bind 127.0.0.1
+</source>
+
+<match oms.statsd.raw>
+  type statsd_aggregator
+  log_level info
+  flush_interval 10s
+  threshold_percentile 90
+  out_tag oms.statsd.aggregated
+</match>
+
+#<match oms.statsd.**>
+#  type stdout
+#</match>

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -30,6 +30,7 @@ MAINTAINER:              'Microsoft Corporation'
 
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/oms.conf;                installer/conf/oms.conf;                               644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/collectd.conf;           installer/conf/omsagent.d/collectd.conf;               644; root; root
+/etc/opt/microsoft/omsagent/sysconf/omsagent.d/statsd.conf;             installer/conf/omsagent.d/statsd.conf;                 644; root; root
 
 /opt/microsoft/omsagent/LICENSE;                                        LICENSE;                                               444; root; root
 
@@ -74,6 +75,8 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/patch_management_lib.rb;                 source/code/plugins/patch_management_lib.rb;           744; root; root
 /opt/microsoft/omsagent/plugin/filter_flatten.rb;                       source/code/plugins/filter_flatten.rb;                 744; root; root
 /opt/microsoft/omsagent/plugin/flattenjson_lib.rb;                      source/code/plugins/flattenjson_lib.rb;                744; root; root
+/opt/microsoft/omsagent/plugin/statsd_lib.rb;                           source/code/plugins/statsd_lib.rb;                     744; root; root
+/opt/microsoft/omsagent/plugin/out_oms_statsd_aggregator.rb;            source/code/plugins/out_oms_statsd_aggregator.rb;      744; root; root
 
 %Links
 /opt/microsoft/omsagent/bin/omsagent; /opt/microsoft/omsagent/ruby/bin/fluentd; 755; root; root

--- a/source/code/plugins/out_oms_statsd_aggregator.rb
+++ b/source/code/plugins/out_oms_statsd_aggregator.rb
@@ -1,0 +1,83 @@
+module Fluent
+
+  class OutputOMSStatsdAggregator < Output
+
+    Plugin.register_output('statsd_aggregator', self)
+
+    def initialize
+      super
+      require_relative 'statsd_lib'
+      require_relative 'omslog'
+      require_relative 'oms_configuration'
+      require_relative 'oms_common'
+    end
+
+    config_param :flush_interval, :time, :default => 10
+    config_param :threshold_percentile, :integer, :default => 90
+    config_param :persist_file, :string, :default => '/var/opt/microsoft/omsagent/state/statsd.data'
+    config_param :out_tag, :string
+
+    def configure(conf)
+      super
+      @statsd = OMS::StatsDState.new(@flush_interval, @threshold_percentile, @persist_file, @log)
+    end
+
+    def start
+      super
+
+      @finished = false
+      @condition = ConditionVariable.new
+      @mutex = Mutex.new
+      @thread = Thread.new(&method(:run_periodic))
+    end
+
+    def shutdown
+      super
+
+      @mutex.synchronize {
+        @finished = true
+        @condition.signal
+      }
+      @thread.join
+    end
+
+    def emit(tag, es, chain)
+      chain.next
+      es.each {| time, record |
+        @log.debug "Receiving data in aggregator #{time}, #{record}"
+        @statsd.receive(record['message'])
+      }
+    end
+
+  private
+
+    def enumerate
+      time = Time.now.to_f
+
+      wrapper = {
+        "DataType" => "LINUX_PERF_BLOB",
+        "IPName" => "LogManagement",
+        "DataItems" => @statsd.convert_to_oms_format(time, OMS::Common.get_hostname)
+      }
+
+      Fluent::Engine.emit(@out_tag, time, wrapper)
+    end
+
+    def run_periodic
+      @mutex.lock
+      done = @finished
+      until done
+        @condition.wait(@mutex, @flush_interval)
+        done = @finished
+        @mutex.unlock
+        if !done
+          enumerate
+        end
+        @mutex.lock
+      end
+      @mutex.unlock
+    end
+
+  end # class
+
+end # module Fluent

--- a/source/code/plugins/statsd_lib.rb
+++ b/source/code/plugins/statsd_lib.rb
@@ -1,0 +1,311 @@
+module OMS
+
+  class StatsDState
+    require_relative 'oms_common'
+    require_relative 'omslog'
+
+    public
+
+    def initialize(flush_interval, threshold_percentile, persist_file_location, log)
+      @flush_interval = flush_interval
+      @threshold_percentile = threshold_percentile
+      @persist_file_location = persist_file_location
+      @log = log
+
+      @timers = Hash.new { |hash, key| hash[key] = [] }
+      @counters = Hash.new { |hash, key| hash[key] = 0 }
+      @sets = Hash.new { |hash, key| hash[key] = {} }
+      @gauges = nil
+
+      if !@persist_file_location.nil? and File.exist? @persist_file_location
+        begin
+          file = File.read(@persist_file_location)
+
+          begin
+            @gauges = Marshal.load(file)
+          rescue => error
+            @log.warn "Error parsing file: #{@persist_file_location} : #{error}"
+          end
+        rescue => error
+          @log.warn "Unable to read file: #{@persist_file_location} : #{error}"
+        end
+      end
+
+      @gauges = Hash.new if @gauges.nil?
+    end
+
+    def receive(data)
+      return if data.nil?
+
+      data.split("\n").each do |line|
+        # expect the line is in the format:
+        # <key>:<values>|<type>
+        bits = line.split(':')
+        key = bits.shift.gsub(/\s+/, '_').gsub(/\//, '-').gsub(/[^a-zA-Z_\-0-9\.]/, '')
+        bits.each do |record|
+          fields = record.split('|')
+          next if fields.nil? || fields.count < 2
+
+          type = fields[1].strip
+
+          if type == 'ms' or type == 't' # timer
+            receive_timer(key, fields[0])
+          elsif type == 'c' # counter
+            receive_counter(key, fields[0])
+          elsif type == 's' # set
+            receive_set(key, fields[0])
+          elsif type == 'g' # gauge
+            receive_gauge(key, fields[0])
+          else
+          end
+        end
+      end
+    end # receive
+
+    def convert_to_oms_format(time, host)
+      @log.trace "Begin publish to OMS"
+
+      res = []
+
+      data = aggregate(true)
+
+      base = {
+        'Timestamp' => OMS::Common.format_time(time),
+        'Host' => host
+      }
+
+      @log.trace "Get #{data['timers'].length} timers"
+
+      data['timers'].each do | name, metrics |
+        counters = []
+        metrics.each do | counter, value |
+          counters << { 'CounterName' => counter, 'Value' => value }
+        end
+
+        metric = {
+          'ObjectName' => 'statsd.timer',
+          'InstanceName' => name,
+          'Collections' => counters
+        }.merge(base)
+
+        res << metric
+      end
+
+      @log.trace "Get #{data['counters'].length} counters"
+
+      data['counters'].each do | name, value |
+        metric = {
+          'ObjectName' => 'statsd.counter',
+          'InstanceName' => name,
+          'Collections' => [{ 'CounterName' => 'rate', 'Value' => value }]
+        }.merge(base)
+
+        res << metric
+      end
+
+      @log.trace "Get #{data['sets'].length} sets"
+
+      data['sets'].each do | name, value |
+        metric = {
+          'ObjectName' => 'statsd.set',
+          'InstanceName' => name,
+          'Collections' => [{ 'CounterName' => 'count', 'Value' => value }]
+        }.merge(base)
+
+        res << metric
+      end
+
+      @log.trace "Get #{data['gauges'].length} gauges"
+
+      data["gauges"].each do | name, value |
+        metric = {
+          'ObjectName' => 'statsd.gauge',
+          'InstanceName' => name,
+          'Collections' => [{ 'CounterName' => 'gauge', 'Value' => value }]
+        }.merge(base)
+
+        res << metric
+      end
+
+      @log.trace "Return #{res.length} metrics"
+
+      res
+    end # publish_to_oms
+
+    def aggregate(need_reset = true)
+      @log.trace "Aggregate the states"
+
+      timers = @timers.dup
+      counters = @counters.dup
+      sets = @sets.dup
+      gauges = @gauges.dup
+
+      reset if need_reset
+
+      res = { 
+        'timers' => aggregate_timers(timers),
+        'counters' => aggregate_counters(counters),
+        'sets' => aggregate_sets(sets),
+        'gauges' => aggregate_gauges(gauges)
+      }
+    end # aggregate
+
+    private
+
+    def receive_timer(key, values)
+      @log.trace "Receive timer: #{key}"
+
+      values.split(',').each do |value|
+        v = Float(value.strip) rescue nil
+        @timers[key] << v if v
+      end
+    end # receive_gauge
+
+    def receive_counter(key, value)
+      @log.trace "Receive counter: #{key}"
+
+      sample_rate = @flush_interval
+      count_str, sample_rate_str = value.split('@', 2)
+
+      if !sample_rate_str.nil? and !sample_rate_str.empty?
+        sample_rate = Float(sample_rate_str.strip) rescue @flush_interval
+      end
+
+      count = Integer(count_str.strip) rescue 1
+      @counters[key] += count.to_i / sample_rate.to_f
+    end # receive_gauge
+
+    def receive_set(key, value)
+      @log.trace "Receive set: #{key}"
+
+      v = Float(value.strip) rescue nil
+
+      if !v.nil?
+        @sets[key][v.to_s] = true
+      end
+    end # receive_gauge
+
+    def receive_gauge(key, value)
+      @log.trace "Receive gauge: #{key}"
+
+      v = Float(value.strip) rescue nil
+
+      if !v.nil? and !(@gauges.has_key?(key) and @gauges[key] == v)
+        @gauges[key] = v
+        persist_data
+      end
+    end # receive_gauge
+
+    def persist_data
+      if !@persist_file_location.nil?
+        begin
+          File.open(@persist_file_location, 'w+') do | f |
+            f.write(Marshal.dump(@gauges))
+          end
+        rescue => error
+          @log.warn "Unable to persist the data to file: #{@persist_file_location} : #{error}"
+        end
+      end
+    end # persist_gauges
+
+    def aggregate_timers(timers)
+      res = {}
+
+      timers.each do | key, values |
+        next if values.length == 0
+
+        values.sort!
+
+        count = values.length
+        min = values[0]
+        max = values[-1]
+
+        mid = (count / 2).round
+        median = (count % 2 == 1) ? values[mid] : (values[mid-1] + values[mid]) / 2
+
+        cumulative_values = []
+        sum = 0
+        values.each do |v|
+          sum += v
+          cumulative_values << sum
+        end
+
+        mean = sum / count
+
+        res[key] = {
+          'min' => min,
+          'max' => max,
+          'sum' => sum,
+          'count' => count,
+          'mean' => mean,
+          'median' => median
+        }
+
+        if count > 1 and @threshold_percentile != 100
+          threshold_idx = (((100 - @threshold_percentile) / 100.0) * count).round
+          num_in_threshold = count - threshold_idx
+
+          next if num_in_threshold < 1
+
+          max_at_threshold = values[num_in_threshold-1]
+          sum_in_threshold = cumulative_values[num_in_threshold-1]
+
+          mean = sum_in_threshold / num_in_threshold
+          
+          mid = (num_in_threshold / 2).round
+          median = (num_in_threshold % 2 == 1) ? values[mid] : (values[mid-1] + values[mid]) / 2
+
+          res[key].merge!({
+            'max_at_threshold' => max_at_threshold,
+            'sum_in_threshold' => sum_in_threshold,
+            'count_in_threshold' => num_in_threshold,
+            'mean_in_threshold' => mean,
+            'median_in_threshold' => median
+          })
+        end
+      end
+
+      res
+    end # aggregate_timers
+
+    def aggregate_counters(counters)
+      res = {}
+
+      counters.each do | key, value |
+        res[key] = value
+      end
+
+      res
+    end # aggregate_counters
+
+    def aggregate_sets(sets)
+      res = {}
+
+      sets.each do | key, value |
+        res[key] = value.length
+      end
+
+      res
+    end # aggregate_sets
+
+    def aggregate_gauges(gauges)
+      res = {}
+
+      gauges.each do | key, value |
+        res[key] = value
+      end
+
+      res
+    end # aggregate_guages
+
+    def reset(reset_gauges = false)
+      @timers = Hash.new { |hash, key| hash[key] = [] }
+      @counters = Hash.new { |hash, key| hash[key] = 0 }
+      @sets = Hash.new { |hash, key| hash[key] = {} }
+      @gauges = Hash.new { |hash, key| hash[key] = 0 } if reset_gauges
+    end # reset
+
+  end # class StatsDAggregator
+
+end # module OMS
+

--- a/test/code/plugins/statsd_lib_test.rb
+++ b/test/code/plugins/statsd_lib_test.rb
@@ -1,0 +1,287 @@
+require 'tempfile'
+require 'test/unit'
+require_relative '../../../source/code/plugins/statsd_lib'
+require_relative 'omstestlib'
+
+class StatsdTest < Test::Unit::TestCase
+
+  class OMS::StatsDState
+    def FlushInterval=(value)
+      @flush_interval = value
+    end
+
+    def ThresholdPercentile=(value)
+      @threshold_percentile = value
+    end
+
+    def PersistFileLocation=(value)
+      @persist_file_location = value
+    end
+  end
+
+  def setup
+    @flush_interval = 10
+    @threshold_percentile = 80
+    @log = OMS::MockLog.new
+    @persist_tempfile = Tempfile.new('statsd.data')
+    @statsd_lib = OMS::StatsDState.new(@flush_interval, @threshold_percentile, @persist_tempfile.path, @log)
+  end
+
+  def teardown
+    @persist_tempfile.unlink
+  end
+
+  def test_boundaries
+    assert_nothing_raised(RuntimeError, "Failed to handle the empty case") do
+      @statsd_lib.receive(nil)
+      @statsd_lib.receive('')
+    end
+  end
+
+  def test_invalid_inputs
+    assert_nothing_raised(RuntimeError, "Failed to handle invalid inputs") do
+      @statsd_lib.receive('abdasdfasdf')
+      @statsd_lib.receive('abda:1|a')
+      @statsd_lib.receive('abdasdf:1')
+      @statsd_lib.receive('abdasdfas:abcd|g')
+    end
+  end
+
+  def test_gauge_not_reset
+    @statsd_lib.receive('sample.gauge:314|g')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['gauges'].nil?, 'gauges should not be nil')
+    assert_equal(314, metrics['gauges']['sample.gauge'], 'sample.gauge value should match')
+
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['gauges'].nil?, 'gauges should not be nil')
+    assert_equal(314, metrics['gauges']['sample.gauge'], 'sample.gauge value should not be reset')
+  end
+
+  def test_gauge_persist_and_2gauges
+    @statsd_lib.receive('sample.gauge:1|g')
+    @statsd_lib.receive('sample.gauge:159|g')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['gauges'].nil?, 'gauges should not be nil')
+    assert_equal(159, metrics['gauges']['sample.gauge'], 'sample.gauge value should updated')
+
+    new_statsd_lib = OMS::StatsDState.new(10, 90, @persist_tempfile.path, @log)
+    metrics = new_statsd_lib.aggregate(true)
+    assert(!metrics['gauges'].nil?, 'gauges should not be nil')
+    assert_equal(159, metrics['gauges']['sample.gauge'], 'sample.gauge value should be persisted')
+
+    @statsd_lib.receive('sample.gauge2:265|g')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['gauges'].nil?, 'gauges should not be nil')
+    assert_equal(159, metrics['gauges']['sample.gauge'], 'sample.gauge value should not change')
+    assert_equal(265, metrics['gauges']['sample.gauge2'], 'sample.gauge2 value should be set')
+  end
+
+  def test_counter_and_reset
+    @statsd_lib.receive('sample.counter:1|c')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['counters'].nil?, 'counters should not be nil')
+    assert_equal(1.0 / @flush_interval, metrics['counters']['sample.counter'], 'sample.counter value should match')
+
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['counters'].nil?, 'counters should not be nil')
+    assert(metrics['counters']['sample.counter'].nil?, 'sample.counter value should be reset')
+  end
+
+  def test_counter_expressions
+    @statsd_lib.receive('sample.counter:1|c')
+    @statsd_lib.receive('sample.counter:2|c')
+    @statsd_lib.receive('sample.counter:3@4|c')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['counters'].nil?, 'counters should not be nil')
+    assert_equal( ( 1.0 + 2 ) / @flush_interval + 3.0 / 4, metrics['counters']['sample.counter'], 'sample.counter value should match')
+  end
+
+  def test_2counters
+    @statsd_lib.receive('sample.counter:5|c')
+    @statsd_lib.receive('sample.counter:6|c')
+    @statsd_lib.receive('sample.counter2:7@8|c')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['counters'].nil?, 'counters should not be nil')
+    assert_equal( ( 5.0 + 6 ) / @flush_interval, metrics['counters']['sample.counter'], 'sample.counter value should match')
+    assert_equal( 7.0 / 8, metrics['counters']['sample.counter2'], 'sample.counter2 value should match')
+  end
+
+  def test_set_and_reset
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set:1111111111111111111111|s')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['sets'].nil?, 'sets should not be nil')
+    assert_equal(2, metrics['sets']['sample.set'], 'sample.set value should match')
+
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['sets'].nil?, 'sets should not be nil')
+    assert(metrics['sets']['sample.set'].nil?, 'sample.set value should be reset')
+  end
+
+  def test_2sets
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set2:233333|s')
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set:1111111111111111111111|s')
+    @statsd_lib.receive('sample.set2:0|s')
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['sets'].nil?, 'sets should not be nil')
+    assert_equal(2, metrics['sets']['sample.set'], 'sample.set value should match')
+    assert_equal(2, metrics['sets']['sample.set2'], 'sample.set2 value should match')
+  end
+
+  def test_timer_and_reset
+    rng = Random.new(Random.new_seed)
+
+    timers = Array.new(rng.rand(100).round+100) { |i| rng.rand(1000).round }
+
+    sum = 0.0
+    timers.each do |t| 
+      sum += t
+      @statsd_lib.receive("sample.timer:#{t}|ms")
+    end
+
+    timers.sort!
+
+    count = timers.length
+    mean = sum / count
+
+    mid = (count / 2).round
+    median = (count % 2 == 1) ? timers[mid] : (timers[mid-1] + timers[mid]) / 2.0
+
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['timers'].nil?, 'timers should not be nil')
+    assert(!metrics['timers']['sample.timer'].nil?, 'sample.timer should not be nil')
+    assert_equal(timers[0], metrics['timers']['sample.timer']['min'], 'sample.timer max should match')
+    assert_equal(timers[-1], metrics['timers']['sample.timer']['max'], 'sample.timer min should match')
+    assert_equal(sum, metrics['timers']['sample.timer']['sum'], 'sample.timer sum should match')
+    assert_equal(count, metrics['timers']['sample.timer']['count'], 'sample.timer count should match')
+    assert_equal(mean, metrics['timers']['sample.timer']['mean'], 'sample.timer mean should match')
+    assert_equal(median, metrics['timers']['sample.timer']['median'], 'sample.timer median should match')
+
+    threshold_idx = (((100 - @threshold_percentile) / 100.0) * count).round
+    num_in_threshold = count - threshold_idx
+
+    sum = 0.0
+    timers[0..num_in_threshold-1].each { |t| sum += t }
+
+    mean = sum / num_in_threshold
+
+    mid = (num_in_threshold / 2).round
+    median = (num_in_threshold % 2 == 1) ? timers[mid] : (timers[mid-1] + timers[mid]) / 2.0
+
+    assert_equal(timers[num_in_threshold-1], metrics['timers']['sample.timer']['max_at_threshold'], 'sample.timer max_at_threshold should match')
+    assert_equal(sum, metrics['timers']['sample.timer']['sum_in_threshold'], 'sample.timer sum_in_threshold should match')
+    assert_equal(num_in_threshold, metrics['timers']['sample.timer']['count_in_threshold'], 'sample.timer count_in_threshold should match')
+    assert_equal(mean, metrics['timers']['sample.timer']['mean_in_threshold'], 'sample.timer mean_in_threshold should match')
+    assert_equal(median, metrics['timers']['sample.timer']['median_in_threshold'], 'sample.timer median_in_threshold should match')
+
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['timers'].nil?, 'timers should not be nil')
+    assert(metrics['timers']['sample.timer'].nil?, 'sample.timer value should be reset')
+  end
+
+  def test_timers_expressions
+    @statsd_lib.receive("sample.timer:123|ms")
+    @statsd_lib.receive("sample.timer:123|t")
+    @statsd_lib.receive("sample.timer:456|t")
+    @statsd_lib.receive("sample.timer:789|ms")
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['timers'].nil?, 'timers should not be nil')
+    assert(!metrics['timers']['sample.timer'].nil?, 'sample.timer should not be nil')
+    assert_equal(123, metrics['timers']['sample.timer']['min'], 'sample.timer max should match')
+    assert_equal(789, metrics['timers']['sample.timer']['max'], 'sample.timer min should match')
+    assert_equal(1491, metrics['timers']['sample.timer']['sum'], 'sample.timer sum should match')
+    assert_equal(4, metrics['timers']['sample.timer']['count'], 'sample.timer count should match')
+    assert_equal(372.75, metrics['timers']['sample.timer']['mean'], 'sample.timer mean should match')
+    assert_equal(289.5, metrics['timers']['sample.timer']['median'], 'sample.timer median should match')
+  end
+
+  def test_2timers
+    @statsd_lib.receive("sample.timer:123|ms")
+    @statsd_lib.receive("sample.timer2:123|t")
+    @statsd_lib.receive("sample.timer:456|t")
+    @statsd_lib.receive("sample.timer2:789|ms")
+    metrics = @statsd_lib.aggregate(true)
+    assert(!metrics['timers'].nil?, 'timers should not be nil')
+    assert(!metrics['timers']['sample.timer'].nil?, 'sample.timer should not be nil')
+    assert_equal(123, metrics['timers']['sample.timer']['min'], 'sample.timer max should match')
+    assert_equal(456, metrics['timers']['sample.timer']['max'], 'sample.timer min should match')
+    assert_equal(579, metrics['timers']['sample.timer']['sum'], 'sample.timer sum should match')
+    assert_equal(2, metrics['timers']['sample.timer']['count'], 'sample.timer count should match')
+    assert_equal(289.5, metrics['timers']['sample.timer']['mean'], 'sample.timer mean should match')
+    assert_equal(289.5, metrics['timers']['sample.timer']['median'], 'sample.timer median should match')
+    assert(!metrics['timers'].nil?, 'timers should not be nil')
+    assert(!metrics['timers']['sample.timer2'].nil?, 'sample.timer2 should not be nil')
+    assert_equal(123, metrics['timers']['sample.timer2']['min'], 'sample.timer2 max should match')
+    assert_equal(789, metrics['timers']['sample.timer2']['max'], 'sample.timer2 min should match')
+    assert_equal(912, metrics['timers']['sample.timer2']['sum'], 'sample.timer2 sum should match')
+    assert_equal(2, metrics['timers']['sample.timer2']['count'], 'sample.timer2 count should match')
+    assert_equal(456, metrics['timers']['sample.timer2']['mean'], 'sample.timer2 mean should match')
+    assert_equal(456, metrics['timers']['sample.timer2']['median'], 'sample.timer2 median should match')
+  end
+
+  def test_publish_to_oms_with_mixed_value
+    @statsd_lib.receive('sample.gauge:1|g')
+    @statsd_lib.receive('sample.gauge:159|g')
+    @statsd_lib.receive('sample.counter:1|c')
+    @statsd_lib.receive('sample.counter:2|c')
+    @statsd_lib.receive('sample.counter:3@4|c')
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set:233333|s')
+    @statsd_lib.receive('sample.set:1111111111111111111111|s')
+    @statsd_lib.receive("sample.timer:123|ms")
+    @statsd_lib.receive("sample.timer:123|t")
+    @statsd_lib.receive("sample.timer:456|t")
+    @statsd_lib.receive("sample.timer:789|ms")
+
+    t = 1470369495.181262
+    data = @statsd_lib.convert_to_oms_format(t, 'testhost123')
+    expected = [{
+      "Collections"=>[
+        {"CounterName"=>"min", "Value"=>123.0},
+        {"CounterName"=>"max", "Value"=>789.0},
+        {"CounterName"=>"sum", "Value"=>1491.0},
+        {"CounterName"=>"count", "Value"=>4},
+        {"CounterName"=>"mean", "Value"=>372.75},
+        {"CounterName"=>"median", "Value"=>289.5},
+        {"CounterName"=>"max_at_threshold", "Value"=>456.0},
+        {"CounterName"=>"sum_in_threshold", "Value"=>702.0},
+        {"CounterName"=>"count_in_threshold", "Value"=>3},
+        {"CounterName"=>"mean_in_threshold", "Value"=>234.0},
+        {"CounterName"=>"median_in_threshold", "Value"=>123.0}
+      ],
+      "Host"=>"testhost123",
+      "InstanceName"=>"sample.timer",
+      "ObjectName"=>"statsd.timer",
+      "Timestamp"=>"2016-08-05T03:58:15.181Z"
+    },
+    {
+      "Collections"=>[{"CounterName"=>"rate", "Value"=>1.05}],
+      "Host"=>"testhost123",
+      "InstanceName"=>"sample.counter",
+      "ObjectName"=>"statsd.counter",
+      "Timestamp"=>"2016-08-05T03:58:15.181Z"
+    },
+    {
+      "Collections"=>[{"CounterName"=>"count", "Value"=>2}],
+      "Host"=>"testhost123",
+      "InstanceName"=>"sample.set",
+      "ObjectName"=>"statsd.set",
+      "Timestamp"=>"2016-08-05T03:58:15.181Z"
+    },
+    {
+      "Collections"=>[{"CounterName"=>"gauge", "Value"=>159.0}],
+      "Host"=>"testhost123",
+      "InstanceName"=>"sample.gauge",
+      "ObjectName"=>"statsd.gauge",
+      "Timestamp"=>"2016-08-05T03:58:15.181Z"
+    }]
+
+    assert_equal(expected, data, 'data is not expected')
+  end
+end


### PR DESCRIPTION
Implement the statsd aggregator and create an output plugin to buffer the data and aggregate in a configured interval. The aggregated data will be emitted to the FluentD engine again to be sent to the OMS by the out_oms plugin.
Add unit test to cover the statsd aggregation logic.
@Microsoft/omsagent-devs 
