### PR TITLE
Bug Fix: Omsagent changes to Split Json for different change tracking…

### DIFF
--- a/installer/conf/omsagent.d/change_tracking.conf
+++ b/installer/conf/omsagent.d/change_tracking.conf
@@ -1,13 +1,13 @@
 <source>
   type exec
-  tag oms.changetracking
+  tag oms.changetracking.package
   command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/change_tracking_inventory.mof --OutXML /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/ChangeTrackingInventory.xml
   format tsv
   keys xml
   run_interval 300s
 </source>
 
-<filter oms.changetracking>
+<filter oms.changetracking.package>
   type filter_changetracking
   # Force upload even if the data has not changed
   force_send_run_interval 24h

--- a/installer/conf/omsagent.d/service_change_tracking.conf
+++ b/installer/conf/omsagent.d/service_change_tracking.conf
@@ -1,0 +1,15 @@
+<source>
+  type exec
+  tag oms.changetracking.service
+  command /opt/microsoft/omsconfig/Scripts/PerformInventory.py --InMOF /etc/opt/microsoft/omsagent/conf/omsagent.d/service_change_tracking_inventory.mof --OutXML /etc/opt/omi/conf/omsconfig/configuration/ServiceChangeTrackingInventory.xml > /dev/null && cat /etc/opt/omi/conf/omsconfig/configuration/ServiceChangeTrackingInventory.xml
+  format tsv
+  keys xml
+  run_interval 300s
+</source>
+
+<filter oms.changetracking.service>
+  type filter_changetracking
+  # Force upload even if the data has not changed
+  force_send_run_interval 24h
+  log_level warn
+</filter>

--- a/installer/conf/omsagent.d/service_change_tracking_inventory.mof
+++ b/installer/conf/omsagent.d/service_change_tracking_inventory.mof
@@ -2,15 +2,17 @@
 @TargetNode='Localhost'
 */
 
-instance of MSFT_nxPackageResource
+instance of MSFT_nxServiceResource
 {
                 Name = "*";
-                ResourceId = "[MSFT_nxPackageResource]Inventory";
+                Controller = "*";
+                ResourceId = "[MSFT_nxServiceResource]Inventory";
                 ModuleName = "PSDesiredStateConfiguration";
                 ModuleVersion = "1.0";
 
 
 };
+
 
 instance of OMI_ConfigurationDocument
 {

--- a/source/code/plugins/filter_changetracking.rb
+++ b/source/code/plugins/filter_changetracking.rb
@@ -35,7 +35,7 @@ module Fluent
     def filter(tag, time, record)
       xml_string = record['xml']
       @log.debug "ChangeTracking : Filtering xml size=#{xml_string.size}"
-      return ChangeTracking.transform_and_wrap(xml_string, @hostname, time, @force_send_run_interval)
+      return ChangeTracking.transform_and_wrap(xml_string, @hostname, time, tag, @force_send_run_interval)
     end # filter
 
   end # class


### PR DESCRIPTION
Omsagent changes and tests for corresponding changes in powershell DSC
to split json for change tracking. 

Bug fix for change tracking.
After inventory mof for file change tracking was introduced, the json produced
by filter_changetracking either contains service and package changes together or only
file changes. This confuses the back end into thinking that there are changes
across all types. The fix is to split the json for each change type

@robbiezhang @vrdmr 
@Microsoft/omsagent-devs 