### PR TITLE
Patch Ruby for handling references to SSLv3 symbols

### DIFF
--- a/build/configure
+++ b/build/configure
@@ -246,6 +246,10 @@ fi
 
 cp ${base_dir}/source/ext/patches/ruby/configure ${base_dir}/source/ext/ruby/configure
 
+# We need to patch Ruby for handling any references to SSLv3 symbols, apply this patch
+
+patch ${base_dir}/source/ext/ruby/ext/openssl/ossl_ssl.c < ${base_dir}/source/ext/patches/ruby/sslv3.patch
+
 # We modify fluentd for branding purposes (omsagent), copy those changes
 
 cp ${base_dir}/source/ext/patches/fluentd/env.rb ${base_dir}/source/ext/fluentd/lib/fluent/env.rb

--- a/source/ext/patches/ruby/sslv3.patch
+++ b/source/ext/patches/ruby/sslv3.patch
@@ -1,0 +1,15 @@
+--- ../../ruby/ext/openssl/ossl_ssl.c	2016-12-15 15:49:32.000000000 -0800
++++ ../../ruby/ext/openssl/copy.c	2016-12-15 15:18:33.000000000 -0800
+@@ -138,9 +138,12 @@
+     OSSL_SSL_METHOD_ENTRY(SSLv2_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv2_client),
+ #endif
++#if defined(HAVE_SSLV3_METHOD) && defined(HAVE_SSLV3_SERVER_METHOD) && \
++        defined(HAVE_SSLV3_CLIENT_METHOD)
+     OSSL_SSL_METHOD_ENTRY(SSLv3),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_client),
++#endif
+     OSSL_SSL_METHOD_ENTRY(SSLv23),
+     OSSL_SSL_METHOD_ENTRY(SSLv23_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv23_client),


### PR DESCRIPTION
@Microsoft/omsagent-devs 
This PR was to resolve the onboarding issue on Ubuntu14.04/16.04 machines that have newer version of OpenSSL installed, that no longer support SSLv3. See [https://github.com/Microsoft/OMS-Agent-for-Linux/issues/173](url)

This commit resolves the issue by patching Ruby such that it references the SSLv3 symbols only if they are defined. However, when looking into upgrading Ruby to version 2.3 we found out that this patch is already a part of the newer Ruby code. [https://github.com/ruby/ruby/commit/801e1fe46d83c856844ba18ae4751478c59af0d1 ](url)
Therefore, I am closing this PR without  merging. @lagalbra will start working on the Ruby upgrade, and ensure that this issue is resolved with her changes.