### PR TITLE
Upgrade old folder structure to multi-homing structure

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -145,49 +145,10 @@ WriteInstallInfo
 # owned by omsagent account. So create them as part of Postinstall, after the
 # service account is created.
 
-mkdir -m 700 /etc/opt/microsoft/omsagent/certs/ 2> /dev/null || true
-chown -R omsagent:omsagent /etc/opt/microsoft/omsagent/certs
-
 mkdir -m 755 /var/opt/microsoft/omsagent        2> /dev/null || true
-mkdir -m 755 /var/opt/microsoft/omsagent/log    2> /dev/null || true
-mkdir -m 755 /var/opt/microsoft/omsagent/run    2> /dev/null || true
-mkdir -m 755 /var/opt/microsoft/omsagent/state  2> /dev/null || true
-mkdir -m 755 /var/opt/microsoft/omsagent/tmp    2> /dev/null || true
-chown -R omsagent:omsagent /var/opt/microsoft/omsagent
+chown -R omsagent:omiusers /var/opt/microsoft/omsagent
 
 # Ditto for conf directory in /etc/opt/microsoft/omsagent/conf ...
-
-mkdir -m 755 ${{CONF_DIR}} 2> /dev/null || true
-
-if [ ! -f ${{CONF_DIR}}/omsagent.conf ]; then
-   cp /etc/opt/microsoft/omsagent/sysconf/omsagent.conf ${{CONF_DIR}}
-fi
-
-# Folder for omsagent.conf includes
-mkdir -m 755 ${{CONF_DIR}}/omsagent.d 2> /dev/null || true
-
-# Copy monitor plugins conf file by default
-if [ ! -f ${{CONF_DIR}}/omsagent.d/monitor.conf ]; then
-   cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/monitor.conf ${{CONF_DIR}}/omsagent.d/monitor.conf
-fi
-
-# Copy operation.conf file by default
-if [ ! -f ${{CONF_DIR}}/omsagent.d/operation.conf ]; then
-   cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/operation.conf ${{CONF_DIR}}/omsagent.d/operation.conf
-fi
-
-# Copy over omi_mapping.json
-if [ ! -f ${{CONF_DIR}}/omsagent.d/omi_mapping.json ]; then
-   cp /etc/opt/microsoft/omsagent/sysconf/omi_mapping.json ${{CONF_DIR}}/omsagent.d/omi_mapping.json
-fi
-
-# Copy oms_audits.xml file by default
-if [ ! -f ${{CONF_DIR}}/omsagent.d/oms_audits.xml ]; then
-   cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/oms_audits.xml ${{CONF_DIR}}/omsagent.d/oms_audits.xml
-fi
-
-# Copy over standalone plugin configurations
-#cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/* ${{CONF_DIR}}/omsagent.d
 
 # Copy collectd conf files only if collectd_marker.conf exists 
 if [ -f /etc/collectd_marker.conf ]; then
@@ -196,12 +157,12 @@ if [ -f /etc/collectd_marker.conf ]; then
     else
         cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/oms.conf /etc/collectd/collectd.conf.d/oms.conf
     fi
-    cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/collectd.conf ${{CONF_DIR}}/omsagent.d/collectd.conf
+    #cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/collectd.conf ${{CONF_DIR}}/omsagent.d/collectd.conf
     rm /etc/collectd_marker.conf
 fi
 
-# The real conf directory has to be owned by omsagent to be readable by the omsagent daemon
-chown -R omsagent:omsagent ${{CONF_DIR}}
+%Postinstall_200
+/opt/microsoft/omsagent/bin/omsadmin.sh -m
 
 %Postinstall_300
 if [ -f /etc/omsagent-onboard.conf ]; then
@@ -221,17 +182,11 @@ fi
 # Thus, if we're an upgrade, skip all of this cleanup
 if ${{PERFORMING_UPGRADE_NOT}}; then
    # Clean up directory tree (created via PostInstall) if dirs are empty
