### PR TITLE
Remove the duplicate omi perf counter for MySQL

### DIFF
--- a/installer/conf/omi_mapping.json
+++ b/installer/conf/omi_mapping.json
@@ -387,10 +387,6 @@
                 "CounterName": "Full Table Scan Pct"
             },
             {
-                "CimPropertyName": "IDB_BP_UsePct",
-                "CounterName": "InnoDB Buffer Pool Use Pct"
-            },
-            {
                 "CimPropertyName": "ServerDiskUseInBytes",
                 "CounterName": "Disk Space Use in Bytes"
             },


### PR DESCRIPTION
The omi_mapping defines the "InnoDB Buffer Pool Use Pct" twice.
It causes the Test_Marshell method in nxOMSAgent resource always return false if the "InnoDB Buffer Pool Use Pct" is in the configuration.

@Microsoft/omsagent-devs 