### PR TITLE
Fix hostname for containerized omsagent

### DIFF
--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -41,6 +41,14 @@ module OMS
         def tzLocalTimePath=(localtimepath)
           @@tzLocalTimePath = localtimepath
         end
+
+        def Hostname=(hostname)
+          @@Hostname = hostname
+        end
+
+        def HostnameFilePath=(hostname_file_path)
+          @@HostnameFilePath = hostname_file_path
+        end
       end
     end
 
@@ -177,6 +185,30 @@ module OMS
       # Sanity check
       assert_not_equal(nil, hostname, "Could not get the hostname")
       assert(hostname.size > 0, "Hostname returned is empty")
+    end
+
+    def test_get_hostname_in_containerzed_agent
+      $log = MockLog.new
+      file_hostname = '/tmp/containerhostname'
+      test_hostname = 'test_hostname'
+      Common.Hostname = nil
+      Common.HostnameFilePath = file_hostname
+
+      # create container hostname file 
+      # get_hostname should read hostname from this file when exist
+      out_file = File.new(file_hostname, "w+")
+      out_file.puts(test_hostname)
+      out_file.close
+      hostname = Common.get_hostname
+      assert_equal(test_hostname, hostname, 'get_hostname should read from /tmp/containerhostname file')
+
+      # Remove container host name file
+      # get_hostname should get hostname from Socket.gethostname when this file when doesn't exist
+      Common.Hostname = nil
+      File.delete(file_hostname)
+      hostname = Common.get_hostname
+      test_hostname = Socket.gethostname.split(".")[0]
+      assert_equal(test_hostname, hostname, 'get_hostname should read from Socket.gethostname')
     end
 
     def test_get_fqdn


### PR DESCRIPTION
@robbiezhang @keikhara @Microsoft/omsagent-devs 

Issue:
  When omsagent runs inside a container, gethostname returns the hostname of the container (random name)
  not the actual machine hostname.
  One way to solve this problem is to set the container hostname same as machine name, but this is not
  possible when host-machine is a private VM inside a cluster.
Solution:
  Share/mount ‘/etc/hostname’ as '/var/opt/microsoft/omsagent/state/containerhostname'file with container and
  omsagent will read hostname from shared file.