-   rmdir /etc/opt/microsoft/omsagent/certs/ 2> /dev/null
-   rmdir /var/opt/microsoft/omsagent/tmp 2> /dev/null
-   rmdir /var/opt/microsoft/omsagent/state 2> /dev/null
-   rmdir /var/opt/microsoft/omsagent/run 2> /dev/null
-   rmdir /var/opt/microsoft/omsagent/log 2> /dev/null
-   rmdir /var/opt/microsoft/omsagent 2> /dev/null
+   rm -rf /var/opt/microsoft/omsagent 2> /dev/null
 
    # Clean up installinfo.txt file (registered as "conf" file to pass rpmcheck)
    rm -f /etc/opt/microsoft/omsagent/sysconf/installinfo.txt*
-   rmdir /etc/opt/microsoft/omsagent/sysconf 2> /dev/null
-   rmdir /etc/opt/microsoft/omsagent 2> /dev/null
+   rm -rf /etc/opt/microsoft/omsagent 2> /dev/null
    rmdir /etc/opt/microsoft 2> /dev/null
    rmdir /etc/opt 2> /dev/null
 fi

--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -53,13 +53,8 @@ SudoSupportsIncludeDirective() {
 
 %Preinstall_1000
 
-# If our service is already running, stop it
-if [ -f ${{OMS_SERVICE}} ]; then
-   ${{OMS_SERVICE}} stop
-fi
-
 # The OMS_SERVICE script will not be present on a fresh install
-[ -f ${{OMS_SERVICE}} ] && ${{OMS_SERVICE}} disableall
+[ -f ${{OMS_SERVICE}} ] && ${{OMS_SERVICE}} disable
 
 # Add the 'omsagent' group if it does not already exist
 # (Can't use useradd with -U since that doesn't exist on older systems)
@@ -83,7 +78,6 @@ fi
 #include Sudoer_Functions
 
 ${{OMI_SERVICE}} reload
-${{OMS_SERVICE}} enable
 
 # Unconfigure sudo if it's already configured
 
@@ -101,11 +95,13 @@ fi
 
 chmod 440 /etc/opt/microsoft/omsagent/sysconf/sudoers
 
+%Postinstall_600
+${{OMS_SERVICE}} start
 
 %Preuninstall_10
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
-    ${{OMS_SERVICE}} disableall
+    ${{OMS_SERVICE}} disable
     ${{CONF_SYSLOG}} purge
 fi
 

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -34,6 +34,9 @@ CONF_PROXY=$ETC_DIR/proxy.conf
 # File with OS information for telemetry
 OS_INFO=/etc/opt/microsoft/scx/conf/scx-release
 
+# Service Control script
+SERVICE_CONTROL=/opt/microsoft/omsagent/bin/service_control
+
 # File with information about the agent installed
 INSTALL_INFO=/etc/opt/microsoft/omsagent/sysconf/installinfo.txt
 
@@ -92,6 +95,9 @@ usage()
     echo
     echo "Remove All Workspaces:"
     echo "$basename -X"
+    echo
+    echo "Migrate Old Workspace to the New Folder Structure:"
+    echo "$basename -m"
     echo
     echo "Define proxy settings ('-u' will prompt for password):"
     echo "$basename [-u user] -p host[:port]"
@@ -196,7 +202,7 @@ parse_args()
 {
     local OPTIND opt
 
-    while getopts "h?s:w:d:vp:u:a:clx:X" opt; do
+    while getopts "h?s:w:d:vp:u:a:clx:Xm" opt; do
         case "$opt" in
         h|\?)
             usage
@@ -239,6 +245,9 @@ parse_args()
             ;;
         X)
             REMOVE_ALL=1
+            ;;
+        m)
+            MIGRATE_OLD_WS=1
             ;;
         esac
     done
@@ -443,7 +452,7 @@ onboard()
 
     # If a test is not in progress then register omsagent as a service and start the agent 
     if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then
-        /opt/microsoft/omsagent/bin/service_control start $WORKSPACE_ID 
+        $SERVICE_CONTROL start $WORKSPACE_ID 
     fi
 
     if [ -e $METACONFIG_PY ]; then
