### PR TITLE
Add Remove, RemoveAll, and List Functions in omsadmin.sh

### DIFF
--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -76,7 +76,6 @@
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt
   key_path %CERT_DIR_WS%/oms.key
-  proxy_path %CONF_DIR_WS%/proxy.conf
   
   buffer_chunk_limit 10m
   buffer_type file
@@ -97,7 +96,6 @@
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt
   key_path %CERT_DIR_WS%/oms.key
-  proxy_path %CONF_DIR_WS%/proxy.conf
 
   buffer_chunk_limit 5m
   buffer_type file

--- a/installer/conf/omsagent.d/heartbeat.conf
+++ b/installer/conf/omsagent.d/heartbeat.conf
@@ -5,5 +5,4 @@
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt
   key_path %CERT_DIR_WS%/oms.key
-  proxy_path %CONF_DIR_WS%/proxy.conf
 </source>

--- a/installer/conf/omsagent.d/monitor.conf
+++ b/installer/conf/omsagent.d/monitor.conf
@@ -21,7 +21,6 @@
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt
   key_path %CERT_DIR_WS%/oms.key
-  proxy_path %CONF_DIR_WS%/proxy.conf
 
   buffer_chunk_limit 1m
   buffer_type file

--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -179,7 +179,7 @@ fi
 UnconfigureSyslog
 
 # The OMS_SERVICE script will not be present on a fresh install
-[ -f ${{OMS_SERVICE}} ] && ${{OMS_SERVICE}} disable
+[ -f ${{OMS_SERVICE}} ] && ${{OMS_SERVICE}} disableall
 
 # Add the 'omsagent' group if it does not already exist
 # (Can't use useradd with -U since that doesn't exist on older systems)
@@ -230,7 +230,7 @@ chmod 440 /etc/opt/microsoft/omsagent/sysconf/sudoers
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
     UnconfigureSyslog
-    ${{OMS_SERVICE}} disable
+    ${{OMS_SERVICE}} disableall
 fi
 
 

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -29,7 +29,7 @@ CONF_OMSADMIN=$CONF_DIR/omsadmin.conf
 CONF_OMSAGENT=$CONF_DIR/omsagent.conf
 
 # Omsagent proxy configuration
-CONF_PROXY=$CONF_DIR/proxy.conf
+CONF_PROXY=$ETC_DIR/proxy.conf
 
 # File with OS information for telemetry
 OS_INFO=/etc/opt/microsoft/scx/conf/scx-release
@@ -77,6 +77,15 @@ usage()
     echo "Maintenance tool for OMS:"
     echo "Onboarding:"
     echo "$basename -w <workspace id> -s <shared key> [-d <top level domain>]"
+    echo
+    echo "List Workspaces:"
+    echo "$basename -l"
+    echo
+    echo "Remove Workspace:"
+    echo "$basename -x <workspace id>"
+    echo
+    echo "Remove All Workspaces:"
+    echo "$basename -X"
     echo
     echo "Define proxy settings ('-u' will prompt for password):"
     echo "$basename [-u user] -p host[:port]"
@@ -181,7 +190,7 @@ parse_args()
 {
     local OPTIND opt
 
-    while getopts "h?s:w:d:vp:u:a:c" opt; do
+    while getopts "h?s:w:d:vp:u:a:clx:X" opt; do
         case "$opt" in
         h|\?)
             usage
@@ -214,6 +223,16 @@ parse_args()
         c) 
             COLLECTD=1
             echo "Setting up collectd for OMS..."
+            ;;
+        l)
+            LIST_WORKSPACES=1
+            ;;
+        x)
+            REMOVE=1
+            WORKSPACE_ID=$OPTARG
+            ;;
+        X)
+            REMOVE_ALL=1
             ;;
         esac
     done
@@ -301,11 +320,7 @@ onboard()
         clean_exit 1
     fi
 
-
-    # If a test is not in progress then create workspace-specific directories
-    if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then
-        create_workspace_directories $WORKSPACE_ID 
-    fi
+    create_workspace_directories $WORKSPACE_ID
 
     if [ -f $FILE_KEY -a -f $FILE_CRT -a -f $CONF_OMSADMIN ]; then
         # Keep the same agent GUID by loading it from the previous conf
