### PR TITLE
local ruby cleanup fix

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -193,7 +193,7 @@ $(RUBY_TESTING_DIR) :
 	# Warning: This step will clean out checked out files from both Ruby and fluentd directories
 	#
 	@$(ECHO) "========================= Performing Building Ruby for testing"
-	sudo $(RMDIR) /usr/local/ruby-2.2.0*
+	$(MKPATH) $(INTERMEDIATE_DIR)
 	$(BASE_DIR)/build/buildRuby.sh test
 
 # Build the version of Ruby that we distribute

--- a/build/configure
+++ b/build/configure
@@ -389,7 +389,7 @@ ruby_configure_quals=(
      )
 
 ruby_config_quals_sysins="--prefix=/opt/microsoft/omsagent/ruby"
-ruby_config_quals_testins="--prefix=/usr/local/ruby-2.2.0e"
+ruby_config_quals_testins="--prefix=${base_dir}/intermediate/${BUILD_CONFIGURATION}/local_ruby-2.2.0e"
 
 if [ "$ULINUX" = "1" ]; then
     ssl_098_dirpath=/usr/local_ssl_0.9.8


### PR DESCRIPTION
This change is for making local ruby installation reliable. Before the change the local ruby was being built under system local path which caused unexpected results when 2 different people run buddy build on pBuild systems, or sometimes 'make distclean' would not be able to delete the path in clean up phase leaving the ruby corrupted even on local dev boxes.

@Microsoft/omsagent-devs 