### PR TITLE
Update doc to reflect kBytes CounterName change

### DIFF
--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -740,7 +740,7 @@ Physical Disk | Avg. Disk sec/Write
 Physical Disk | Physical Disk Bytes/sec
 Process | Pct Privileged Time
 Process | Pct User Time
-Process | Used Memory
+Process | Used Memory kBytes
 Process | Virtual Shared Memory
 Processor | % DPC Time
 Processor | % Idle Time


### PR DESCRIPTION
The list of available metrics now shows the new change "Process/Used Memory kBytes" instead of the old CounterName "Process/Used Memory"