@@ -412,13 +427,12 @@ onboard()
 
     save_config
 
+    copy_omsagent_conf
+
+    update_symlinks
+
     # If a test is not in progress then register omsagent as a service and start the agent 
-    # If a test is in progress then omsagent conf/symlinks do not need to be updated
     if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then
-        copy_omsagent_conf
-
-        update_symlinks
-
         /opt/microsoft/omsagent/bin/service_control start $WORKSPACE_ID 
     fi
 
@@ -453,13 +467,131 @@ collectd()
     echo "...Done"
 }
 
-create_workspace_directories()
+remove_workspace()
+{
+    setup_workspace_variables $WORKSPACE_ID
+
+    if [ -d "$CONF_DIR" ]; then
+        log_info "Disable workspace: $WORKSPACE_ID"
+
+        /opt/microsoft/omsagent/bin/service_control disable $WORKSPACE_ID
+    else
+        log_error "Workspace $WORKSPACE_ID doesn't exist"
+    fi
+
+    log_info "Cleanup the folders"
+
+    rm -rf "$VAR_DIR_WS" "$ETC_DIR_WS"
+
+    reset_default_workspace
+}
+
+reset_default_workspace()
+{
+    if [ -h $DF_CONF_DIR -a ! -d $DF_CONF_DIR ]; then
+        # default conf folder is removed
+        local ws_id=`ls -1t $ETC_DIR | grep -E '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$' | head -n1`
+
+        if [ "${ws_id}" != "" ]; then
+            # find 1 workspace
+            setup_workspace_variables ${ws_id}
+
+            update_symlinks
+        else
+            # no workspace, remove the default symlinks
+            remove_symlinks
+        fi
+    fi
+}
+
+remove_symlinks()
+{
+    rm "$DF_TMP_DIR" "$DF_RUN_DIR" "$DF_STATE_DIR" "$DF_LOG_DIR" "$DF_CERT_DIR" "$DF_CONF_DIR" > /dev/null 2>&1 
+}
+
+remove_all()
+{
+    # remove the symlinks first so that the remove_workspace will not reset them
+    remove_symlinks
+
+    for ws_id in `ls -1 $ETC_DIR | grep -E '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'`
+    do
+        WORKSPACE_ID=${ws_id}
+        remove_workspace
+    done
+}
+
+show_workspace_status()
+{
+    local ws_conf_dir=$1
+    local ws_id=$2
+    local is_primary=$3
+    local status='Unknown'
+
+    if [ -f ${ws_conf_dir}/.service_registered ]; then
+        status='Success(OMSAgent Registered)'
+    elif [ -f ${ws_conf_dir}/omsadmin.conf ]; then
+        status='Failure(OMSAgent Not Registered)'
+    else
+        status='Failure(Agent Not Onboarded)'
+    fi
+
+    if [ ${is_primary} -eq 1 ]; then
+        echo "Primary Workspace: ${ws_id}    ${status}"
+    else
+        echo "Workspace: ${ws_id}    ${status}"
+    fi
+}
+
+list_workspaces()
+{
+    local found_ws=0
+    local ws_conf_dir=$ETC_DIR/conf
+
+    if [ -h ${ws_conf_dir} ]; then
+        # symbolic link - multiple workspace folder structure
+        local primary_ws_id=''
+        if [ -f ${ws_conf_dir}/omsadmin.conf ]; then
+            primary_ws_id=`grep WORKSPACE_ID ${ws_conf_dir}/omsadmin.conf | cut -d= -f2`
+        fi
+
+        if [ "${primary_ws_id}" != "" ]; then
+            found_ws=1
+            show_workspace_status ${ws_conf_dir} ${primary_ws_id} 1
+        fi
+
+        for ws_id in `ls -1 $ETC_DIR | grep -E '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'`
+        do
+            if [ "${primary_ws_id}" != "${ws_id}" ]; then
+                found_ws=1
+                show_workspace_status $ETC_DIR/${ws_id}/conf ${ws_id} 0
+            fi
+        done
+    elif [ -d ${ws_conf_dir} ]; then
+        # directory - single workspace folder structure
+        local ws_id=''
+
+        if [ -f ${ws_conf_dir}/omsadmin.conf ]; then
+            ws_id=`grep WORKSPACE_ID ${ws_conf_dir}/omsadmin.conf | cut -d= -f2`
+        fi
+
+        if [ "${ws_id}" != "" ]; then
+            found_ws=1
+            show_workspace_status ${ws_conf_dir} ${ws_id} 1
+        fi
+    fi
+
+    if [ $found_ws -eq 0 ]; then
+        echo "No Workspace"
+    fi
+
+    return 1
+}
+
+setup_workspace_variables()
 {
     VAR_DIR_WS=$VAR_DIR/$1
     ETC_DIR_WS=$ETC_DIR/$1
-
-    make_dir $VAR_DIR_WS
-    make_dir $ETC_DIR_WS
 
     TMP_DIR=$VAR_DIR_WS/tmp
     STATE_DIR=$VAR_DIR_WS/state
@@ -467,6 +599,14 @@ create_workspace_directories()
     LOG_DIR=$VAR_DIR_WS/log
     CERT_DIR=$ETC_DIR_WS/certs
     CONF_DIR=$ETC_DIR_WS/conf
+}
+
+create_workspace_directories()
+{
+    setup_workspace_variables $1
+
+    make_dir $VAR_DIR_WS
+    make_dir $ETC_DIR_WS
 
     make_dir $TMP_DIR
     make_dir $STATE_DIR
@@ -480,9 +620,6 @@ create_workspace_directories()
 
     # Omsagent daemon configuration
     CONF_OMSAGENT=$CONF_DIR/omsagent.conf
-
-    # Omsagent proxy configuration
-    CONF_PROXY=$CONF_DIR/proxy.conf
 
     # Certs
     FILE_KEY=$CERT_DIR/oms.key
@@ -581,8 +718,20 @@ main()
         fi
     fi
 
+    if [ "$REMOVE" = "1" ]; then
+        remove_workspace || clean_exit 1
+    fi
+
+    if [ "$REMOVE_ALL" = "1" ]; then
+        remove_all || clean_exit 1
+    fi
+
     if [ "$ONBOARDING" = "1" ]; then
         onboard || clean_exit 1
+    fi
+
+    if [ "$LIST_WORKSPACES" = "1" ]; then
+        list_workspaces || clean_exit 1
     fi
 
     if [ "$COLLECTD" = "1" ]; then

--- a/installer/scripts/omsagent.ulinux
+++ b/installer/scripts/omsagent.ulinux
@@ -32,7 +32,7 @@ if [ ! -f /opt/microsoft/omsagent/bin/service_control ]; then
     exit 1
 fi
 
-. /opt/microsoft/omsagent/bin/service_control functions
+. /opt/microsoft/omsagent/bin/service_control functions $WORKSPACE_ID
 
 if [ -f /etc/init.d/functions ]; then
     INIT_STYLE=R      # INIT_STYLE uses R/S/D for its representative platform RedHat/SuSE/Debian 

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -16,12 +16,12 @@
 #    reload:   Reload agent configuration
 #
 
+VAR_DIR=/var/opt/microsoft/omsagent
+ETC_DIR=/etc/opt/microsoft/omsagent
+BIN_DIR=/opt/microsoft/omsagent/bin
+
 setup_variables()
 {
-    VAR_DIR=/var/opt/microsoft/omsagent
-    ETC_DIR=/etc/opt/microsoft/omsagent
-    BIN_DIR=/opt/microsoft/omsagent/bin
-
     if [ -z "$1" ]; then
         if [ -f $ETC_DIR/conf/omsadmin.conf ]; then
             . "$ETC_DIR/conf/omsadmin.conf"
@@ -319,6 +319,15 @@ disable_omsagent_service()
     rm -f $CONF_DIR/.service_registered
 }
 
+disable_all_omsagent_services()
+{
+    for ws_id in `ls -1 $ETC_DIR | grep -E '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'`
+    do
+       setup_variables ${ws_id}
+       disable_omsagent_service
+    done
+}
+
 case "$1" in
     functions)
         setup_variables $2
