### PR TITLE
Nit fix for sending timestamps only for valid dates

### DIFF
--- a/source/code/plugins/patch_management_lib.rb
+++ b/source/code/plugins/patch_management_lib.rb
@@ -152,13 +152,12 @@ class LinuxUpdates
         ret["PackageName"] = availableUpdatesHash["Name"]
         ret["Architecture"] = availableUpdatesHash.key?("Architecture") ? availableUpdatesHash["Architecture"] : nil
         ret["PackageVersion"] = availableUpdatesHash["Version"]
-        ret["Timestamp"] = (availableUpdatesHash["BuildDate"].nil? or 
-                            availableUpdatesHash["BuildDate"].strip == "" or
-                            availableUpdatesHash["BuildDate"].strip == "BuildDate") ? nil :
-                                OMS::Common.format_time(availableUpdatesHash["BuildDate"].to_i)
         ret["Repository"] = availableUpdatesHash.key?("Repository") ? availableUpdatesHash["Repository"] : nil
         ret["Installed"] = false
         ret["UpdateState"] = "Needed"
+        if (Integer(availableUpdatesHash["BuildDate"]) rescue false)
+            ret["Timestamp"] = OMS::Common.format_time(availableUpdatesHash["BuildDate"].to_i)
+        end
         ret
     end
 
@@ -171,14 +170,13 @@ class LinuxUpdates
         ret["PackageName"] = packageHash["Name"]
         ret["Architecture"] = packageHash.key?("Architecture") ? packageHash["Architecture"] : nil
         ret["PackageVersion"] = packageHash["Version"]  
-        ret["Timestamp"] = (packageHash["InstalledOn"].nil? or 
-                            packageHash["InstalledOn"].strip == "" or
-                            packageHash["InstalledOn"].strip == "Unknown") ? nil : 
-                                OMS::Common.format_time(packageHash["InstalledOn"].to_i)
         ret["Size"] = packageHash["Size"]
         ret["Repository"] = packageHash.key?("Repository") ? packageHash["Repository"] : nil
         ret["Installed"] = true
         ret["UpdateState"] = "NotNeeded"
+        if (Integer(packageHash["InstalledOn"]) rescue false)
+            ret["Timestamp"] = OMS::Common.format_time(packageHash["InstalledOn"].to_i)
+        end
         ret
     end
 

--- a/test/code/plugins/patch_management_lib_test.rb
+++ b/test/code/plugins/patch_management_lib_test.rb
@@ -78,7 +78,6 @@ class LinuxUpdatesTest < Test::Unit::TestCase
       "Architecture"=>"amd64",
       "PackageName"=>"dpkg",
       "PackageVersion"=>"1.18.4ubuntu1.1",
-      "Timestamp"=> nil,
       "Repository"=>"Ubuntu:16.04/xenial-updates",
       "Installed"=>false,
       "UpdateState"=>"Needed"
@@ -166,7 +165,6 @@ class LinuxUpdatesTest < Test::Unit::TestCase
       "Architecture"=>"all",
       "PackageName"=> "autotools-dev",
       "PackageVersion"=>"20150820.1",
-      "Timestamp"=> nil,
       "Repository"=> nil,
       "Size"=>"151",
       "Installed"=>true,
@@ -200,8 +198,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                     "PackageName" => "autotools-dev",
                     "PackageVersion" => "20150820.1",
                     "Repository" => nil,
-                    "Size" => "151",
-                    "Timestamp" => nil
+                    "Size" => "151"
                 }]
             }]
         }
@@ -264,8 +261,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                     "PackageName" => "autotools-dev",
                     "PackageVersion" => "20150820.1",
                     "Repository" => nil,
-                    "Size" => "151",
-                    "Timestamp" => nil
+                    "Size" => "151"
                 }]
             }]
         }
@@ -295,8 +291,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                     "Architecture"=>"amd64",
                     "PackageName" => "dpkg",
                     "PackageVersion" => "1.18.4ubuntu1.1",
-                    "Repository" => "Ubuntu:15.04/xenial-updates",
-                    "Timestamp" => nil
+                    "Repository" => "Ubuntu:15.04/xenial-updates"
                 }]
             }]
         }
@@ -357,8 +352,7 @@ class LinuxUpdatesTest < Test::Unit::TestCase
                     "Architecture"=>"amd64",
                     "PackageName" => "dpkg",
                     "PackageVersion" => "1.18.4ubuntu1.1",
-                    "Repository" => "Ubuntu:15.04/xenial-updates",
-                    "Timestamp" => nil
+                    "Repository" => "Ubuntu:15.04/xenial-updates"
                 }]
             }]
         }


### PR DESCRIPTION
Earlier, timestamp for each installed or available
update was being sent, which did not have clean
data and thus were misrepreseted in the reporting.

This fix makes this field optional and not send
if the underlying resource does not send correct
format or does not send at all.

Please review.

@Microsoft/omsagent-devs @stasku 