@@ -468,8 +477,8 @@ collectd()
     if [ -d "$COLLECTD_DIR" ]; then
         cp $SYSCONF_DIR/omsagent.d/oms.conf $COLLECTD_DIR/oms.conf
         cp $SYSCONF_DIR/omsagent.d/collectd.conf $CONF_DIR/omsagent.d/collectd.conf
-        chown omsagent:omsagent $CONF_DIR/omsagent.d/collectd.conf
-        /opt/microsoft/omsagent/bin/service_control restart 
+        chown omsagent:omiusers $CONF_DIR/omsagent.d/collectd.conf
+        $SERVICE_CONTROL restart 
     else
         echo "$COLLECTD_DIR - directory does not exist. Please make sure collectd is installed properly"
         return 1
@@ -484,17 +493,16 @@ remove_workspace()
     if [ -d "$CONF_DIR" ]; then
         log_info "Disable workspace: $WORKSPACE_ID"
 
-        /opt/microsoft/omsagent/bin/service_control disable $WORKSPACE_ID
+        $SERVICE_CONTROL disable $WORKSPACE_ID
     else
         log_error "Workspace $WORKSPACE_ID doesn't exist"
     fi
 
     log_info "Cleanup the folders"
 
-    local port=`grep 'port .*' $CONF_DIR/omsagent.d/syslog.conf | cut -d ' ' -f4`
-
-    if [ -z ${port} ]; then
-        port=`grep 'port .*' $CONF_DIR/omsagent.conf | cut -d ' ' -f4`
+    local port=$DEFAULT_SYSLOG_PORT
+    if [ -e "$CONF_DIR/omsagent.d/syslog.conf" ]; then
+        port=`grep 'port .*' $CONF_DIR/omsagent.d/syslog.conf | cut -d ' ' -f4`
     fi
 
     /opt/microsoft/omsagent/bin/configure_syslog.sh unconfigure $WORKSPACE_ID ${port}
@@ -606,6 +614,34 @@ list_workspaces()
     return 1
 }
 