@@ -365,6 +374,9 @@ case "$1" in
         disable_omsagent_service
         ;;
 
+    disableall)
+        disable_all_omsagent_services
+        ;;
     *)
         echo "Unknown parameter : $1" 1>&2
         exit 1

--- a/source/code/plugins/in_heartbeat_request.rb
+++ b/source/code/plugins/in_heartbeat_request.rb
@@ -15,7 +15,7 @@ module Fluent
     config_param :omsadmin_conf_path, :string
     config_param :cert_path, :string
     config_param :key_path, :string
-    config_param :proxy_path, :string
+    config_param :proxy_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf' #optional
     config_param :os_info, :string, :default => '/etc/opt/microsoft/scx/conf/scx-release' #optional
     config_param :install_info, :string, :default => '/etc/opt/microsoft/omsagent/sysconf/installinfo.txt' #optional
 

--- a/source/code/plugins/out_oms.rb
+++ b/source/code/plugins/out_oms.rb
@@ -21,7 +21,7 @@ module Fluent
     config_param :omsadmin_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/omsadmin.conf'
     config_param :cert_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.crt'
     config_param :key_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.key'
-    config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/proxy.conf'
+    config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf'
     config_param :compress, :bool, :default => true
 
     def configure(conf)

--- a/source/code/plugins/out_oms_api.rb
+++ b/source/code/plugins/out_oms_api.rb
@@ -26,7 +26,7 @@ module Fluent
     config_param :omsadmin_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/omsadmin.conf'
     config_param :cert_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.crt'
     config_param :key_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.key'
