### PR TITLE
Updated omsagent installation guide for post install onboarding

### DIFF
--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -171,6 +171,7 @@ Run the omsadmin.sh command supplying the workspace id and key for your workspac
 ```
 cd /opt/microsoft/omsagent/bin
 sudo ./omsadmin.sh -w <WorkspaceID> -s <Shared Key>
+sudo ./service_control enable
 ```
 
 ## Onboarding using a file
@@ -181,8 +182,8 @@ sudo ./omsadmin.sh -w <WorkspaceID> -s <Shared Key>
 WORKSPACE_ID=<WorkspaceID>
 SHARED_KEY=<Shared Key>
 ```
-3.	Restart the omsagent:
-`sudo service omsagent restart`
+3.	Register the omsagent service and restart:
+`sudo ./service_control enable`
 4.	The file will be deleted on successful onboarding
 
 # Viewing Linux Data


### PR DESCRIPTION
Updated oms agent installation guide for post install onboarding to use service_control enable to register omsagent and restart the service altogether. Per current design, oms agent service restart no longer works since at the time it is called (right after onboarding using cmdline or a file) the agent is not registered as a service.
@Microsoft/omsagent-devs 