### PR TITLE
fix in_npmd_server_plugintest.rb test cases

### DIFF
--- a/test/code/plugins/fake_npmd_binary.rb
+++ b/test/code/plugins/fake_npmd_binary.rb
@@ -5,7 +5,7 @@ class NPMDTest
     NPMD_CONN_CONFIRM = "NPMDAgent Connected!"
     FAKE_PATH_DATA = '{"DataItems":[{"SubType":"NetworkPath"}]}'
     FAKE_AGENT_DATA = '{"DataItems":[{"SubType":"NetworkAgent"}]}'
-    TEST_ENDPOINT = File.dirname(__FILE__) + "/test_agent.sock"
+    TEST_ENDPOINT = "tmp_npmd_test/test_agent.sock"
 
     def initialize
         @clientSock = nil


### PR DESCRIPTION
1. Send relative fake endpoint path to prevent endpoint path too long error
2. Ignore Errno:ESRCH as before killing of fake instance it might have exited
3. Give time between binary recreation as so that mtime comparision remains
   valid.
4. Kill all stale instances during shutdown as well if any.