+migrate_old_workspace()
+{
+    if [ -d $DF_CONF_DIR -a ! -h $DF_CONF_DIR ]; then
+        WORKSPACE_ID=`grep WORKSPACE_ID $DF_CONF_DIR/omsadmin.conf | cut -d= -f2`
+
+        if [ $? -ne 0 -o -z $WORKSPACE_ID ]; then
+            echo "WORKSPACE_ID is not found. Skip migration."
+            return
+        fi
+
+        create_workspace_directories $WORKSPACE_ID
+
+        cp -rpf $DF_TMP_DIR $VAR_DIR_WS
+        cp -rpf $DF_STATE_DIR $VAR_DIR_WS
+        cp -rpf $DF_RUN_DIR $VAR_DIR_WS
+        cp -rpf $DF_LOG_DIR $VAR_DIR_WS
+
+        cp -rpf $DF_CERT_DIR $ETC_DIR_WS
+        cp -rpf $DF_CONF_DIR $ETC_DIR_WS
+
+        if [ -f $DF_CONF_DIR/proxy.conf ]; then
+            cp -pf $DF_CONF_DIR/proxy.conf $ETC_DIR
+        fi
+
+        update_symlinks
+    fi
+}
+
 setup_workspace_variables()
 {
     VAR_DIR_WS=$VAR_DIR/$1
@@ -632,6 +668,8 @@ create_workspace_directories()
     make_dir $LOG_DIR
     make_dir $CERT_DIR
     make_dir $CONF_DIR
+
+    chmod 700 $CERT_DIR
 
     # Generated conf file containing information for this script
     CONF_OMSADMIN=$CONF_DIR/omsadmin.conf
@@ -675,6 +713,7 @@ copy_omsagent_conf()
     cp $SYSCONF_DIR/omsagent.d/heartbeat.conf $OMSAGENTD_DIR
     cp $SYSCONF_DIR/omsagent.d/operation.conf $OMSAGENTD_DIR
     cp $SYSCONF_DIR/omi_mapping.json $OMSAGENTD_DIR
+    cp $SYSCONF_DIR/oms_audits.xml $OMSAGENTD_DIR
 
     update_path $OMSAGENTD_DIR/monitor.conf
     update_path $OMSAGENTD_DIR/heartbeat.conf
@@ -779,6 +818,10 @@ main()
 
     if [ "$LIST_WORKSPACES" = "1" ]; then
         list_workspaces || clean_exit 1
+    fi
+
+    if [ "$MIGRATE_OLD_WS" = "1" ]; then
+        migrate_old_workspace || clean_exit 1
     fi
 
     if [ "$COLLECTD" = "1" ]; then

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -20,6 +20,8 @@ VAR_DIR=/var/opt/microsoft/omsagent
 ETC_DIR=/etc/opt/microsoft/omsagent
 BIN_DIR=/opt/microsoft/omsagent/bin
 
+WORKSPACE_REGEX='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+
 setup_variables()
 {
     if [ -z "$1" ]; then
@@ -319,9 +321,45 @@ disable_omsagent_service()
     rm -f $CONF_DIR/.service_registered
 }
 
+start_all_omsagent()
+{
+    for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
+    do
+       setup_variables ${ws_id}
+       start_omsagent
+    done
+}
+
+stop_all_omsagent()
+{
+    for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
+    do
+       setup_variables ${ws_id}
+       stop_omsagent
+    done
+}
+
+restart_all_omsagent()
+{
+    for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
+    do
+       setup_variables ${ws_id}
+       restart_omsagent
+    done
+}
+
+enable_all_omsagent_services()
+{
+    for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
+    do
+       setup_variables ${ws_id}
+       enable_omsagent_service
+    done
+}
+
 disable_all_omsagent_services()
 {
-    for ws_id in `ls -1 $ETC_DIR | grep -E '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'`
+    for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
     do
        setup_variables ${ws_id}
        disable_omsagent_service
@@ -340,24 +378,40 @@ case "$1" in
         ;;
 
     start)
-        setup_variables $2
-        start_omsagent
+        if [ -z $2 ]; then
+            start_all_omsagent
+        else
+            setup_variables $2
+            start_omsagent
+        fi
         ;;
 
     stop)
-        setup_variables $2
-        stop_omsagent
+        if [ -z $2 ]; then
+            stop_all_omsagent
+        else
+            setup_variables $2
+            stop_omsagent
+        fi
         ;;
 
     restart)
-        setup_variables $2
-        restart_omsagent
+        if [ -z $2 ]; then
+            restart_all_omsagent
+        else
+            setup_variables $2
+            restart_omsagent
+        fi
         ;;
 
     reload)
-        setup_variables $2
         # TODO: Due to a bug in OMS right now, we can't reload via a signal
-        restart_omsagent
+        if [ -z $2 ]; then
+            restart_all_omsagent
+        else
+            setup_variables $2
+            restart_omsagent
+        fi
         ;;
 
     find-systemd-dir)
@@ -365,18 +419,23 @@ case "$1" in
         ;;
 
     enable)
-        setup_variables $2
-        enable_omsagent_service
+        if [ -z $2 ]; then
+            enable_all_omsagent_services
+        else
+            setup_variables $2
+            enable_omsagent_service
+        fi
         ;;
 
     disable)
-        setup_variables $2
-        disable_omsagent_service
+        if [ -z $2 ]; then
+	    disable_all_omsagent_services
+        else
+            setup_variables $2
+	    disable_omsagent_service
+        fi
         ;;
 
-    disableall)
-        disable_all_omsagent_services
-        ;;
     *)
         echo "Unknown parameter : $1" 1>&2
         exit 1


### PR DESCRIPTION
In upgrade command, convert the old folder structure to
use the multi-homing one, and re-register the omsagent service

Cleanup the code in base_omsagent.data

Change the command for service_control. If $2 (Workspace ID) is
not specified, it will run the operation on all workspaces.
This makes the commands backward compatible.

@Microsoft/omsagent-devs @lagalbra 