### PR TITLE
Fix the regex in omsadmin.sh

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -360,7 +360,7 @@ onboard()
         clean_exit 1
     fi
 
-    if [[ ! $WORKSPACE_ID =~ ^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$ ]]; then
+    if [[ ! $WORKSPACE_ID =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
         log_error "The Workspace ID is not valid"
         clean_exit 1
     fi


### PR DESCRIPTION
CentOS 5 doesn't support parentheses in regex

@Microsoft/omsagent-devs 