### PR TITLE
PerfCounter name change to include KB

### DIFF
--- a/installer/conf/omi_mapping.json
+++ b/installer/conf/omi_mapping.json
@@ -219,7 +219,8 @@
             },
             {
                 "CimPropertyName": "UsedMemory",
-                "CounterName": "Used Memory"
+                "CounterName": "Used Memory",
+                "DisplayName": "Used Memory kBytes"
             },
             {
                 "CimPropertyName": "VirtualSharedMemory",

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -22,6 +22,7 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/opt/microsoft/omsagent/sysconf/omsagent.conf;                      installer/conf/omsagent.conf;                          644; root; root
 /etc/opt/microsoft/omsagent/sysconf/installinfo.txt;                    installer/conf/installinfo.txt;                        644; root; root; conffile
 /etc/opt/microsoft/omsagent/sysconf/omi_mapping.json;                   installer/conf/omi_mapping.json;                       644; root; root
+/etc/opt/microsoft/omsagent/conf/omi_mapping.json;                      installer/conf/omi_mapping.json;                       644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/change_tracking.conf;    installer/conf/omsagent.d/change_tracking.conf;        644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/change_tracking_inventory.mof;    installer/conf/omsagent.d/change_tracking_inventory.mof;    644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/monitor.conf;            installer/conf/omsagent.d/monitor.conf;                644; root; root

--- a/source/code/plugins/in_oms_omi.rb
+++ b/source/code/plugins/in_oms_omi.rb
@@ -15,7 +15,7 @@ module Fluent
     config_param :counter_name_regex, :string, :default => ".*"
     config_param :interval, :time, :default => nil
     config_param :tag, :string, :default => "oms.omi"  
-    config_param :omi_mapping_path, :string, :default => "/etc/opt/microsoft/omsagent/sysconf/omi_mapping.json"
+    config_param :omi_mapping_path, :string, :default => "/etc/opt/microsoft/omsagent/conf/omi_mapping.json"
 
     def configure (conf)
       super

--- a/test/code/plugins/omi_lib_test.rb
+++ b/test/code/plugins/omi_lib_test.rb
@@ -116,7 +116,7 @@ class OmiLib_Test < Test::Unit::TestCase
 			"System Uptime",
 			"Process Pct Privileged Time",
 			"Process Pct User Time",
-			"Process Used Memory",
+			"Process Used Memory kBytes",
 			"Process Virtual Shared Memory",
 			"Apache HTTP Server Total Pct CPU",
 			"Apache HTTP Server Idle Workers",
@@ -186,7 +186,7 @@ class OmiLib_Test < Test::Unit::TestCase
 
 		#Test SCX_UnixProcessStatisticalInformation
 		process_perf_record = [{"ClassName"=>"SCX_UnixProcessStatisticalInformation","Caption"=>"Unix process information","Description"=>"A snapshot of a current process","Name"=>"omsagent","CSCreationClassName"=>"SCX_ComputerSystem","CSName"=>"kab-cen-oms1.scx.com","OSCreationClassName"=>"SCX_OperatingSystem","OSName"=>"Linux Distribution","Handle"=>"28402","ProcessCreationClassName"=>"SCX_UnixProcessStatisticalInformation","CPUTime"=>"0","VirtualText"=>"2666496","VirtualData"=>"953671680","VirtualSharedMemory"=>"5216","CpuTimeDeadChildren"=>"180","SystemTimeDeadChildren"=>"123","PercentUserTime"=>"0","PercentPrivilegedTime"=>"0","UsedMemory"=>"40208","PercentUsedMemory"=>"3","PagesReadPerSec"=>"0"}]
-		expected_process_record = [{"Host":"testhost", "ObjectName":"Process","InstanceName":"omsagent","Collections":[{"CounterName":"Pct User Time","Value":"0"},{"CounterName":"Pct Privileged Time","Value":"0"},{"CounterName":"Used Memory","Value":"40208"},{"CounterName":"Virtual Shared Memory","Value":"5216"}]}]
+		expected_process_record = [{"Host":"testhost", "ObjectName":"Process","InstanceName":"omsagent","Collections":[{"CounterName":"Pct User Time","Value":"0"},{"CounterName":"Pct Privileged Time","Value":"0"},{"CounterName":"Virtual Shared Memory","Value":"5216"}]}]
 		transform_validate_records_helper(expected_process_record, process_perf_record , all_performance_counters, "Process Input Class Failed!")
 
 		#Test Apache_HTTPDServerStatistics


### PR DESCRIPTION
Goal: add units label to "Used Memory" CounterName in Perf Process object
Implementation: Extended omi_mapping.json schema, added logic in oms_omi_lib.rb to support user configuration compatibility, updated unit tests