### PR TITLE
Manage the Port for Syslog and Monitor Agent

### DIFF
--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -36,14 +36,6 @@
   interval 30s
 </source>
 
-<source>
-  type syslog
-  port 25224
-  bind 127.0.0.1
-  protocol_type udp
-  tag oms.syslog
-</source>
-
 #<source>
 #  type tail
 #  path /var/log/nagios/nagios.log
@@ -59,10 +51,6 @@
 #  zabbix_username Admin
 #  zabbix_password zabbix
 #</source>
-
-<filter oms.syslog.**>
-  type filter_syslog
-</filter>
 
 #<filter oms.nagios>
 #  type filter_nagios_log

--- a/installer/conf/omsagent.d/monitor.conf
+++ b/installer/conf/omsagent.d/monitor.conf
@@ -1,6 +1,7 @@
 <source>
   type monitor_agent
   tag oms.health
+  port %MONITOR_AGENT_PORT%
   emit_interval 5m
   emit_config true
 </source>

--- a/installer/conf/omsagent.d/syslog.conf
+++ b/installer/conf/omsagent.d/syslog.conf
@@ -1,0 +1,12 @@
+<source>
+  type syslog
+  port %SYSLOG_PORT%
+  bind 127.0.0.1
+  protocol_type udp
+  tag oms.syslog
+</source>
+
+<filter oms.syslog.**>
+  type filter_syslog
+</filter>
+

--- a/installer/conf/rsyslog.conf
+++ b/installer/conf/rsyslog.conf
@@ -1,18 +1,18 @@
-# OMS Syslog collection
-kern.warning              @127.0.0.1:25224
-user.warning              @127.0.0.1:25224
-daemon.warning            @127.0.0.1:25224
-auth.warning              @127.0.0.1:25224
-syslog.warning            @127.0.0.1:25224
-uucp.warning              @127.0.0.1:25224
-authpriv.warning          @127.0.0.1:25224
-ftp.warning               @127.0.0.1:25224
-cron.warning              @127.0.0.1:25224
-local0.warning            @127.0.0.1:25224
-local1.warning            @127.0.0.1:25224
-local2.warning            @127.0.0.1:25224
-local3.warning            @127.0.0.1:25224
-local4.warning            @127.0.0.1:25224
-local5.warning            @127.0.0.1:25224
-local6.warning            @127.0.0.1:25224
-local7.warning            @127.0.0.1:25224
+# OMS Syslog collection for workspace %WORKSPACE_ID%
+kern.warning              @127.0.0.1:%SYSLOG_PORT%
+user.warning              @127.0.0.1:%SYSLOG_PORT%
+daemon.warning            @127.0.0.1:%SYSLOG_PORT%
+auth.warning              @127.0.0.1:%SYSLOG_PORT%
+syslog.warning            @127.0.0.1:%SYSLOG_PORT%
+uucp.warning              @127.0.0.1:%SYSLOG_PORT%
+authpriv.warning          @127.0.0.1:%SYSLOG_PORT%
+ftp.warning               @127.0.0.1:%SYSLOG_PORT%
+cron.warning              @127.0.0.1:%SYSLOG_PORT%
+local0.warning            @127.0.0.1:%SYSLOG_PORT%
+local1.warning            @127.0.0.1:%SYSLOG_PORT%
+local2.warning            @127.0.0.1:%SYSLOG_PORT%
+local3.warning            @127.0.0.1:%SYSLOG_PORT%
+local4.warning            @127.0.0.1:%SYSLOG_PORT%
+local5.warning            @127.0.0.1:%SYSLOG_PORT%
+local6.warning            @127.0.0.1:%SYSLOG_PORT%
+local7.warning            @127.0.0.1:%SYSLOG_PORT%

