### PR TITLE
Ensure that proxy.conf location is backwards-compatible

### DIFF
--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -183,12 +183,7 @@ module MaintenanceModule
     # Extract proxy setting information from proxy configuration file
     def get_proxy_info
       proxy = {}
-
-      if file_exists_nonempty(@proxy_path)
-        proxy = OMS::Configuration.get_proxy_config(@proxy_path)
-        log_info("Using proxy settings from #{@proxy_path}")
-      end
-
+      proxy = OMS::Configuration.get_proxy_config(@proxy_path)
       return proxy
     end
 

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -37,6 +37,11 @@ module OMS
       end
 
       def get_proxy_config(proxy_conf_path)
+        old_proxy_conf_path = '/etc/opt/microsoft/omsagent/conf/proxy.conf'
+        if !File.exist?(proxy_conf_path) and File.exist?(old_proxy_conf_path)
+          proxy_conf_path = old_proxy_conf_path
+        end
+
         begin
           proxy_config = parse_proxy_config(File.read(proxy_conf_path))
         rescue SystemCallError # Error::ENOENT


### PR DESCRIPTION
For backwards-compatibility with agents upgraded to a bundle with the new proxy.conf location

Behavior will be to check the new location, then the old location, then assume no proxy is configured.
Plugins and the omsadmin script have been updated.

@Microsoft/omsagent-devs @KrisBash 