### PR TITLE
Register service per workspace

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -60,7 +60,7 @@ BODY_RENEW_CERT=$TMP_DIR/body_renew_cert.xml
 RESP_RENEW_CERT=$TMP_DIR/resp_renew_cert.xml
 
 AGENT_USER=omsagent
-AGENT_GROUP=omsagent
+AGENT_GROUP=omiusers
 
 # Default settings
 URL_TLD=opinsights.azure.com
@@ -442,7 +442,7 @@ onboard()
 
     # If a test is not in progress then register omsagent as a service and start the agent 
     if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then
-        /opt/microsoft/omsagent/bin/service_control start 
+        /opt/microsoft/omsagent/bin/service_control start $WORKSPACE_ID 
     fi
 
     if [ -e $METACONFIG_PY ]; then

--- a/installer/scripts/omsagent.systemd
+++ b/installer/scripts/omsagent.systemd
@@ -7,12 +7,13 @@ Wants=omid.service
 Type=simple
 User=omsagent
 Group=omiusers
-PIDFile=/var/opt/microsoft/omsagent/run/omsagent.pid
+PIDFile=%RUN_DIR_WS%/omsagent.pid
 ExecStart=/opt/microsoft/omsagent/bin/omsagent \
-  -d /var/opt/microsoft/omsagent/run/omsagent.pid \
-  -o /var/opt/microsoft/omsagent/log/omsagent.log \
+  -d %RUN_DIR_WS%/omsagent.pid \
+  -o %LOG_DIR_WS%/omsagent.log \
+  -c %CONF_DIR_WS%/omsagent.conf \
   --no-supervisor
-ExecStop=/bin/rm -f /var/opt/microsoft/omsagent/run/omsagent.pid
+ExecStop=/bin/rm -f %RUN_DIR_WS%/omsagent.pid
 KillMode=process
 KillSignal=SIGKILL
 TimeoutStartSec=10

--- a/installer/scripts/omsagent.ulinux
+++ b/installer/scripts/omsagent.ulinux
@@ -16,10 +16,11 @@
 # Description:       Operations Management Suite (omsagent) Server
 ### END INIT INFO
 
+WORKSPACE_ID=""
 OMS_HOME=/opt/microsoft/omsagent
-OMS_NAME="Operations Management Suite agent"
+OMS_NAME="Operations Management Suite agent ($WORKSPACE_ID)"
 
-OMS_BIN=$OMS_HOME/bin/omsagent
+OMS_BIN=$OMS_HOME/bin/omsagent-$WORKSPACE_ID
 test -x $OMS_BIN || { echo "$OMS_BIN not installed";
     if [ "$1" = "stop" ]; then exit 0;
     else exit 5; fi; }
@@ -53,13 +54,13 @@ USER_REQ=""
 case "$1" in
      start)
         AGENT_RUNNING=is_omsagent_running
-        START_QUALS="-d $PIDFILE --no-supervisor -o $LOGFILE"
+        START_QUALS="-d $PIDFILE --no-supervisor -o $LOGFILE -c $CONFFILE"
 
         case $INIT_STYLE in
             D)
                 log_begin_msg "Starting $OMS_NAME: "
                 [ "`id -u`" -eq 0 ] && USER_REQ="--chuid omsagent"
-                $AGENT_RUNNING && /sbin/start-stop-daemon --start $USER_REQ --quiet --pidfile $PIDFILE --name "omsagent" --startas $OMS_BIN -- $START_QUALS
+                $AGENT_RUNNING && /sbin/start-stop-daemon --start $USER_REQ --quiet --pidfile $PIDFILE --exec $OMS_BIN -- $START_QUALS
                 RETVAL=$?
                 log_end_msg $RETVAL
                 ;;               

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -16,9 +16,45 @@
 #    reload:   Reload agent configuration
 #
 