-    config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/proxy.conf'
+    config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf'
     config_param :api_version, :string, :default => '2016-04-01'
     config_param :compress, :bool, :default => true
     config_param :time_generated_field, :string, :default => ''

--- a/source/code/plugins/out_oms_blob.rb
+++ b/source/code/plugins/out_oms_blob.rb
@@ -29,7 +29,7 @@ module Fluent
     config_param :key_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.key'
     config_param :blob_uri_expiry, :string, :default => '00:10:00'
     config_param :url_suffix_template, :string, :default => "custom_data_type + '/00000000-0000-0000-0000-000000000002/' + OMS::Common.get_hostname + '/' + OMS::Configuration.agent_id + '/' + suffix + '.log'"
-    config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/conf/proxy.conf'
+    config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf'
 
     def configure(conf)
       super

--- a/test/code/plugins/out_oms_systestbase.rb
+++ b/test/code/plugins/out_oms_systestbase.rb
@@ -37,6 +37,7 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
     # Setup test onboarding script and folder
     @omsadmin_test_dir = `#{@prep_omsadmin} #{@base_dir} #{@ruby_test_dir}`.strip()
     assert_equal(0, $?.to_i, "Unexpected failure setting up the test")
+    @omsadmin_test_dir_ws = "#{@omsadmin_test_dir}/#{TEST_WORKSPACE_ID}"
   end
   
   def do_onboard
@@ -47,9 +48,9 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
 
   def load_configurations
     # Mock the configuration
-    conf_path = "#{@omsadmin_test_dir}/omsadmin.conf"
-    cert_path = "#{@omsadmin_test_dir}/oms.crt"
-    key_path = "#{@omsadmin_test_dir}/oms.key"
+    conf_path = "#{@omsadmin_test_dir_ws}/conf/omsadmin.conf"
+    cert_path = "#{@omsadmin_test_dir_ws}/certs/oms.crt"
+    key_path = "#{@omsadmin_test_dir_ws}/certs/oms.key"
 
     conf = %[
       omsadmin_conf_path #{conf_path}

--- a/test/installer/scripts/agent_maintenance_script_systest.rb
+++ b/test/installer/scripts/agent_maintenance_script_systest.rb
@@ -63,9 +63,9 @@ class AgentMaintenanceSystemTest < MaintenanceSystemTestBase
     onboarded_output = do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)
     assert_no_match(/(e|E)rror/, onboarded_output, "Unexpected error onboarding for maintenance tests")
     # Onboarded valid data
