### PR TITLE
Bug fix: fix rake systemtest

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -533,7 +533,8 @@ systemtestrb : $(RUBY_TESTING_DIR)
 	cd $(BASE_DIR); $(RUBY_TESTING_DIR)/bin/rake -f $(BASE_DIR)/test/Rakefile.rb systemtest \
 		BASE_DIR=$(BASE_DIR) \
 		PLUGINS_TEST_DIR=$(BASE_DIR)/test/code/plugins \
-		RUBY_TESTING_DIR=$(RUBY_TESTING_DIR)
+		RUBY_TESTING_DIR=$(RUBY_TESTING_DIR) \
+		RUBY_DEST_DIR=$(RUBY_TESTING_DIR)
 else
 systemtestrb:
 	@echo "Warning: ruby system tests will not run without $(SYSTEST_CONFIG)" >&2


### PR DESCRIPTION
Currently, running "make systemtest" produces an error like this:
"rake aborted!
Errno::ENOENT: No such file or directory - /bin/gem"

This commit added the ruby environment variable to unit tests but not system tests; my change simply adds it to system tests as well, which fixes the error: https://github.com/Microsoft/OMS-Agent-for-Linux/commit/b04fbc8cf4c73ce464fd2e716314d3affbb588ec#diff-a9ecd20e00022844a7800c7a1d224791R523

@Microsoft/omsagent-devs 