### PR TITLE
Enable generic operation events using filter_operations.rb

### DIFF
--- a/installer/conf/omsagent.d/monitor.conf
+++ b/installer/conf/omsagent.d/monitor.conf
@@ -1,6 +1,6 @@
 <source>
   type monitor_agent
-  tag oms.operation
+  tag oms.health
   emit_interval 5m
   emit_config true
 </source>
@@ -10,11 +10,11 @@
   interval 5m
 </source>
 
-<filter oms.operation.**>
+<filter oms.health.**>
   type filter_operation
 </filter>
 
-<match oms.operation.** oms.heartbeat.**>
+<match oms.health.** oms.heartbeat.**>
   type out_oms
   log_level info
   buffer_chunk_limit 1m

--- a/installer/conf/omsagent.d/operation.conf
+++ b/installer/conf/omsagent.d/operation.conf
@@ -1,0 +1,8 @@
+<source>
+  type dsc_monitor 
+  tag oms.operation.dsc
+</source>
+
+<filter oms.operation.**>
+  type filter_operation
+</filter>

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -32,9 +32,10 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/collectd.conf;           installer/conf/omsagent.d/collectd.conf;               644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/statsd.conf;             installer/conf/omsagent.d/statsd.conf;                 644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/auditlog.conf;           installer/conf/omsagent.d/auditlog.conf;               644; root; root
-/etc/opt/microsoft/omsagent/sysconf/omsagent.d/mysql_workload.conf;           installer/conf/omsagent.d/mysql_workload.conf;               644; root; root
+/etc/opt/microsoft/omsagent/sysconf/omsagent.d/mysql_workload.conf;     installer/conf/omsagent.d/mysql_workload.conf;         644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/mongo.conf;              installer/conf/omsagent.d/mongo.conf;                  644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/vmware_esxi.conf;        installer/conf/omsagent.d/vmware_esxi.conf;            644; root; root
+/etc/opt/microsoft/omsagent/sysconf/omsagent.d/operation.conf;          installer/conf/omsagent.d/operation.conf;              644; root; root
 
 /opt/microsoft/omsagent/LICENSE;                                        LICENSE;                                               444; root; root
 
@@ -88,6 +89,7 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/mysql_workload_lib.rb;                   source/code/plugins/mysql_workload_lib.rb;             744; root; root
 /opt/microsoft/omsagent/plugin/in_mysql_workload.rb;                    source/code/plugins/in_mysql_workload.rb;              744; root; root
 /opt/microsoft/omsagent/plugin/parser_vmware_logs.rb;                   source/code/plugins/parser_vmware_logs.rb;             744; root; root
+/opt/microsoft/omsagent/plugin/in_dsc_monitor.rb;                       source/code/plugins/in_dsc_monitor.rb;                 744; root; root
 
 %Links
 /opt/microsoft/omsagent/bin/omsagent; /opt/microsoft/omsagent/ruby/bin/fluentd; 755; root; root
@@ -149,6 +151,11 @@ mkdir -m 755 ${{CONF_DIR}}/omsagent.d 2> /dev/null || true
 # Copy monitor plugins conf file by default
 if [ ! -f ${{CONF_DIR}}/omsagent.d/monitor.conf ]; then
    cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/monitor.conf ${{CONF_DIR}}/omsagent.d/monitor.conf
+fi
+
+# Copy operation.conf file by default
+if [ ! -f ${{CONF_DIR}}/omsagent.d/operation.conf ]; then
+   cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/operation.conf ${{CONF_DIR}}/omsagent.d/operation.conf
 fi
 
 # Copy over omi_mapping.json

--- a/source/code/plugins/filter_operation.rb
+++ b/source/code/plugins/filter_operation.rb
@@ -12,7 +12,7 @@ module Fluent
     end
 			
     def filter(tag, time, record)
-      records = @operation_lib.filter_and_wrap(record, time)
+      records = @operation_lib.filter_and_wrap(tag, record, time)
       # only return non empty records
       if !records.empty?
         return records

