### PR TITLE
Revert "Fix test ruby cleanup to make it reliable"

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -193,6 +193,7 @@ $(RUBY_TESTING_DIR) :
 	# Warning: This step will clean out checked out files from both Ruby and fluentd directories
 	#
 	@$(ECHO) "========================= Performing Building Ruby for testing"
+	sudo $(RMDIR) /usr/local/ruby-2.2.0*
 	$(BASE_DIR)/build/buildRuby.sh test
 
 # Build the version of Ruby that we distribute

--- a/build/buildRuby.sh
+++ b/build/buildRuby.sh
@@ -235,9 +235,8 @@ if [ $RUNNING_FOR_TEST -eq 0 ]; then
 
     # Pacify Make (Make doesn't know that the generated Ruby directory can vary)
     mkdir -p ${BASE_DIR}/intermediate/${BUILD_CONFIGURATION}/ruby
-else
-    mkdir -p ${RUBY_DESTDIR}
-    echo "Installing MySQL gem into Test Ruby path: ${RUBY_DESTDIR}..." 
+else 
+    echo "Installing MySQL gem into Test Ruby..." 
     elevate ${RUBY_DESTDIR}/bin/gem install mysql2
 fi
 

--- a/build/configure
+++ b/build/configure
@@ -389,7 +389,7 @@ ruby_configure_quals=(
      )
 
 ruby_config_quals_sysins="--prefix=/opt/microsoft/omsagent/ruby"
-ruby_config_quals_testins="--prefix=${base_dir}/intermediate/${BUILD_CONFIGURATION}/local_ruby-2.2.0d"
+ruby_config_quals_testins="--prefix=/usr/local/ruby-2.2.0d"
 
 if [ "$ULINUX" = "1" ]; then
     ssl_098_dirpath=/usr/local_ssl_0.9.8


### PR DESCRIPTION
This reverts commit 84ea4c0fb6178dcc731962f531fd9001f3048eef till all combinations (ruby and its cleanup being built from root or non root users, or both) are tested. 