### PR TITLE
Update security events input parsing for additional Cisco ASA formats

### DIFF
--- a/installer/conf/omsagent.d/security_events.conf
+++ b/installer/conf/omsagent.d/security_events.conf
@@ -4,7 +4,7 @@
   bind 127.0.0.1
   protocol_type udp
   tag oms.security
-  format /^(?<time>[^ ]*\s*[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_%\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+  format /^(?<time>(?:\w+ ){2,3}(?:\d+:){2}\d+):? ?(?:(?<host>[^: ]+) ?:?)? (?<ident>[a-zA-Z0-9_%\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?: *(?<message>.*)$/
 </source>
 
 <filter oms.security.**>


### PR DESCRIPTION
Fix for #201 
Update the regex format of the syslog source to support non standard
formats of Cisco ASA logs:
- Year field in the timestamp
- Empty hostname field
- ':' char following the hostname

Examples of supported log formats:
- Sep 14 2016 09:33:47 Host1 : [tag]: [message]
- Sep 14 2016 10:07:20: [tag]: [message]
- Sep 26 09:50:20 Host1 [tag]: [message]