### PR TITLE
Fix the StatsD unit test failure

### DIFF
--- a/test/code/plugins/statsd_lib_test.rb
+++ b/test/code/plugins/statsd_lib_test.rb
@@ -257,28 +257,28 @@ class StatsdTest < Test::Unit::TestCase
       ],
       "Host"=>"testhost123",
       "InstanceName"=>"sample.timer",
-      "ObjectName"=>"statsd.timer",
+      "ObjectName"=>"StatsD Timer",
       "Timestamp"=>"2016-08-05T03:58:15.181Z"
     },
     {
       "Collections"=>[{"CounterName"=>"rate", "Value"=>1.05}],
       "Host"=>"testhost123",
       "InstanceName"=>"sample.counter",
-      "ObjectName"=>"statsd.counter",
+      "ObjectName"=>"StatsD Counter",
       "Timestamp"=>"2016-08-05T03:58:15.181Z"
     },
     {
       "Collections"=>[{"CounterName"=>"count", "Value"=>2}],
       "Host"=>"testhost123",
       "InstanceName"=>"sample.set",
-      "ObjectName"=>"statsd.set",
+      "ObjectName"=>"StatsD Set",
       "Timestamp"=>"2016-08-05T03:58:15.181Z"
     },
     {
       "Collections"=>[{"CounterName"=>"gauge", "Value"=>159.0}],
       "Host"=>"testhost123",
       "InstanceName"=>"sample.gauge",
-      "ObjectName"=>"statsd.gauge",
+      "ObjectName"=>"StatsD Gauge",
       "Timestamp"=>"2016-08-05T03:58:15.181Z"
     }]
 


### PR DESCRIPTION
Fix the unit test failure introduced by commit 77317ce790a8bb64f7faf6c2bd91583db7c8fda1
    Update the ObjectName of the StatsD Perf Data
    Use user friendly name "StatsD Timer", "StatsD Counter",
    "StatsD Set", and "StatsD Gauge" as the ObjectName

@Microsoft/omsagent-devs 