--- a/installer/conf/syslog-ng.conf
+++ b/installer/conf/syslog-ng.conf
@@ -1,4 +1,3 @@
-#OMS_facility = all
-filter f_warning_oms { level(warning); };
-destination warning_oms { udp("127.0.0.1" port(25224)); };
-log { source(src); filter(f_warning_oms); destination(warning_oms); };
+filter f_%WORKSPACE_ID%_oms { level(warning); };
+destination d_%WORKSPACE_ID%_oms { udp("127.0.0.1" port(%SYSLOG_PORT%)); };
+log { source(%SOURCE%); filter(f_%WORKSPACE_ID%_oms); destination(d_%WORKSPACE_ID%_oms); };

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -30,6 +30,7 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/patch_management_inventory.mof;  installer/conf/omsagent.d/patch_management_inventory.mof;        644; root; root
 
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/oms.conf;                installer/conf/oms.conf;                               644; root; root
+/etc/opt/microsoft/omsagent/sysconf/omsagent.d/syslog.conf;             installer/conf/omsagent.d/syslog.conf;                 644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/collectd.conf;           installer/conf/omsagent.d/collectd.conf;               644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/statsd.conf;             installer/conf/omsagent.d/statsd.conf;                 644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/auditlog.conf;           installer/conf/omsagent.d/auditlog.conf;               644; root; root
@@ -46,6 +47,7 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/bin/omsadmin.sh;                                installer/scripts/omsadmin.sh;                         755; root; root
 /opt/microsoft/omsagent/bin/service_control;                            installer/scripts/service_control;                     755; root; root
 /opt/microsoft/omsagent/bin/uninstall;                                  installer/scripts/uninstall.sh;                        755; root; root
+/opt/microsoft/omsagent/bin/configure_syslog.sh;                        installer/scripts/configure_syslog.sh;                 755; root; root
 /opt/microsoft/omsagent/bin/tailfilereader.rb;                          installer/scripts/tailfilereader.rb;                   744; root; root
 /opt/microsoft/omsagent/bin/hdinsightmanifestreader.rb;                 installer/scripts/hdinsightmanifestreader.rb;          744; root; root
 

--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -1,8 +1,8 @@
 %Variables
 PF:           'Linux'
-RSYSLOG_DEST: '/etc/rsyslog.d/95-omsagent.conf'
 OMI_SERVICE:  '/opt/omi/bin/service_control'
 OMS_SERVICE:  '/opt/microsoft/omsagent/bin/service_control'
+CONF_SYSLOG:  '/opt/microsoft/omsagent/bin/configure_syslog.sh'
 
 %Directories
 /etc;                                                   755; root; root; sysdir
@@ -16,123 +16,6 @@ OMS_SERVICE:  '/opt/microsoft/omsagent/bin/service_control'
 /etc/opt/microsoft/omsagent/sysconf/omsagent.systemd;                   installer/scripts/omsagent.systemd;                    644; root; root
 
 /etc/opt/microsoft/omsagent/sysconf/sudoers;                            installer/conf/sudoers;                                664; root; root