-    @omsadmin_conf_path = "#{@omsadmin_test_dir}/omsadmin.conf"
-    @cert_path = "#{@omsadmin_test_dir}/oms.crt"
-    @key_path = "#{@omsadmin_test_dir}/oms.key"
+    @omsadmin_conf_path = "#{@omsadmin_test_dir_ws1}/conf/omsadmin.conf"
+    @cert_path = "#{@omsadmin_test_dir_ws1}/certs/oms.crt"
+    @key_path = "#{@omsadmin_test_dir_ws1}/certs/oms.key"
     @os_info_path = "#{@omsadmin_test_dir}/scx-release"
     @install_info_path = "#{@base_dir}/installer/conf/installinfo.txt"
     @log = OMS::MockLog.new

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -11,14 +11,14 @@ class OmsadminTest < MaintenanceSystemTestBase
     assert_equal(true, stat.readable?, "'#{path}' should be readable")
   end
   
-  def post_onboard_validation
-    crt_path = "#{@omsadmin_test_dir}/oms.crt"
-    key_path = "#{@omsadmin_test_dir}/oms.key"
+  def post_onboard_validation(ws_dir = @omsadmin_test_dir_ws1)
+    crt_path = "#{ws_dir}/certs/oms.crt"
+    key_path = "#{ws_dir}/certs/oms.key"
 
     # Make sure certs and config was generated
     assert(File.file?(crt_path), "'#{crt_path}' does not exist!")
     assert(File.file?(key_path), "'#{key_path}' does not exist!")
-    assert(File.file?("#{@omsadmin_test_dir}/omsadmin.conf"), "omsadmin.conf does not exist!")
+    assert(File.file?("#{ws_dir}/conf/omsadmin.conf"), "omsadmin.conf does not exist!")
 
     # Check permissions
     crt_uid = File.stat(crt_path).uid
@@ -31,7 +31,7 @@ class OmsadminTest < MaintenanceSystemTestBase
   def test_create_proxy_file
     assert(!File.file?(@proxy_conf), "Proxy file should not be present beforehand.")
     output = `#{@omsadmin_script} -p proxy_host:8080`
-    assert_equal(0, $?.to_i, "Unexpected failure creating proxy file.")
+    assert_equal(0, $?.to_i, "Unexpected failure creating proxy file. #{output}")
     assert_match(/Created proxy configuration/, output, "Did not find proxy config create message")
     assert(File.file?(@proxy_conf), "Failed to find generated proxy file.")
     check_cert_perms(@proxy_conf)
@@ -49,7 +49,7 @@ class OmsadminTest < MaintenanceSystemTestBase
   def test_onboard_proxy_sucess
     prep_proxy(TEST_PROXY_SETTING)
     output = do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)
-    assert_match(/Using proxy settings/, output, "Did not find using proxy settings message")
+    assert_match(/Using proxy settings/, output, "Did not find using proxy settings message: #{output}")
   end
 
   def test_onboard_proxy_failure
@@ -76,8 +76,8 @@ class OmsadminTest < MaintenanceSystemTestBase
   def test_reonboard
     do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)
 
-    crt_path = "#{@omsadmin_test_dir}/oms.crt"
-    key_path = "#{@omsadmin_test_dir}/oms.key"
+    crt_path = "#{@omsadmin_test_dir_ws1}/certs/oms.crt"
+    key_path = "#{@omsadmin_test_dir_ws1}/certs/oms.key"
 
     # Save state
     crt_hash = Digest::SHA256.file(crt_path)
@@ -94,15 +94,42 @@ class OmsadminTest < MaintenanceSystemTestBase
 
   def test_reonboard_different_workspace_id
     do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)
-    old_guid = get_GUID()
+    old_guid = get_GUID(@omsadmin_test_dir_ws1)
 
     output = do_onboard(TEST_WORKSPACE_ID_2, TEST_SHARED_KEY_2)
-    new_guid = get_GUID()
+    new_guid = get_GUID(@omsadmin_test_dir_ws2)
 