--- a/source/code/plugins/in_dsc_monitor.rb
+++ b/source/code/plugins/in_dsc_monitor.rb
@@ -1,0 +1,104 @@
+require 'fluent/input'
+require 'fluent/config/error'
+require 'yaml/store'
+
+module Fluent
+  class DscMonitoringInput < Input
+    Fluent::Plugin.register_input('dsc_monitor', self)
+
+    config_param :tag, :string, :default=>nil
+    config_param :check_install_interval, :time, :default=>86400
+    config_param :check_status_interval, :time, :default=>1800
+    config_param :dsc_cache_file, :string, :default=>'/var/opt/microsoft/omsagent/state/dsc_cache.yml'
+   
+    def configure(conf)
+      super
+      if !@tag 
+        raise Fluent::ConfigError, "'tag' option is required on dsc_checks input"
+      end
+    end
+
+    def start
+      super
+      @finished_check_install = false
+      @finished_check_status = false
+      @thread_check_install = Thread.new(&method(:run_check_install))
+      @thread_check_status = Thread.new(&method(:run_check_status))
+      @dsc_cache = YAML::Store.new(dsc_cache_file) #Creates the file if it doesn't exist; otherwise, the existing file will be read.
+    end
+
+    def check_install
+      dpkg = (%x(which dpkg > /dev/null 2>&1; echo $?)).to_i
+      if dpkg == 0
+        %x(dpkg --list omsconfig > /dev/null 2>&1; echo $?).to_i
+      else
+        %x(rpm -qi omsconfig > /dev/null 2>&1; echo $?).to_i
+      end
+    end
+
+    def run_check_install
+      until @finished_check_install
+        @install_status = check_install
+
+        if @install_status == 1
+           router.emit(@tag, Time.now.to_f, {"message"=>"omconfig is not installed, OMS Portal \
+configuration will not be applied and solutions such as Change Tracking and Update Assessment will \
+not function properly. omsconfig can be installed by rerunning the omsagent installation"})
+        end
+        sleep @check_install_interval
+      end
+    end
+
+    def get_dsc_status
+      begin
+        dsc_status = %x(/opt/microsoft/omsconfig/Scripts/TestDscConfiguration.py)
+      rescue => error
+        OMS::Log.error_once("Unable to run TestDscConfiguration.py for dsc : #{error}")
+      end
+      if dsc_status.match("ReturnValue=0") and dsc_status.match("InDesiredState=true")
+        return 0
+      else
+        return 1
+      end
+    end
+
+    def run_check_status
+      begin
+      sleep @check_status_interval
+    
+      until @finished_check_status && @install_status == 0
+        dsc_status = get_dsc_status
+
+        # returns value of dsc configuration test from the cache
+        # if key does not exist, assigns the string as value
+        stored_dsc_status = @dsc_cache.transaction {
+          @dsc_cache.fetch(:status, "DSC configuration test status not stored yet")
+        }
+
+        if dsc_status == 1 and stored_dsc_status == 1
+          router.emit(@tag, Time.now.to_f, {"message"=>"Two successive configuration applications from \
+OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-DSC-for-Linux/issues"})
+        end
+
+        # store dsc configuration test status in the cache
+        @dsc_cache.transaction { 
+          @dsc_cache[:status] = dsc_status
+          @dsc_cache.commit
+        }
+        sleep @check_status_interval
+      end 
+      rescue => e
+        $log.error e
+      end
+    end       
+
+    def shutdown
+      super
+      @finished_check_install = true
+      @finished_check_status = true
+      @thread_check_install.join
+      @thread_check_status.join
+    end
+
+  end
+end

--- a/source/code/plugins/operation_lib.rb
+++ b/source/code/plugins/operation_lib.rb
@@ -39,9 +39,30 @@ module OperationModule
 
       return {}
     end
+
+    def filter_generic(record,time)
+      if record.is_a?(Hash) && !record.empty? && record.has_key?("message")
+        dataitem = {}
+        dataitem["Timestamp"] = OMS::Common.format_time(time)
+        dataitem["OperationStatus"] = "Warning"
+        dataitem["Computer"] = OMS::Common.get_hostname or "Unknown host"
+        dataitem["Detail"] = record["message"]
+        dataitem["Category"] = "OMS Agent for Linux issue"
+        dataitem["Solution"] = "Log Management"
+        return dataitem
+      end
+      return {}
+    end
  
