### PR TITLE
Update Rakefile to run rake directly

### DIFF
--- a/test/Rakefile.rb
+++ b/test/Rakefile.rb
@@ -1,4 +1,4 @@
-#!/usr/local/ruby-2.2.0/bin rake
+#!~/bin/omsagent_test_ruby/bin rake
 
 require 'rake/testtask'
 require 'rake/clean'


### PR DESCRIPTION
This line of the Rakefile allows a developer to run Rake directly against our OMSAgent Ruby. It should be changed whenever we change the location of our built test Ruby.

@Microsoft/omsagent-devs 