### PR TITLE
Delete onboard file on purge/remove if it exists

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -639,6 +639,7 @@ cd $EXTRACT_DIR
 set +e
 if [ "$installMode" = "R" -o "$installMode" = "P" ]; then
     rm -f "$OMS_CONSISTENCY_INVOKER" > /dev/null 2> /dev/null 
+    rm -f "$ONBOARD_FILE" > /dev/null 2> /dev/null
     if [ -f /opt/microsoft/omsagent/bin/uninstall ]; then
         /opt/microsoft/omsagent/bin/uninstall $installMode
     else


### PR DESCRIPTION
@Microsoft/omsagent-devs 
When onboarding fails using invalid workspace id or key, the /etc/omsagent-onboard.conf file remains on the machine even after --purge. This is a fix for such cases.