### PR TITLE
Add hdinsight filter plugin

### DIFF
--- a/installer/conf/sudoers
+++ b/installer/conf/sudoers
@@ -23,4 +23,7 @@ omsagent ALL=(ALL) NOPASSWD: /usr/bin/docker inspect *
 
 #run tailfilereader.rb
 omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/bin/tailfilereader.rb *
+
+#run hdinsightmanifestreader.rb
+omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsoft/omsagent/bin/hdinsightmanifestreader.rb
 # End sudo configuration for omsagent

--- a/installer/scripts/hdinsightmanifestreader.rb
+++ b/installer/scripts/hdinsightmanifestreader.rb
@@ -1,0 +1,2 @@
+result=`sudo python -c "from hdinsight_common.AmbariHelper import AmbariHelper; print AmbariHelper().get_cluster_manifest().deployment.cluster_name"`
+puts result

--- a/source/code/plugins/filter_hdinsight.rb
+++ b/source/code/plugins/filter_hdinsight.rb
@@ -1,0 +1,44 @@
+module Fluent
+  require_relative 'omslog'
+  require_relative 'oms_common'
+  require 'json'
+  require 'open3'
+
+
+  class HdinsightFilter < Filter
+    Fluent::Plugin.register_filter('filter_hdinsight', self)
+
+    BASE_DIR = File.dirname(File.expand_path('..', __FILE__))
+    RUBY_DIR = BASE_DIR + '/ruby/bin/ruby '
+    SCRIPT = BASE_DIR + '/bin/hdinsightmanifestreader.rb '
+	
+	attr_accessor :command
+
+    def configure(conf)
+      super
+      @hostname = OMS::Common.get_hostname or "Unknown host"
+      @command = "sudo " << RUBY_DIR << SCRIPT
+      @clustername = ""
+    end
+
+    def start
+      super
+      Open3.popen3(@command) {|stdin, stdout, stderr, wait_thr|
+          pid = wait_thr.pid
+          stdin.close
+          @clustername = stdout.read
+          wait_thr.value
+      }	  
+    end
+
+    def shutdown
+      super
+    end
+
+    def filter(tag, time, record)
+      record["ClusterName"] = @clustername
+      record["HostName"] = @hostname
+      record
+    end
+  end
+end

--- a/test/code/plugins/hdinsightfilter_plugintest.rb
+++ b/test/code/plugins/hdinsightfilter_plugintest.rb
@@ -1,0 +1,29 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/filter_hdinsight'
+
+class HdinsightFilterTest < Test::Unit::TestCase
+
+  def setup
+    Fluent::Test.setup
+  end
+
+  def teardown
+    super
+    Fluent::Engine.stop
+  end
+
+  CONFIG = %[]
+
+  def create_driver(conf=CONFIG)
+    Fluent::Test::FilterTestDriver.new(Fluent::HdinsightFilter).configure(conf)
+  end
+
+  def test_filter
+    d = create_driver
+    d.instance.command = "echo 'fake_cluster_name'"
+    d.run
+    record = Hash.new
+    emit = d.instance.filter("", "", record)
+    assert_equal("fake_cluster_name\n", emit["ClusterName"])
+  end
+end


### PR DESCRIPTION
This is the filter plugin for HDInsight clusters. When the filter is
used, it will add cluster information as part of json output.