### PR TITLE
vmware: fixed regex, skipping logs from blacklisted processes.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -193,7 +193,7 @@ $(RUBY_TESTING_DIR) :
 	# Warning: This step will clean out checked out files from both Ruby and fluentd directories
 	#
 	@$(ECHO) "========================= Performing Building Ruby for testing"
-	sudo $(RMDIR) /usr/local/ruby-2.2.0*
+	$(MKPATH) $(INTERMEDIATE_DIR)
 	$(BASE_DIR)/build/buildRuby.sh test
 
 # Build the version of Ruby that we distribute

--- a/build/configure
+++ b/build/configure
@@ -389,7 +389,7 @@ ruby_configure_quals=(
      )
 
 ruby_config_quals_sysins="--prefix=/opt/microsoft/omsagent/ruby"
-ruby_config_quals_testins="--prefix=/usr/local/ruby-2.2.0e"
+ruby_config_quals_testins="--prefix=${base_dir}/intermediate/${BUILD_CONFIGURATION}/local_ruby-2.2.0e"
 
 if [ "$ULINUX" = "1" ]; then
     ssl_098_dirpath=/usr/local_ssl_0.9.8

--- a/source/code/plugins/parser_vmware_logs.rb
+++ b/source/code/plugins/parser_vmware_logs.rb
@@ -25,13 +25,22 @@ module Fluent
 
           if record['SyslogMessage']
             begin
+              # Default Values
+              record['ESXIFailure'] = ''
+              record['Operation'] = ''
+
+              # Remove '[1234]' from process name
+              record['ProcessName'].gsub!(/\[.*\]/, "")
+
               # Regex for Device. Example string: naa.60a9800041764b6c463f43786855a3t2
               record['Device'] = record['SyslogMessage'].to_s.match(/naa\.[a-z0-9]{32}/).to_s
+
               # Regex for SCSI Status. Example string: H:0x8 D:0x0 P:0x0
               record['SCSIStatus'] = record['SyslogMessage'].to_s.match(/\sH\:[a-z0-9]{1,2}x[a-z0-9]{1,2}\sD\:[a-z0-9]{1,2}x[a-z0-9]{1,2}\sP\:[a-z0-9]{1,2}x[a-z0-9]{1,2}\s/).to_s.strip
+
               if record['ProcessName'] == 'vobd'
                 # Regex for ESXI Failure. Example string: [esx.problem.scsi.device.io.latency.high]
-                esxifailure = record['SyslogMessage'].to_s.match /\[esx\.problem\.(?<Failure>.*)\]/
+                esxifailure = record['SyslogMessage'].to_s.match /\[esx\.problem\.(?<Failure>[a-zA-z0-9\.]*)\]/
                 if esxifailure
                   record['ESXIFailure'] = esxifailure['Failure']
                 end
@@ -62,7 +71,11 @@ module Fluent
             end
           end
 
-          yield time, record
+          # Do not yeild record if it is from 'crond','syslog','root','slpd','omsagent' or 'systemd' process
+          process_blacklist = ['crond', 'syslog', 'root', 'slpd', 'omsagent', 'systemd' ]
+          unless process_blacklist.include? record['ProcessName']
+              yield time, record
+          end
         end
       end
     end


### PR DESCRIPTION
@Microsoft/omi-devs 
@keikhara 

Fixes:
1. Removed '[12345]' from the process name.
2. Fixed the ESXIFailure regex to match exact data.
3. Skipping the logs generated from 'crond', 'syslog', 'root', 'slpd', 'omsagent' and 'systemd' processes.