-LOGFILE=/var/opt/microsoft/omsagent/log/omsagent.log
-PIDFILE=/var/opt/microsoft/omsagent/run/omsagent.pid
-OMSADMIN_CONF=/etc/opt/microsoft/omsagent/conf/omsadmin.conf
+setup_variables()
+{
+    VAR_DIR=/var/opt/microsoft/omsagent
+    ETC_DIR=/etc/opt/microsoft/omsagent
+    BIN_DIR=/opt/microsoft/omsagent/bin
+
+    if [ -z "$1" ]; then
+        if [ -f $ETC_DIR/conf/omsadmin.conf ]; then
+            . "$ETC_DIR/conf/omsadmin.conf"
+        else
+            echo "Warning: No workspace is onboarded"
+            exit 0 
+        fi
+    else
+        if [ -f $ETC_DIR/$1/conf/omsadmin.conf ]; then
+            . "$ETC_DIR/$1/conf/omsadmin.conf"
+        else
+            echo "Warning: Specified workspace $1 doesn't exist"
+            exit 0
+        fi
+    fi
+
+    VAR_DIR_WS=$VAR_DIR/$WORKSPACE_ID
+    ETC_DIR_WS=$ETC_DIR/$WORKSPACE_ID
+
+    TMP_DIR=$VAR_DIR_WS/tmp
+    STATE_DIR=$VAR_DIR_WS/state
+    RUN_DIR=$VAR_DIR_WS/run
+    LOG_DIR=$VAR_DIR_WS/log
+    CERT_DIR=$ETC_DIR_WS/certs
+    CONF_DIR=$ETC_DIR_WS/conf
+
+    LOGFILE=$LOG_DIR/omsagent.log
+    PIDFILE=$RUN_DIR/omsagent.pid
+    CONFFILE=$CONF_DIR/omsagent.conf
+    OMSADMIN_CONF=$CONF_DIR/omsadmin.conf
+
+    OMSAGENT_WS=omsagent-$WORKSPACE_ID
+}
 
 verify_privileges()
 {
@@ -93,7 +129,7 @@ stop_omsagent_process()
 
 start_omsagent_process()
 {
-    is_omsagent_running && /opt/microsoft/omsagent/bin/omsagent -d $PIDFILE --no-supervisor -o $LOGFILE
+    is_omsagent_running && /opt/microsoft/omsagent/bin/omsagent -d $PIDFILE --no-supervisor -o $LOGFILE -c $CONFFILE
 }
 
 #
@@ -109,14 +145,14 @@ start_omsagent()
 
     # If systemd lives here, then we have a systemd unit file
     if pidof systemd 1> /dev/null 2> /dev/null; then
-        /bin/systemctl start omsagent
+        /bin/systemctl start $OMSAGENT_WS
     else
         if [ -x /usr/sbin/invoke-rc.d ]; then
-            /usr/sbin/invoke-rc.d omsagent start
+            /usr/sbin/invoke-rc.d $OMSAGENT_WS start
         elif [ -x /sbin/service ]; then
-            /sbin/service omsagent start
+            /sbin/service $OMSAGENT_WS start
         elif [ -x /bin/systemctl ]; then
-            /bin/systemctl start omsagent
+            /bin/systemctl start $OMSAGENT_WS
         else
             echo "Unrecognized service controller to start OMS Agent service" 1>&2
             exit 1
@@ -130,14 +166,14 @@ stop_omsagent()
     if [ $? -ne 0 ]; then
         # If systemd lives here, then we have a systemd unit file
         if pidof systemd 1> /dev/null 2> /dev/null; then
-            /bin/systemctl stop omsagent
+            /bin/systemctl stop $OMSAGENT_WS
         else
             if [ -x /usr/sbin/invoke-rc.d ]; then
-                /usr/sbin/invoke-rc.d omsagent stop
+                /usr/sbin/invoke-rc.d $OMSAGENT_WS stop
             elif [ -x /sbin/service ]; then
-                /sbin/service omsagent stop
+                /sbin/service $OMSAGENT_WS stop
             elif [ -x /bin/systemctl ]; then
-                /bin/systemctl stop omsagent
+                /bin/systemctl stop $OMSAGENT_WS
             else
                 echo "Unrecognized service controller to stop OMS Agent service" 1>&2
                 exit 1
@@ -160,14 +196,14 @@ restart_omsagent()
 
     # If systemd lives here, then we have a systemd unit file
     if pidof systemd 1> /dev/null 2> /dev/null; then
-        /bin/systemctl restart omsagent
+        /bin/systemctl restart $OMSAGENT_WS
     else
         if [ -x /usr/sbin/invoke-rc.d ]; then
-            /usr/sbin/invoke-rc.d omsagent restart
+            /usr/sbin/invoke-rc.d $OMSAGENT_WS restart
         elif [ -x /sbin/service ]; then
-            /sbin/service omsagent restart
+            /sbin/service $OMSAGENT_WS restart
         elif [ -x /bin/systemctl ]; then
-            /bin/systemctl restart omsagent
+            /bin/systemctl restart $OMSAGENT_WS
         else
             echo "Unrecognized service controller to restart OMS Agent service" 1>&2
             exit 1
@@ -207,29 +243,46 @@ find_systemd_dir()
 enable_omsagent_service()
 {
     exit_if_agent_not_onboarded
-    if [ ! -f /etc/opt/microsoft/omsagent/conf/.service_registered ] && [ -f $OMSADMIN_CONF ]; then
+    if [ ! -f $CONF_DIR/.service_registered ] && [ -f $OMSADMIN_CONF ]; then
         echo "Configuring OMS agent service ..."
+        if [ ! -f $BIN_DIR/$OMSAGENT_WS ]; then
+            ln -s $BIN_DIR/omsagent $BIN_DIR/$OMSAGENT_WS
+        fi
+
         if pidof systemd 1> /dev/null 2> /dev/null; then
             # systemd
             local systemd_dir=$(find_systemd_dir)
-            cp /etc/opt/microsoft/omsagent/sysconf/omsagent.systemd ${systemd_dir}/omsagent.service
+            local omsagent_service=${systemd_dir}/$OMSAGENT_WS.service
+
+            cp /etc/opt/microsoft/omsagent/sysconf/omsagent.systemd $omsagent_service 
+
+            sed -i s,%CONF_DIR_WS%,$CONF_DIR,1 $omsagent_service
+            sed -i s,%CERT_DIR_WS%,$CERT_DIR,1 $omsagent_service
+            sed -i s,%TMP_DIR_WS%,$TMP_DIR,1 $omsagent_service
+            sed -i s,%RUN_DIR_WS%,$RUN_DIR,1 $omsagent_service
+            sed -i s,%STATE_DIR_WS%,$STATE_DIR,1 $omsagent_service
+            sed -i s,%LOG_DIR_WS%,$LOG_DIR,1 $omsagent_service
+
             /bin/systemctl daemon-reload
-            /bin/systemctl -q enable omsagent
+            /bin/systemctl -q enable $OMSAGENT_WS
         else
-            cp /etc/opt/microsoft/omsagent/sysconf/omsagent.ulinux /etc/init.d/omsagent
+            local omsagent_initd=/etc/init.d/$OMSAGENT_WS
+            cp /etc/opt/microsoft/omsagent/sysconf/omsagent.ulinux $omsagent_initd
+
+            sed -i s,WORKSPACE_ID=.*,WORKSPACE_ID=$WORKSPACE_ID,1 $omsagent_initd
 
             if [ -x /usr/sbin/update-rc.d ]; then
-                update-rc.d omsagent defaults > /dev/null
+                update-rc.d $OMSAGENT_WS defaults > /dev/null
             elif [ -x /usr/lib/lsb/install_initd ]; then
-                /usr/lib/lsb/install_initd /etc/init.d/omsagent
+                /usr/lib/lsb/install_initd $omsagent_initd
             elif [ -x /sbin/chkconfig ]; then
-                chkconfig --add omsagent > /dev/null
+                /sbin/chkconfig --add $OMSAGENT_WS > /dev/null
             else
                 echo "Could not find a service controller to configure the OMS Agent Service."
                 exit 1
             fi
         fi
-        touch  /etc/opt/microsoft/omsagent/conf/.service_registered
+        touch  $CONF_DIR/.service_registered
     fi 
 }
 
@@ -241,51 +294,59 @@ disable_omsagent_service()
 
     # Registered as a systemd service?
     local systemd_dir=$(find_systemd_dir)
-    if [ -f ${systemd_dir}/omsagent.service ]; then
+    local omsagent_service=${systemd_dir}/$OMSAGENT_WS.service
+    local omsagent_initd=/etc/init.d/$OMSAGENT_WS
+    if [ -f $omsagent_service ]; then
         echo "Unconfiguring OMS agent (systemd) service ..."
-        /bin/systemctl -q disable omsagent
-        rm -f ${systemd_dir}/omsagent.service
+        /bin/systemctl -q disable $OMSAGENT_WS
+        rm -f $omsagent_service
         /bin/systemctl daemon-reload
-    elif [ -f /etc/init.d/omsagent ]; then
+    elif [ -f $omsagent_initd ]; then
         echo "Unconfiguring OMS agent service ..."
         if [ -f /usr/sbin/update-rc.d ]; then
-            /usr/sbin/update-rc.d -f omsagent remove
+            /usr/sbin/update-rc.d -f $OMSAGENT_WS remove
         elif [ -x /usr/lib/lsb/remove_initd ]; then
-            /usr/lib/lsb/remove_initd /etc/init.d/omsagent
+            /usr/lib/lsb/remove_initd $omsagent_initd
         elif [ -x /sbin/chkconfig ]; then
-            chkconfig --del omsagent > /dev/null
+            /sbin/chkconfig --del $OMSAGENT_WS > /dev/null
         else
             echo "Unrecognized Service Controller to unregister OMS Agent Service."
             exit 1
         fi
 
-        rm /etc/init.d/omsagent
+        rm $omsagent_initd
     fi
-    rm -f /etc/opt/microsoft/omsagent/conf/.service_registered
+    rm -f $CONF_DIR/.service_registered
 }
 
 case "$1" in
     functions)
