### PR TITLE
Fix building test ruby that fails due to ruby clean up leaving test ruby corrupted

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -193,7 +193,6 @@ $(RUBY_TESTING_DIR) :
 	# Warning: This step will clean out checked out files from both Ruby and fluentd directories
 	#
 	@$(ECHO) "========================= Performing Building Ruby for testing"
-	sudo $(RMDIR) /usr/local/ruby-2.2.0*
 	$(BASE_DIR)/build/buildRuby.sh test
 
 # Build the version of Ruby that we distribute

--- a/build/buildRuby.sh
+++ b/build/buildRuby.sh
@@ -235,8 +235,9 @@ if [ $RUNNING_FOR_TEST -eq 0 ]; then
 
     # Pacify Make (Make doesn't know that the generated Ruby directory can vary)
     mkdir -p ${BASE_DIR}/intermediate/${BUILD_CONFIGURATION}/ruby
-else 
-    echo "Installing MySQL gem into Test Ruby..." 
+else
+    mkdir -p ${RUBY_DESTDIR}
+    echo "Installing MySQL gem into Test Ruby path: ${RUBY_DESTDIR}..." 
     elevate ${RUBY_DESTDIR}/bin/gem install mysql2
 fi
 

--- a/build/configure
+++ b/build/configure
@@ -389,7 +389,7 @@ ruby_configure_quals=(
      )
 
 ruby_config_quals_sysins="--prefix=/opt/microsoft/omsagent/ruby"
-ruby_config_quals_testins="--prefix=/usr/local/ruby-2.2.0d"
+ruby_config_quals_testins="--prefix=${base_dir}/intermediate/${BUILD_CONFIGURATION}/local_ruby-2.2.0d"
 
 if [ "$ULINUX" = "1" ]; then
     ssl_098_dirpath=/usr/local_ssl_0.9.8


### PR DESCRIPTION
We have seen instances (in pBuild and dev environments) where make does not properly rebuild the local ruby if there was a previous build break or failure which causes subsequent make command or running make with unit tests fail. Not an issue in clean VM setup where the bundle was never built or was always built successfully. When it repros local ruby folder is left corrupted and the workaround is to manually delete it then rerun the make. 
Looking at the code it seems weird to see removing versions of local ruby being done from the local ruby folder while that folder itself is expected to be deleted.  This PR is about moving the localruby cleanup logic be performed in ruby cleanup stage(used in distclean) to be consistent with the code that prepares the system to install ruby as well as be consistent with the makefile. This should help to resolve the issue we are seeing with local ruby being corrupted and make not being able to properly rebuild it.
@Microsoft/omsagent-devs ;