### PR TITLE
Fix markdown references to restarting omsagent daemon

### DIFF
--- a/docs/Apache-HTTP-Server-Logs-Collection.md
+++ b/docs/Apache-HTTP-Server-Logs-Collection.md
@@ -29,7 +29,7 @@
   ```
 
 5. Restart the OMS agent:
-`sudo service omsagent restart`
+`sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]`
 
 6. Confirm that there are no errors in the OMS agent log:
 `tail /var/opt/microsoft/omsagent/log/omsagent.log`

--- a/docs/Cisco-Asa-Preview-Configuration.md
+++ b/docs/Cisco-Asa-Preview-Configuration.md
@@ -42,7 +42,7 @@
 
 
 7. Restart the OMS agent:  
-```sudo service omsagent restart``` or ```systemctl restart omsagent```
+```sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]```
 
 
 8. Confirm that there are no errors in the OMS Agent log:  

--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -173,14 +173,14 @@ proxyconf="https://proxyuser:proxypassword@proxyserver01:8080"
 sudo echo $proxyconf >>/etc/opt/microsoft/omsagent/proxy.conf
 sudo chown omsagent:omiusers /etc/opt/microsoft/omsagent/proxy.conf
 sudo chmod 600 /etc/opt/microsoft/omsagent/proxy.conf
-sudo /opt/microsoft/omsagent/bin/service_control restart
+sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]
 ```
 
 **Removing the proxy configuration**
 To remove a previously defined proxy configuration and revert to direct connectivity, remove the proxy.conf file:
 ```
 sudo rm /etc/opt/microsoft/omsagent/proxy.conf
-sudo /opt/microsoft/omsagent/bin/service_control restart
+sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]
 ```
 
 # Onboarding with Operations Management Suite
@@ -246,7 +246,7 @@ sudo sh /opt/microsoft/omsagent/bin/omsadmin.sh -X
 ```
 
 # Manage omsagent Daemon
-From 1.3.0-1, we will register omsagent daemon for each onboarded workspace. The daemon name is omsagent-<workspace-id>
+From 1.3.0-1, we will register omsagent daemon for each onboarded workspace. The daemon name is omsagent-\<workspace-id>
 You can use /opt/microsoft/omsagent/bin/service_control command to operate the daemon.
 
 ```
@@ -311,7 +311,7 @@ To define a default user account for the MySQL server on localhost:
 ```
 sudo su omsagent -c '/opt/microsoft/mysql-cimprov/bin/mycimprovauth default 127.0.0.1 <username> <password>'
 
-sudo /opt/omi/bin/service_control restart
+sudo /opt/omi/bin/service_control restart [<workspace id>]
 ```
 Alternatively, you can specify the required MySQL credentials in a file, by creating the file: `/var/opt/microsoft/mysql-cimprov/auth/omsagent/mysql-auth`. For more information on managing MySQL credentials for monitoring through the mysql-auth file, see **Appendix C** of this document.
 
@@ -413,7 +413,7 @@ By default, the OMS Agent for Linux receives events from the syslog daemon over 
 *	Restart the omsagent and syslog daemons:
 
 	```
-	sudo /opt/microsoft/omsagent/bin/service_control restart
+	sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]
 	sudo service rsyslog restart
 	```
 *	Confirm that no errors are reported in the omsagent log:
@@ -621,7 +621,7 @@ Example seperate configuration file `exec-json.conf` for /etc/opt/microsoft/omsa
 </match>
 ```
 
-Once complete restart the OMS Agent for Linux service `sudo service omsagent restart` or `sudo systemctl restart omsagent` and the data shows up in Log Analytics under `Type=<FLUENTD_TAG>_CL`.
+Once complete, restart the OMS Agent for Linux service: `sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]` and the data shows up in Log Analytics under `Type=<FLUENTD_TAG>_CL`.
 
 **Example:**The following custom tag `tag oms.api.tomcat` shows up as `Type=tomcat_CL` in Log Analytics
 
@@ -667,7 +667,7 @@ sudo usermod -a -G nagios omsagent
 *	Restart the omsagent daemon
 
 ```
-sudo service omsagent restart
+sudo sh /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]
 ```
 ### Zabbix Alerts
 To collect alerts from a Zabbix server, you'll perform similiar steps to those for Nagios above, except you'll need to specify a user and password in *clear text*. This is not ideal, but we recommend that you create the user and grant permissions to monitor onlu.

--- a/docs/OMS-MySQL-Instructions.md
+++ b/docs/OMS-MySQL-Instructions.md
@@ -50,7 +50,7 @@ If `mysql.conf` is not present in the above location, move it:
 `sudo service mysql restart` or `/etc/init.d/mysqld restart`
 
 6. Restart the OMS agent:
-`sudo service omsagent restart`
+`sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]`
 
 
 7. Confirm that there are no errors in the OMS Agent log:  
@@ -81,7 +81,7 @@ If you encounter the following error in `omsagent.log`:
 Change `create 640 mysql adm` to `create 644 mysql adm`
 
 3. After changing file permissions, the OMS agent should be restarted:  
-`sudo service omsagent restart`
+`sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]`
 
 
 

--- a/docs/OMS-PostgreSQL-Instructions.md
+++ b/docs/OMS-PostgreSQL-Instructions.md
@@ -26,7 +26,7 @@
 `sudo service postgresql restart` or `/etc/init.d/postgresql restart`
 
 6. Restart the OMS agent:
-`sudo service omsagent restart`
+`sudo sh /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]`
 
 7. Confirm that there are no errors in the OMS Agent log:
 `tail /var/opt/microsoft/omsagent/log/omsagent.log`

--- a/docs/Security-Events-Preview-Configuration.md
+++ b/docs/Security-Events-Preview-Configuration.md
@@ -58,7 +58,7 @@ Collection of the following 3rd party security log types is supported:
 
 
 6. Restart the OMS Agent:  
-```sudo service omsagent restart``` or ```systemctl restart omsagent```
+```sudo /opt/microsoft/omsagent/bin/service_control restart [<workspace id>]```
 
 7. Confirm that there are no errors in the OMS Agent log:  
 ```tail /var/opt/microsoft/omsagent/log/omsagent.log```

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -175,7 +175,7 @@ This is a known issue an occurs on first upload of Linux data into an OMS worksp
 * Check if onboarding the OMS Service was successful by checking if the following file exists: `/etc/opt/microsoft/omsagent/conf/omsadmin.conf`
  * Re-onboard using the omsadmin.sh command line [instructions](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/OMS-Agent-for-Linux.md#onboarding-using-the-command-line)
 * If using a proxy, check proxy troubleshooting steps aboce
-* In some cases, when the OMS Agent for Linux cannot talk to the OMS Service, data on the Agent is backed up to the full buffer size: 50 MB. The OMS Agent for Linux should be restarted by running the following command `service omsagent restart` or `systemctl restart omsagent`.
+* In some cases, when the OMS Agent for Linux cannot talk to the OMS Service, data on the Agent is backed up to the full buffer size: 50 MB. The OMS Agent for Linux should be restarted by running the following command `/opt/microsoft/omsagent/bin/service_control restart [<workspace id>]`.
  * **Note:** This issue is fixed in Agent version >= 1.1.0-28
 
 ### My portal side configuration for (Syslog/Linux Performance Counter) is not being applied


### PR DESCRIPTION
Update docs with correct service command found [here](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/OMS-Agent-for-Linux.md#manage-omsagent-daemon)

@Microsoft/omsagent-devs @agup006 