### PR TITLE
Patch for handling references to SSLv2 and SSLv3 symbols

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -158,7 +158,7 @@ distclean : clean clean-ruby clean-dsc clean-scx
 	-$(RMDIR) $(OMI_ROOT)/output*
 
 	cd $(BASE_DIR)/source/ext/fluentd; git checkout -- lib/fluent/env.rb
-	cd $(BASE_DIR)/source/ext/ruby; git checkout -- ext/openssl/ossl_ssl.c
+	cd $(BASE_DIR)/source/ext/ruby; git checkout -- ext/openssl/ossl_ssl.c ext/openssl/extconf.rb
 	-$(RM) $(BASE_DIR)/build/Makefile.version
 	-$(RM) $(BASE_DIR)/build/config.mak
 	-$(RM) $(PAL_DIR)/build/config.mak

--- a/build/configure
+++ b/build/configure
@@ -220,6 +220,10 @@ apply_patch() {
 # Necessary patch for upgrade to Ruby 2.3, incompatibility with OpenSSL 0.9.8
 apply_patch ${base_dir}/source/ext/patches/ruby/clear_options.patch ${base_dir}/source/ext/ruby/ext/openssl/ossl_ssl.c
 
+# This patch is borrowed from the latest Ruby code as of 1/18/2017 and resolves the error "undefined symbol: SSLv3_method"
+# Upgrading to a version higher than Ruby 2.3 may already include this patch
+apply_patch ${base_dir}/source/ext/patches/ruby/SSLv2_SSLv3_method.patch ${base_dir}/source/ext/ruby/ext/openssl/extconf.rb
+
 # No errors allowed from this point forward
 set -e
 

--- a/source/ext/patches/ruby/SSLv2_SSLv3_method.patch
+++ b/source/ext/patches/ruby/SSLv2_SSLv3_method.patch
@@ -1,0 +1,31 @@
+--- ../source/ext/ruby/ext/openssl/extconf.rb	2017-01-17 17:56:15.963999999 -0800
++++ ../source/ext/ruby/ext/openssl/extconf.rb.new	2017-01-17 17:54:07.567999999 -0800
+@@ -59,6 +59,15 @@
+ end
+ 
+ Logging::message "=== Checking for OpenSSL features... ===\n"
++# check OPENSSL_NO_{SSL2,SSL3_METHOD} macro: on some environment, these symbols
++# exist even if compiled with no-ssl2 or no-ssl3-method.
++unless have_macro("OPENSSL_NO_SSL2", "openssl/opensslconf.h")
++  have_func("SSLv2_method")
++end
++unless have_macro("OPENSSL_NO_SSL3_METHOD", "openssl/opensslconf.h")
++  have_func("SSLv3_method")
++end
++
+ have_func("ERR_peek_last_error")
+ have_func("ASN1_put_eoc")
+ have_func("BN_mod_add")
+@@ -97,12 +106,6 @@
+ have_func("SSL_SESSION_get_id")
+ have_func("SSL_SESSION_cmp")
+ have_func("OPENSSL_cleanse")
+-have_func("SSLv2_method")
+-have_func("SSLv2_server_method")
+-have_func("SSLv2_client_method")
+-have_func("SSLv3_method")
+-have_func("SSLv3_server_method")
+-have_func("SSLv3_client_method")
+ have_func("TLSv1_1_method")
+ have_func("TLSv1_1_server_method")
+ have_func("TLSv1_1_client_method")


### PR DESCRIPTION
@Microsoft/omsagent-devs 
Fix for issue #173  
The issue can be repro'd on Ubuntu 14.04 and 16.04 when running the onboarding script after:
1. OpenSSL package is upgraded using
    `sudo apt-get update`
    `sudo apt-get upgrade`
OR
2. Adding a repository that contains openSSL build without SSLv3 support, such as by following the instructions here http://askubuntu.com/questions/756181/installing-php-5-6-on-xenial-16-04

This patch adds a check for OPENSSL_NO_SSL2 and OPENSSL_NO_SSL3 macros to fix the issue that arises because SSLv2 and SSLv3 symbols seem to exist even if the openssl is compiled using -no-ssl2 or -no-ssl3 options.