### PR TITLE
Add -O parameter to onboarding helper script for explicit output

### DIFF
--- a/installer/scripts/onboard_agent.sh
+++ b/installer/scripts/onboard_agent.sh
@@ -72,9 +72,9 @@ fi
 # Download, install, and onboard OMSAgent for Linux, depending on architecture of machine
 if [ $(uname -m) = 'x86_64' ]; then
     # x64 architecture
-    wget ${GITHUB_RELEASE}${BUNDLE_X64} && sudo sh ./${BUNDLE_X64} ${bundleParameters}
+    wget -O ${BUNDLE_X64} ${GITHUB_RELEASE}${BUNDLE_X64} && sudo sh ./${BUNDLE_X64} ${bundleParameters}
 else
     # x86 architecture
-    wget ${GITHUB_RELEASE}${BUNDLE_X86} && sudo sh ./${BUNDLE_X86} ${bundleParameters}
+    wget -O ${BUNDLE_X86} ${GITHUB_RELEASE}${BUNDLE_X86} && sudo sh ./${BUNDLE_X86} ${bundleParameters}
 fi
 


### PR DESCRIPTION
This unblocked one customer, and it does not impact other scenarios.
While the omsagent bundle will now be downloaded under a less explicit name, the version can still be discovered by looking at installinfo.txt after the bundle has been installed.
If desired, I can add a file rename command before installing the bundle.
@Microsoft/omsagent-devs 