-
-%Syslog_Services
-RestartService() {
-    if [ -z "$1" ]; then
-        echo "RestartService requires parameter (service name to restart)" 1>&2
-        return 1
-    fi
-
-    echo "Restarting service: $1"
-
-    # Does the service exist under systemd?
-    local systemd_dir=$(${{OMS_SERVICE}} find-systemd-dir)
-    pidof systemd 1> /dev/null 2> /dev/null
-    if [ $? -eq 0 -a -f ${systemd_dir}/${1}.service ]; then
-        /bin/systemctl restart $1
-    else
-        if [ -x /usr/sbin/invoke-rc.d ]; then
-            /usr/sbin/invoke-rc.d $1 restart
-        elif [ -x /sbin/service ]; then
-            /sbin/service $1 restart
-        elif [ -x /bin/systemctl ]; then
-            /bin/systemctl restart $1
-        else
-            echo "Unrecognized service controller to start service $1" 1>&2
-	    return 1
-        fi
-     fi    
-}
-
-ConfigureRsyslog() {
-    if [ ! -f ${{RSYSLOG_DEST}} ]; then
-        echo "Configuring rsyslog for OMS logging"
-
-        cp /etc/opt/microsoft/omsagent/sysconf/rsyslog.conf ${{RSYSLOG_DEST}}
-        chown omsagent:omsagent ${{RSYSLOG_DEST}}
-        RestartService rsyslog
-    fi
-}
-
-UnconfigureRsyslog() {
-    if [ -f ${{RSYSLOG_DEST}} ]; then
-        echo "Unconfiguring rsyslog for OMS logging"
-
-        rm -f ${{RSYSLOG_DEST}}
-        RestartService rsyslog
-    fi
-}
-
-ConfigureOldRsyslog() {
-    # Don't configure Rsyslog (old version) if already configured (avoid duplicate entries)
-    egrep -q "OMS Syslog|@127.0.0.1:25224" /etc/rsyslog.conf
-    if [ $? -ne 0 ]; then
-        echo "Configuring (old) rsyslog for OMS logging"
-
-        cat /etc/opt/microsoft/omsagent/sysconf/rsyslog.conf >> /etc/rsyslog.conf
-        RestartService rsyslog
-    fi
-}
-
-UnconfigureOldRsyslog() {
-    egrep -q "OMS Syslog|@127.0.0.1:25224" /etc/rsyslog.conf
-    if [ $? -eq 0 ]; then
-        echo "Unconfiguring (old) rsyslog for OMS logging"
-
-        cp /etc/rsyslog.conf /etc/rsyslog.bak
-        egrep -v "OMS Syslog|@127.0.0.1:25224" /etc/rsyslog.bak > /etc/rsyslog.conf
-        RestartService rsyslog
-    fi
-}
-
-ConfigureSyslog_ng() {
-    # Don't reconfigure syslog-ng if already configured (avoid duplicate entries)
-    egrep -q "OMS_|_oms" /etc/syslog-ng/syslog-ng.conf
-    if [ $? -ne 0 ]; then
-        echo "Configuring syslog-ng for OMS logging"
-
-        cat /etc/opt/microsoft/omsagent/sysconf/syslog-ng.conf >> /etc/syslog-ng/syslog-ng.conf
-        RestartService syslog
-    fi
-}
-
-UnconfigureSyslog_ng() {
-    egrep -q "OMS_|_oms" /etc/syslog-ng/syslog-ng.conf
-    if [ $? -eq 0 ]; then
-        echo "Unconfiguring syslog-ng for OMS logging"
-
-        cp /etc/syslog-ng/syslog-ng.conf /etc/syslog-ng/syslog-ng.bak
-        egrep -v "OMS_|_oms" /etc/syslog-ng/syslog-ng.bak > /etc/syslog-ng/syslog-ng.conf
-        RestartService syslog
-    fi
-}
-
-ConfigureSyslog() {
-    if [ -f /etc/rsyslog.conf -a -d /etc/rsyslog.d ]; then
-        ConfigureRsyslog
-    elif [ -f /etc/rsyslog.conf ]; then
-        ConfigureOldRsyslog
-    elif [ -f /etc/syslog-ng/syslog-ng.conf ]; then
-        ConfigureSyslog_ng
-    else
-        echo "No supported syslog daemon found. Syslog messages will not be processed."
-        return 1
-    fi
-}
-
-UnconfigureSyslog() {
-    if [ -f /etc/rsyslog.conf -a -d /etc/rsyslog.d ]; then
-        UnconfigureRsyslog
-    elif [ -f /etc/rsyslog.conf ]; then
-        UnconfigureOldRsyslog
-    elif [ -f /etc/syslog-ng/syslog-ng.conf ]; then
-        UnconfigureSyslog_ng
-    else
-        echo "No supported syslog daemon found; unable to unconfigure syslog monitoring."
-        return 1
-    fi
-}
 
 %Sudoer_Functions
 RemoveSudoersSupport() {
@@ -169,14 +52,11 @@ SudoSupportsIncludeDirective() {
 
 
 %Preinstall_1000
-#include Syslog_Services
 
 # If our service is already running, stop it
 if [ -f ${{OMS_SERVICE}} ]; then
    ${{OMS_SERVICE}} stop
 fi
-
-UnconfigureSyslog
 
 # The OMS_SERVICE script will not be present on a fresh install
 [ -f ${{OMS_SERVICE}} ] && ${{OMS_SERVICE}} disableall
@@ -200,13 +80,10 @@ fi
 /usr/sbin/usermod -g omiusers omsagent 1> /dev/null 2> /dev/null
 
 %Postinstall_500
-#include Syslog_Services
 #include Sudoer_Functions
 
 ${{OMI_SERVICE}} reload
 ${{OMS_SERVICE}} enable
-
-ConfigureSyslog
 
 # Unconfigure sudo if it's already configured
 
@@ -226,11 +103,10 @@ chmod 440 /etc/opt/microsoft/omsagent/sysconf/sudoers
 
 
 %Preuninstall_10
-#include Syslog_Services
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
-    UnconfigureSyslog
     ${{OMS_SERVICE}} disableall
+    ${{CONF_SYSLOG}} purge
 fi
 
 

--- a/installer/scripts/configure_syslog.sh
+++ b/installer/scripts/configure_syslog.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+
+RSYSLOG_TEMP=/etc/opt/microsoft/omsagent/sysconf/rsyslog.conf
+SYSLOG_NG_TEMP=/etc/opt/microsoft/omsagent/sysconf/syslog-ng.conf
+
+RSYSLOG_D=/etc/rsyslog.d
+
+RSYSLOG_DEST=$RSYSLOG_D/95-omsagent.conf
+OLD_RSYSLOG_DEST=/etc/rsyslog.conf
+
+SYSLOG_NG_DEST=/etc/syslog-ng/syslog-ng.conf
+
+OMS_SERVICE=/opt/microsoft/omsagent/bin/service_control
+
+WORKSPACE_ID=
+SYSLOG_PORT=
+
+RestartService() {
+    if [ -z "$1" ]; then
+        echo "RestartService requires parameter (service name to restart)" 1>&2
+        return 1
+    fi
+
+    echo "Restarting service: $1"
+
+    # Does the service exist under systemd?
+    local systemd_dir=$(${OMS_SERVICE} find-systemd-dir)
+    pidof systemd 1> /dev/null 2> /dev/null
+    if [ $? -eq 0 -a -f ${systemd_dir}/${1}.service ]; then
+        /bin/systemctl restart $1
+    else
+        if [ -x /usr/sbin/invoke-rc.d ]; then
+            /usr/sbin/invoke-rc.d $1 restart
+        elif [ -x /sbin/service ]; then
+            /sbin/service $1 restart
+        elif [ -x /bin/systemctl ]; then
+            /bin/systemctl restart $1
+        else
+            echo "Unrecognized service controller to start service $1" 1>&2
+	    return 1
+        fi
+     fi
+}
+
+ConfigureRsyslog() {
+    if [ ! -f ${RSYSLOG_DEST} ]; then
+        # Rsyslog (new version) doesn't exist. Copy
+        echo "Configuring rsyslog for OMS logging"
+
+        cat ${RSYSLOG_TEMP} | sed "s/%WORKSPACE_ID%/${WORKSPACE_ID}/g" | sed "s/%SYSLOG_PORT%/${SYSLOG_PORT}/g" > ${RSYSLOG_DEST}
+        chown omsagent:omiusers ${RSYSLOG_DEST}
+        RestartService rsyslog
+    else
+        # Don't configure Rsyslog (new version) if the port is already configured
+        egrep -q "@127.0.0.1:${SYSLOG_PORT}" ${RSYSLOG_DEST}
+        if [ $? -ne 0 ]; then
+            echo "Configuring rsyslog for OMS logging"
+
+            cat ${RSYSLOG_TEMP} | sed "s/%WORKSPACE_ID%/${WORKSPACE_ID}/g" | sed "s/%SYSLOG_PORT%/${SYSLOG_PORT}/g" >> ${RSYSLOG_DEST}
+        fi
+    fi
+}
+
+UnconfigureRsyslog() {
+    if [ -f ${RSYSLOG_DEST} ]; then
+        echo "Unconfiguring rsyslog for OMS logging"
+
+        egrep -q "OMS Syslog collection for workspace ${WORKSPACE_ID}|@127.0.0.1:${SYSLOG_PORT}" ${RSYSLOG_DEST}
+        if [ $? -eq 0 ]; then
+            cp ${RSYSLOG_DEST} ${RSYSLOG_DEST}.bak
+            egrep -v "OMS Syslog collection for workspace ${WORKSPACE_ID}|@127.0.0.1:${SYSLOG_PORT}" ${RSYSLOG_DEST}.bak > ${RSYSLOG_DEST}
+            rm -f ${RSYSLOG_DEST}.bak 1> /dev/null 2> /dev/null
+            RestartService rsyslog
+        fi
+    fi
+}
+
+PurgeRsyslog() {
+    if [ -f ${RSYSLOG_DEST} ]; then
+        echo "Purging rsyslog for OMS logging"
+
+        rm -f ${RSYSLOG_DEST}
+        RestartService rsyslog
+    fi
+}
+
+ConfigureOldRsyslog() {
+    # Don't configure Rsyslog (old version) if already configured (avoid duplicate entries)
+    egrep -q "@127.0.0.1:${SYSLOG_PORT}" ${OLD_RSYSLOG_DEST}
+    if [ $? -ne 0 ]; then
+        echo "Configuring (old) rsyslog for OMS logging"
+
+        cat ${RSYSLOG_TEMP} | sed "s/%WORKSPACE_ID%/${WORKSPACE_ID}/g" | sed "s/%SYSLOG_PORT%/${SYSLOG_PORT}/g" >> ${OLD_RSYSLOG_DEST}
+        RestartService rsyslog
+    fi
+}
+
+UnconfigureOldRsyslog() {
+    egrep -q "OMS Syslog collection for workspace ${WORKSPACE_ID}|@127.0.0.1:${SYSLOG_PORT}" ${OLD_RSYSLOG_DEST}
+    if [ $? -eq 0 ]; then
+        echo "Unconfiguring (old) rsyslog for OMS logging"
+
+        cp ${OLD_RSYSLOG_DEST} ${OLD_RSYSLOG_DEST}.bak
+        egrep -v "OMS Syslog collection for workspace ${WORKSPACE_ID}|@127.0.0.1:${SYSLOG_PORT}" ${OLD_RSYSLOG_DEST}.bak > ${OLD_RSYSLOG_DEST}
+        rm -f ${OLD_RSYSLOG_DEST}.bak 1> /dev/null 2> /dev/null
+        RestartService rsyslog
+    fi
+}
+
+PurgeOldRsyslog() {
+    egrep -q "OMS Syslog collection|@127.0.0.1:25..." ${OLD_RSYSLOG_DEST}
+    if [ $? -eq 0 ]; then
+        echo "Purging (old) rsyslog for OMS logging"
+
+        cp ${OLD_RSYSLOG_DEST} ${OLD_RSYSLOG_DEST}.bak
+        egrep -v "OMS Syslog collection|@127.0.0.1:25..." ${OLD_RSYSLOG_DEST}.bak > ${OLD_RSYSLOG_DEST}
+        rm -f ${OLD_RSYSLOG_DEST}.bak 1> /dev/null 2> /dev/null
+        RestartService rsyslog
+    fi
+}
+
+ConfigureSyslog_ng() {
+    # Don't reconfigure syslog-ng if already configured (avoid duplicate entries)
+    egrep -q "${WORKSPACE_ID}_oms" ${SYSLOG_NG_DEST}
+    if [ $? -ne 0 ]; then
+        echo "Configuring syslog-ng for OMS logging"
+
+        local source=`grep '^source .*src' ${SYSLOG_NG_DEST} | cut -d ' ' -f2`
+        if [ -z "${source}" ]; then
+            source=src
+        fi
+
+        cat ${SYSLOG_NG_TEMP} | sed "s/%SOURCE%/${source}/g" | sed "s/%WORKSPACE_ID%/${WORKSPACE_ID}/g" | sed "s/%SYSLOG_PORT%/${SYSLOG_PORT}/g" >> ${SYSLOG_NG_DEST}
+        RestartService syslog-ng
+    fi
+}
+
+UnconfigureSyslog_ng() {
+    egrep -q "${WORKDPACE_ID}_oms" ${SYSLOG_NG_DEST}
+    if [ $? -eq 0 ]; then
+        echo "Unconfiguring syslog-ng for OMS logging"
+
+        cp ${SYSLOG_NG_DEST} ${SYSLOG_NG_DEST}.bak
+        egrep -v "${WORKSPACE_ID}_oms" ${SYSLOG_NG_DEST}.bak > ${SYSLOG_NG_DEST}
+        rm -f ${SYSLOG_NG_DEST}.bak 1> /dev/null 2> /dev/null
+        RestartService syslog-ng
+    fi
+}
+
+PurgeSyslog_ng() {
+    egrep -q "_oms" ${SYSLOG_NG_DEST}
+    if [ $? -eq 0 ]; then
+        echo "Purging syslog-ng for OMS logging"
+
+        cp ${SYSLOG_NG_DEST} ${SYSLOG_NG_DEST}.bak
+        egrep -v "_oms" ${SYSLOG_NG_DEST}.bak > ${SYSLOG_NG_DEST}
+        rm -f ${SYSLOG_NG_DEST}.bak 1> /dev/null 2> /dev/null
+        RestartService syslog-ng
+    fi
+}
+
+ConfigureSyslog() {
+    if [ -f ${OLD_RSYSLOG_DEST} -a -d ${RSYSLOG_D} ]; then
+        ConfigureRsyslog
+    elif [ -f ${OLD_RSYSLOG_DEST} ]; then
+        ConfigureOldRsyslog
+    elif [ -f ${SYSLOG_NG_DEST} ]; then
+        ConfigureSyslog_ng
+    else
+        echo "No supported syslog daemon found. Syslog messages will not be processed."
+        return 1
+    fi
+}
+
+UnconfigureSyslog() {
+    if [ -f ${OLD_RSYSLOG_DEST} -a -d ${RSYSLOG_D} ]; then
+        UnconfigureRsyslog
+    elif [ -f ${OLD_RSYSLOG_DEST} ]; then
+        UnconfigureOldRsyslog
+    elif [ -f ${SYSLOG_NG_DEST} ]; then
+        UnconfigureSyslog_ng
+    else
+        echo "No supported syslog daemon found; unable to unconfigure syslog monitoring."
+        return 1
+    fi
+}
+
+PurgeSyslog() {
+    if [ -f ${OLD_RSYSLOG_DEST} -a -d ${RSYSLOG_D} ]; then
+        PurgeRsyslog
+    elif [ -f ${OLD_RSYSLOG_DEST} ]; then
+        PurgeOldRsyslog
+    elif [ -f ${SYSLOG_NG_DEST} ]; then
+        PurgeSyslog_ng
+    else
+        echo "No supported syslog daemon found; unable to purge syslog monitoring."
+        return 1
+    fi
+}
+
+SetVariables() {
+    WORKSPACE_ID=$1
+    SYSLOG_PORT=$2
+
+    if [ -z $WORKSPACE_ID -o -z $SYSLOG_PORT ]; then
+        echo "WORKSPACE_ID and SYSLOG_PORT are required" 1>&2
+        exit 1
+    fi
+}
+
+case "$1" in
+    configure)
+        SetVariables $2 $3
+        ConfigureSyslog || exit 1
+        ;;
+
+    unconfigure)
+        SetVariables $2 $3
+        UnconfigureSyslog || exit 1
+        ;;
+
+    purge)
+        PurgeSyslog || exit 1
+        ;;
+    *)
+        echo "Unknow parameter : $1" 1>&2
+        exit 1
+        ;;
+esac
+


### PR DESCRIPTION
Move the syslog fluentd configuration out of the
omsagent.conf into omsagent.d/syslog.conf, and make it
a template for different workspace and port.
Make monitor.conf a template too.

In onboarding phase, find a free port to the syslog and
monitor agent, and customize the port in the conf.
Port for syslog starts from 25224
Port for monitor agent starts from 25324

Support configure rsyslog and syslog-ng per workspace
Move the syslog configure into configure_syslog.sh
from the linux.data. The configuration will now happen
in the onboarding phase instead of installation phase.

Configure the rsyslog or syslog-ng according to the
port assigned to the workspace in 3 different ways:
/etc/rsyslog.d/95-omsagent.conf
/etc/rsyslog.conf
/etc/syslog-ng/syslog-ng.conf

Remove the syslog configure settings when removing
the workspace.

@Microsoft/omsagent-devs @lagalbra 