### PR TITLE
Migrate existing omsagent.conf to use workspace folder

### DIFF
--- a/installer/scripts/configure_syslog.sh
+++ b/installer/scripts/configure_syslog.sh
@@ -57,6 +57,7 @@ ConfigureRsyslog() {
             echo "Configuring rsyslog for OMS logging"
 
             cat ${RSYSLOG_TEMP} | sed "s/%WORKSPACE_ID%/${WORKSPACE_ID}/g" | sed "s/%SYSLOG_PORT%/${SYSLOG_PORT}/g" >> ${RSYSLOG_DEST}
+            RestartService rsyslog
         fi
     fi
 }


### PR DESCRIPTION
Migrating old omsagent.conf, use the conf, cert, and state
with the workspace folder in the path

Look up the allocated the ports in the conf files when
allocating port for syslog and monitor agent

@Microsoft/omsagent-devs @lagalbra 