-    # With current multihoming support, the GUID is re-used when onboarding to an additional workspace
-    # TODO Robbie change this when AGENT_GUID logic has been fully converted with multihoming
-    assert_equal(old_guid, new_guid, "The GUID should not change when reonboarding to another workspace ID")
-    assert_match(/Reusing/, output, "Should be reusing GUID")
+    assert_not_equal(old_guid, new_guid, "The GUID should change when reonboarding with a different workspace ID")
+    assert_not_match(/Reusing/, output, "Should not be reusing GUID")
+  end
+
+  def test_onboard_two_workspaces
+    $log.info "Test results in #{@omsadmin_test_dir}"
+    output1 = do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)
+    assert_match(/Generating certificate/, output1, "Did not find cert generation message for workspace 1")
+    post_onboard_validation(@omsadmin_test_dir_ws1)
+
+    output2 = do_onboard(TEST_WORKSPACE_ID_2, TEST_SHARED_KEY_2)
+    assert_match(/Generating certificate/, output2, "Did not find cert generation message for workspace 2")
+    post_onboard_validation(@omsadmin_test_dir_ws2)
+
+    output_list = `#{@omsadmin_script} -l`
+    assert_match(/#{TEST_WORKSPACE_ID}/, output_list, "Did not find workspace 1 in list")
+    assert_match(/#{TEST_WORKSPACE_ID_2}/, output_list, "Did not find workspace 2 in list")
+
+    remove_workspace(TEST_WORKSPACE_ID)
+    remove_workspace(TEST_WORKSPACE_ID, false)
+
+    output_list = `#{@omsadmin_script} -l`
+
+    assert_not_match(/#{TEST_WORKSPACE_ID}/, output_list, "Should not find workspace 1 in list")
+    assert_match(/#{TEST_WORKSPACE_ID_2}/, output_list, "Did not find workspace 2 in list")
+
+    output_removeall = `#{@omsadmin_script} -X`
+    assert_equal(0, $?.to_i, "Remove all workspace should succeed: #{output_removeall}")
+
+    output_list = `#{@omsadmin_script} -l`
+    assert_match(/No Workspace/, output_list, "No workspace should be listed: #{output_list}")
   end
 
 end

--- a/test/installer/scripts/prep_omsadmin.sh
+++ b/test/installer/scripts/prep_omsadmin.sh
@@ -11,9 +11,9 @@ OMSADMIN=$TESTDIR/omsadmin.sh
 cp $BASE_DIR/installer/scripts/omsadmin.sh $OMSADMIN
 chmod u+wx $OMSADMIN
 
-sed -i s,TMP_DIR=.*,TMP_DIR=$TESTDIR,1 $OMSADMIN
-sed -i s,CONF_DIR=.*,CONF_DIR=$TESTDIR,1 $OMSADMIN
-sed -i s,CERT_DIR=.*,CERT_DIR=$TESTDIR,1 $OMSADMIN
+sed -i s,ETC_DIR=.*,ETC_DIR=$TESTDIR,1 $OMSADMIN
+sed -i s,VAR_DIR=.*,VAR_DIR=$TESTDIR,1 $OMSADMIN
+sed -i s,SYSCONF_DIR=.*,SYSCONF_DIR=$BASE_DIR/installer/conf,1 $OMSADMIN
 sed -i s,OS_INFO=.*,OS_INFO=$TESTDIR/scx-release,1 $OMSADMIN
 sed -i s,RUBY=.*,RUBY=${RUBY_TESTVERS}/bin/ruby,1 $OMSADMIN
 sed -i s,AUTH_KEY_SCRIPT=.*,AUTH_KEY_SCRIPT=$BASE_DIR/installer/scripts/auth_key.rb,1 $OMSADMIN


### PR DESCRIPTION
Add the following parameters for omsadmin:
-l: list all workspaces
-x <workspace id>: remove the specified workspace
-X: remove all workspaces

Update the system tests for multi-homing onboarding,
so that the configuration from different workspaces won't corrupt.
Add system tests for onboard 2 workspaces, and verified
the multi-onboarding, and list/remove/removeall functions

Fixed a bug in disable service
Make the proxy.conf a global file for all workspaces
@Microsoft/omsagent-devs @lagalbra 