### PR TITLE
Move heartbeat FQDN evaluation to topology script

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -148,7 +148,6 @@ save_config()
     echo AZURE_RESOURCE_ID=$AZURE_RESOURCE_ID >> $CONF_OMSADMIN
     echo OMSCLOUD_ID=$OMSCLOUD_ID | tr -d ' ' >> $CONF_OMSADMIN
     echo UUID=$UUID | tr -d ' ' >> $CONF_OMSADMIN
-    echo FQDN=$FQDN >> $CONF_OMSADMIN
     chown_omsagent "$CONF_OMSADMIN"
 }
 
@@ -286,18 +285,6 @@ parse_args()
     fi
 }
 
-set_FQDN()
-{
-    local hostname=`hostname`
-    local domainname=`hostname -d 2> /dev/null`
-
-    if [ -n "$domainname" ]; then
-        FQDN="$hostname.$domainname"
-    else
-        FQDN="$hostname"
-    fi
-}
-
 create_proxy_conf()
 {
     local conf_proxy_content=$1
@@ -372,10 +359,9 @@ onboard()
 
     REQ_DATE=`date +%Y-%m-%dT%T.%N%:z`
     CERT_SERVER=`cat $FILE_CRT | awk 'NR>2 { print line } { line = $0 }'`
-    set_FQDN
 
     # append telemetry to $BODY_ONBOARD
-    `$RUBY $TOPOLOGY_REQ_SCRIPT -t "$BODY_ONBOARD" "$OS_INFO" "$CONF_OMSADMIN" "$FQDN" "$AGENT_GUID" "$CERT_SERVER" "$RUN_DIR/omsagent.pid"` 
+    `$RUBY $TOPOLOGY_REQ_SCRIPT -t "$BODY_ONBOARD" "$OS_INFO" "$CONF_OMSADMIN" "$AGENT_GUID" "$CERT_SERVER" "$RUN_DIR/omsagent.pid"` 
     [ $? -ne 0 ] && log_error "Error appending Telemetry during Onboarding. "
 
     cat /dev/null > "$SHARED_KEY_FILE"

--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -37,7 +37,6 @@ module MaintenanceModule
       @WORKSPACE_ID = nil
       @AGENT_GUID = nil
       @URL_TLD = nil
-      @FQDN = nil
       @LOG_FACILITY = nil
       @CERTIFICATE_UPDATE_ENDPOINT = nil
 
@@ -157,8 +156,6 @@ module MaintenanceModule
           if !@URL_TLD.end_with?(".com")
             @URL_TLD.concat(".com")  # Ensure URL_TLD is backwards-compatible
           end
-        elsif line =~ /^FQDN/
-          @FQDN = line.sub("FQDN=","").strip
         elsif line =~ /^LOG_FACILITY/
           @LOG_FACILITY = line.sub("LOG_FACILITY=","").strip
         elsif line =~ /^CERTIFICATE_UPDATE_ENDPOINT/
@@ -330,8 +327,8 @@ module MaintenanceModule
       if @load_config_success != 0
         log_error("Error loading configuration from #{@omsadmin_conf_path}")
         return 1
-      elsif @WORKSPACE_ID.nil? or @AGENT_GUID.nil? or @URL_TLD.nil? or @FQDN.nil? or
-          @WORKSPACE_ID.empty? or @AGENT_GUID.empty? or @URL_TLD.empty? or @FQDN.empty?
+      elsif @WORKSPACE_ID.nil? or @AGENT_GUID.nil? or @URL_TLD.nil? or
+          @WORKSPACE_ID.empty? or @AGENT_GUID.empty? or @URL_TLD.empty?
         log_error("Missing required field from configuration file: #{@omsadmin_conf_path}")
         return 1
       elsif !file_exists_nonempty(@cert_path) or !file_exists_nonempty(@key_path)
@@ -342,7 +339,7 @@ module MaintenanceModule
       # Generate the request body
       begin
         body_hb_xml = AgentTopologyRequestHandler.new.handle_request(@os_info, @omsadmin_conf_path,
-            @FQDN, @AGENT_GUID, get_cert_server(@cert_path), @pid_path, telemetry=true)
+            @AGENT_GUID, get_cert_server(@cert_path), @pid_path, telemetry=true)
         if !xml_contains_telemetry(body_hb_xml)
           log_debug("No Telemetry data was appended to the heartbeat request")
         end

--- a/source/code/plugins/agent_topology_request_script.rb
+++ b/source/code/plugins/agent_topology_request_script.rb
@@ -120,10 +120,20 @@ def obj_to_hash(obj)
   return hash
 end
 
+def evaluate_fqdn()
+  hostname = `hostname`
+  domainname = `hostname -d 2> /dev/null`
+
+  if !domainname.nil? and !domainname.empty?
+    return "#{hostname}.#{domainname}"
+  end
+  return hostname
+end
+
 class AgentTopologyRequestHandler < StrongTypedClass
-  def handle_request(os_info, conf_omsadmin, fqdn, entity_type_id, auth_cert, pid_file, telemetry)
+  def handle_request(os_info, conf_omsadmin, entity_type_id, auth_cert, pid_file, telemetry)
     topology_request = AgentTopologyRequest.new
-    topology_request.FullyQualfiedDomainName = fqdn
+    topology_request.FullyQualfiedDomainName = evaluate_fqdn()
     topology_request.EntityTypeId = entity_type_id
     topology_request.AuthenticationCertificate = auth_cert
 
@@ -171,7 +181,7 @@ if __FILE__ == $0
   end.parse!  
 
   topology_request_xml = AgentTopologyRequestHandler.new.handle_request(ARGV[1], ARGV[2],
-      ARGV[3], ARGV[4], ARGV[5], ARGV[6], options[:telemetry])
+      ARGV[3], ARGV[4], ARGV[5], options[:telemetry])
 
   path = ARGV[0]
   File.open(path, 'a') do |f|

--- a/test/code/plugins/agent_maintenance_script_plugintest.rb
+++ b/test/code/plugins/agent_maintenance_script_plugintest.rb
@@ -25,7 +25,6 @@ class MaintenanceUnitTest < Test::Unit::TestCase
                         "AZURE_RESOURCE_ID=\n" \
                         "OMSCLOUD_ID=7783-7084-3265-9085-8269-3286-77\n" \
                         "UUID=274E8EF9-2B6F-8A45-801B-AAEE62710796\n" \
-                        "FQDN=fakefqdn.domain.net\n"
 
   VALID_HEARTBEAT_RESP = "<?xml version=\"1.0\" encoding=\"utf-8\"?><LinuxAgentTopologyResponse "\
                          "queryInterval=\"PT1H\" id=\"628a6594-a618-4da4-a989-bcd9a322d403\" "\


### PR DESCRIPTION
Without this change, upgrading from old bundle to a bundle after commit [9bab3ab](https://github.com/Microsoft/OMS-Agent-for-Linux/commit/7a5ab6b16b7c8730c6d3dd4e80c139a87adc64d3) without using the workspace ID and key parameters (-w, -s) will result in OMS heartbeat not being sent and errors in omsagent.log.
@Microsoft/omsagent-devs @vrdmr @agup006 