### PR TITLE
Fixed the split issue when OSShortName is not present. Tested

### DIFF
--- a/source/code/plugins/patch_management_lib.rb
+++ b/source/code/plugins/patch_management_lib.rb
@@ -59,8 +59,13 @@ class LinuxUpdates
         hostOSDetailsMap = getHostOSDetails()
 
         # match string of the form (1 or more non . chars)- followed by a . - (1 or more non . chars) - followed by anything
-        osName = (os_short_name == nil) ? hostOSDetailsMap["OSShortName"].split("_")[0] : os_short_name.split("_")[0]
-        if (os_version == nil)
+        if hostOSDetailsMap.key?("OSShortName")
+            osName = (os_short_name.nil?) ? hostOSDetailsMap["OSShortName"].split("_")[0] : os_short_name.split("_")[0]
+        else
+            osName =  (os_short_name.nil?) ? hostOSDetailsMap["OSFullName"] : os_short_name.split("_")[0]
+        end
+
+        if (os_version.nil?)
             @os_major_version = hostOSDetailsMap["OSVersion"][MAJOR_MINOR_VERSION_REGEX, 1] unless hostOSDetailsMap["OSVersion"].nil?
             @os_minor_version = hostOSDetailsMap["OSVersion"][MAJOR_MINOR_VERSION_REGEX, 2] unless hostOSDetailsMap["OSVersion"].nil?
             @default_version = hostOSDetailsMap["OSVersion"]

--- a/test/code/plugins/patch_management_lib_test.rb
+++ b/test/code/plugins/patch_management_lib_test.rb
@@ -31,6 +31,38 @@ class LinuxUpdatesTest < Test::Unit::TestCase
 
   end
 
+  def test_os_short_name()
+    # Ubuntu
+    assert_equal(LinuxUpdates.getOSShortName("Ubuntu_12.04", "12.04"), "Ubuntu_12.04")
+    assert_equal(LinuxUpdates.getOSShortName("Ubuntu_12.10", "12.10"), "Ubuntu_12.04")
+    assert_equal(LinuxUpdates.getOSShortName("Ubuntu_14.04", "14.04"), "Ubuntu_14.04")
+    assert_equal(LinuxUpdates.getOSShortName("Ubuntu_15.10", "15.10"), "Ubuntu_14.04")
+    assert_equal(LinuxUpdates.getOSShortName("Ubuntu_16.04", "16.04"), "Ubuntu_16.04")
+    assert_equal(LinuxUpdates.getOSShortName("Ubuntu_16.10", "16.10"), "Ubuntu_16.04")
+    
+    # CentOS 
+    assert_equal(LinuxUpdates.getOSShortName("CentOS_5.0", "5.0"), "CentOS_5.0") 
+    assert_equal(LinuxUpdates.getOSShortName("CentOS_5.7", "5.7"), "CentOS_5.0") 
+    assert_equal(LinuxUpdates.getOSShortName("CentOS_6.0", "6.0"), "CentOS_6.0") 
+    assert_equal(LinuxUpdates.getOSShortName("CentOS_6.7", "6.7"), "CentOS_6.0")
+    assert_equal(LinuxUpdates.getOSShortName("CentOS_7.0", "7.0"), "CentOS_7.0") 
+    assert_equal(LinuxUpdates.getOSShortName("CentOS_7.1", "7.1"), "CentOS_7.0")
+
+    # RHEL
+    assert_equal(LinuxUpdates.getOSShortName("RHEL_5.0", "5.0"), "RHEL_5.0")
+    assert_equal(LinuxUpdates.getOSShortName("RHEL_5.5", "5.5"), "RHEL_5.0")
+    assert_equal(LinuxUpdates.getOSShortName("RHEL_6.0", "6.0"), "RHEL_6.0")
+    assert_equal(LinuxUpdates.getOSShortName("RHEL_6.6", "6.6"), "RHEL_6.0")
+    assert_equal(LinuxUpdates.getOSShortName("RHEL_7.0", "7.0"), "RHEL_7.0")
+    assert_equal(LinuxUpdates.getOSShortName("RHEL_7.7", "7.7"), "RHEL_7.0")
+    
+    # SLES
+    assert_equal(LinuxUpdates.getOSShortName("SUSE_11.0", "11.0"), "SUSE_11.0")
+    assert_equal(LinuxUpdates.getOSShortName("SUSE_11.10", "11.10"), "SUSE_11.0")
+    assert_equal(LinuxUpdates.getOSShortName("SUSE_12.6", "12.6"), "SUSE_12.0")
+    assert_equal(LinuxUpdates.getOSShortName("SUSE_12.0", "12.0"), "SUSE_12.0")
+  end
+
   def test_strToXML
     xml = LinuxUpdates.strToXML(@installed_packages_xml_str)
     assert(xml.is_a?(REXML::Document), "Expected return type is REXML::Document")


### PR DESCRIPTION
This nit fix is for cases when Agent is old and does not have
OSShortName in the scx-release file.

@Microsoft/omsagent-devs Could you please review it.

Thanks.