### PR TITLE
Removed mysql pre-req of mysql-devel for the end user

### DIFF
--- a/docs/How-to-setup-mysql-plugin.md
+++ b/docs/How-to-setup-mysql-plugin.md
@@ -1,15 +1,10 @@
 # How to enable MySQL plugin to collect MySQL server stats and performance data
-  - Machine has to have libmysqlclient.so installed (libmysqlclient can be download and installed it through mysql-devel package)
-
-Example for RPM based systems : yum install mysql-devel
-    
-Example for Debian based systems: apt-get install libmysqlclient-dev
 * Install omsagent on the machine
 * Install MySQL server on the machine
 * Start MySQL server:
 
    service mysqld start
-* Copy mysqlworkload.conf from sysconf to omsagent local path under /conf/omsagent.d/mysqlworkload.conf.
+* Copy mysqlworkload.conf from /etc/opt/microsoft/omsagent/sysconf/omsagent.d/ to /etc/opt/microsoft/omsagent/conf/omsagent.d/.
 * Restart omsagent:
  
 		service omsagent restart

--- a/installer/conf/omi_mapping.json
+++ b/installer/conf/omi_mapping.json
@@ -387,10 +387,6 @@
                 "CounterName": "Full Table Scan Pct"
             },
             {
-                "CimPropertyName": "IDB_BP_UsePct",
-                "CounterName": "InnoDB Buffer Pool Use Pct"
-            },
-            {
                 "CimPropertyName": "ServerDiskUseInBytes",
                 "CounterName": "Disk Space Use in Bytes"
             },

--- a/installer/conf/omsagent.d/mongo.conf
+++ b/installer/conf/omsagent.d/mongo.conf
@@ -22,7 +22,8 @@
   type tail
   path /var/log/mongodb/mongod.log
   tag  oms.api.MongoDBlog
-  format /(?<timestamp>[^ ]*) (?<severity>[A-Z]) (?<component>(-|([^ ]*)))\s* \[(?<context>[^\]]*)\] ((?<query>.*) (?<querytime_ms>[\d\.]+ms)|(?<message>.*))/
+  format /(?<timestamp>[^ ]*) (?<severity>[A-Z]) (?<component>(-|([^ ]*)))\s* \[(?<context>[^\]]*)\] ((?<query>.*) (?<querytime_ms>[\d\.]+(?=ms))|(?<message>.*))/
+  types querytime_ms:float
 </source>
 
 <match oms.api.MongoDBlog>


### PR DESCRIPTION
Removed mysql pre-req of mysql-devel for the end user since this
dependancy on native lib is needed for building the omsagent bundle only
and not during the bundle installation. Added the lib dependancy to
build-oms-agent document instead.

@Microsoft/omsagent-devs 