### PR TITLE
Add single script to download install and onboard the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Welcome to the OMS Agent for Linux! The OMS Agent for Linux enables rich and rea
 ## Quick Install guide
 Run the following commands to download the omsagent, validate the checksum, and install+onboard the agent. *Commands are for 64-bit*. The Workspace ID and Primary Key can be found inside the OMS Portal under Settings in the **connected sources** tab.
 ```
-$> wget https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_Ignite2016_v1.2.0-75/omsagent-1.2.0-75.universal.x64.sh
-$> sha256sum ./omsagent-1.2.0-75.universal.x64.sh
-$> sudo sh ./omsagent-1.2.0-75.universal.x64.sh --upgrade -w <YOUR OMS WORKSPACE ID> -s <YOUR OMS WORKSPACE PRIMARY KEY>
+$> wget https://raw.githubusercontent.com/Microsoft/OMS-Agent-for-Linux/master/installer/scripts/onboard_agent.sh && sh onboard_agent.sh -w <YOUR OMS WORKSPACE ID> -s <YOUR OMS WORKSPACE PRIMARY KEY>
 ```
 ## Azure Install guide
 If you are an Azure customer, we have an Azure VM Extension that allows you to onboard with a couple of clicks.

--- a/installer/scripts/onboard_agent.sh
+++ b/installer/scripts/onboard_agent.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+#
+# Easy download/install/onboard script for the OMSAgent for Linux
+#
+
+
+# Values to be updated upon each new release
+GITHUB_RELEASE="https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent-201610-v1.2.0-148/"
+BUNDLE_X64="omsagent-1.2.0-148.universal.x64.sh"
+BUNDLE_X86="omsagent-1.2.0-148.universal.x86.sh"
+
+usage()
+{
+    echo "usage: $1 [OPTIONS]"
+    echo "Options:"
+    echo "  -w id, --id id             Use workspace ID <id> for automatic onboarding."
+    echo "  -s key, --shared key       Use <key> as the shared key for automatic onboarding."
+    echo "  -d dmn, --domain dmn       Use <dmn> as the OMS domain for onboarding. Optional."
+    echo "                             default: opinsights.azure.com"
+    echo "                             ex: opinsights.azure.us (for FairFax)"
+    echo "  -? | -h | --help           shows this usage text."
+}
+
+
+# Extract parameters
+while [ $# -ne 0 ]
+do
+    case "$1" in
+        -d|--domain)
+            topLevelDomain=$2
+            shift 2
+            ;;
+
+        -s|--shared)
+            onboardKey=$2
+            shift 2
+            ;;
+
+        -w|--id)
+            onboardID=$2
+            shift 2
+            ;;
+
+        -\? | -h | --help)
+            usage `basename $0` >&2
+            exit 0
+            ;;
+
+         *)
+            echo "Unknown argument: '$1'" >&2
+            echo "Use -h or --help for usage" >&2
+            exit 1
+            ;;
+    esac
+done
+
+
+# Assemble parameters
+bundleParameters="--upgrade"
+if [ -n "$onboardID" ]; then
+    bundleParameters="${bundleParameters} -w $onboardID"
+fi
+if [ -n "$onboardKey" ]; then
+    bundleParameters="${bundleParameters} -s $onboardKey"
+fi
+if [ -n "$topLevelDomain" ]; then
+    bundleParameters="${bundleParameters} -d $topLevelDomain"
+fi
+
+
+# Download, install, and onboard OMSAgent for Linux, depending on architecture of machine
+if [ $(uname -m) = 'x86_64' ]; then
+    # x64 architecture
+    wget ${GITHUB_RELEASE}${BUNDLE_X64} && sudo sh ./${BUNDLE_X64} ${bundleParameters}
+else
+    # x86 architecture
+    wget ${GITHUB_RELEASE}${BUNDLE_X86} && sudo sh ./${BUNDLE_X86} ${bundleParameters}
+fi
+


### PR DESCRIPTION
This script will execute both commands necessary to get the OMSAgent for Linux:
wget ....
sudo sh omsagent-*....
The main page README has been updated to reference this quicker method