+        setup_variables $2
         ;;
 
     is-running)
+        setup_variables $2
         is_omsagent_running
         exit $?
         ;;
 
     start)
+        setup_variables $2
         start_omsagent
         ;;
 
     stop)
+        setup_variables $2
         stop_omsagent
         ;;
 
     restart)
+        setup_variables $2
         restart_omsagent
         ;;
 
     reload)
+        setup_variables $2
         # TODO: Due to a bug in OMS right now, we can't reload via a signal
         restart_omsagent
         ;;
@@ -295,10 +356,12 @@ case "$1" in
         ;;
 
     enable)
+        setup_variables $2
         enable_omsagent_service
         ;;
 
     disable)
+        setup_variables $2
         disable_omsagent_service
         ;;
 


### PR DESCRIPTION
Update the scripts to support the following multi-homing scenarios:
- Register service: systemd, debian, redhat, suse
- Enable service: systemd, update-rc.d, install_initd, chkconfig
- Start service: systemctl, invoke-rc.d, service

Make the omsagent.systemd and omsagent.ulinux as template, 
whose parameters will be resolved after onboarding.

Update the service_control to use the $2 as the workspace id.
If it's not specified, it will fallback to the default config.

This change is intended to be merged into the FB-multihoming feature branch.

@Microsoft/omsagent-devs 