-    def filter_and_wrap(record, time)
-      data_item = filter(record, time)
+    def filter_and_wrap(tag, record, time)
+      tag_type = tag.match(/[^\.]*$/) 
+      case tag_type[0]
+      when "buffer"
+        data_item = filter(record, time)
+      when "dsc" 
+        data_item = filter_generic(record, time)
+      end
+
       if (data_item != nil and data_item.size > 0)
         wrapper = {
          "DataType"=>"OPERATION_BLOB",

--- a/test/code/plugins/in_dsc_monitor_plugintest.rb
+++ b/test/code/plugins/in_dsc_monitor_plugintest.rb
@@ -1,0 +1,100 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/in_dsc_monitor'
+require 'flexmock/test_unit'
+
+class DscMonitorTest < Test::Unit::TestCase
+  include FlexMock::TestCase
+
+  TMP_DIR = File.dirname(__FILE__) + "/../tmp/test_dscmonitor"
+  CHECK_IF_DPKG = "which dpkg > /dev/null 2>&1; echo $?" 
+  CHECK_DSC_INSTALL = "dpkg --list omsconfig > /dev/null 2>&1; echo $?"
+  CHECK_DSC_STATUS = "/opt/microsoft/omsconfig/Scripts/TestDscConfiguration.py"
+
+  def setup
+    Fluent::Test.setup
+    FileUtils.mkdir_p(TMP_DIR)
+  end
+
+  def teardown
+    super
+    if TMP_DIR
+      FileUtils.rm_rf(TMP_DIR)
+    end
+    Fluent::Engine.stop
+  end
+
+  CONFIG = %[
+    tag oms.mock.dsc 
+    check_install_interval 2 
+    check_status_interval 2
+    dsc_cache_file #{TMP_DIR}/cache.yml
+  ]
+
+  def create_driver(conf=CONFIG)
+    Fluent::Test::InputTestDriver.new(Fluent::DscMonitoringInput).configure(conf)
+  end
+
+  def test_dsc_install_failure_message
+    dsc_install_fail_message = "omconfig is not installed, OMS Portal \
+configuration will not be applied and solutions such as Change Tracking and Update Assessment will \
+not function properly. omsconfig can be installed by rerunning the omsagent installation" 
+
+    flexmock(Fluent::DscMonitoringInput).new_instances do |instance|
+      instance.should_receive(:`).with(CHECK_IF_DPKG).and_return(0)
+      instance.should_receive(:`).with(CHECK_DSC_INSTALL).and_return(1)
+    end
+
+    d = create_driver
+    d.run
+    emits = d.emits
+
+    assert_equal(true, emits.length > 0)
+    assert_equal("oms.mock.dsc", emits[0][0])
+    assert_instance_of(Float, emits[0][1])
+    assert_equal(dsc_install_fail_message, emits[0][2]["message"])
+  end
+
+  def test_dsc_check_failure_message
+    dsc_statuscheck_fail_message = "Two successive configuration applications from \
+OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-DSC-for-Linux/issues"
+
+    flexmock(Fluent::DscMonitoringInput).new_instances do |instance|
+      instance.should_receive(:`).with(CHECK_IF_DPKG).and_return(0)
+      instance.should_receive(:`).with(CHECK_DSC_INSTALL).and_return(0)
+      instance.should_receive(:`).with(CHECK_DSC_STATUS).and_return("Mock DSC config check")
+    end
+
+    d = create_driver
+    d.run(num_waits = 90)
+    emits = d.emits
+
+    assert_equal(true, emits.length > 0)
+    assert_equal("oms.mock.dsc", emits[0][0])
+    assert_instance_of(Float, emits[0][1])
+    assert_equal(dsc_statuscheck_fail_message, emits[0][2]["message"])
+  end
+
+
+  def test_dsc_check_success_emits_no_messages
+    result =
+	"instance of TestConfiguration
+	{
+	ReturnValue=0
+	InDesiredState=true
+	ResourceId={}
+	}"
+ 
+    flexmock(Fluent::DscMonitoringInput).new_instances do |instance|
+      instance.should_receive(:`).with(CHECK_IF_DPKG).and_return(0)
+      instance.should_receive(:`).with(CHECK_DSC_INSTALL).and_return(0)
+      instance.should_receive(:`).with(CHECK_DSC_STATUS).and_return(result)
+    end
+
+    d = create_driver
+    d.run(num_waits = 90)
+    emits = d.emits
+
+    assert_equal(0, emits.length)
+  end
+
+end

--- a/test/code/plugins/operation_lib_test.rb
+++ b/test/code/plugins/operation_lib_test.rb
@@ -44,9 +44,25 @@ class OperationLib_Test < Test::Unit::TestCase
     assert(data_item.has_key?("Timestamp") && data_item.has_key?("OperationStatus") && data_item.has_key?("Computer") && data_item.has_key?("Detail") && data_item.has_key?("Category") && data_item.has_key?("Solution") && data_item.has_key?("HelpLink"))
   end
 
+  def test_generic_filter
+    assert_equal({}, call_generic_filter(nil), "null record fails")
+    assert_equal({}, call_generic_filter(""), "empty string record fails")
+    assert_equal({}, call_generic_filter(10), "int record fails")
+    assert_equal({}, call_generic_filter({}), "empty hash record fails")
+
+    data_item = call_generic_filter({"message"=>"This is a test message"})
+    assert(data_item.has_key?("Computer") && data_item.has_key?("Timestamp") && data_item.has_key?("Detail") && data_item.has_key?("OperationStatus") && data_item.has_key?("Category") && data_item.has_key?("Solution"))
+    assert_equal("This is a test message", data_item["Detail"])
+  end
   # wrapper to call filter
   def call_filter(record)
     @@operation_lib.filter(record, Time.now)
   end
+
+  # wrapper to call generic filter
+  def call_generic_filter(record)
+    @@operation_lib.filter_generic(record, Time.now)
+  end
+
 end
 


### PR DESCRIPTION
New input plugin for checking dsc install and configuration
DSC installation is checked once a day.
DSC PerformRequiredConfigurationChecks.py is run every 30 mins, two successive failures sends an operation event.
@Microsoft/omsagent-devs 