### PR TITLE
Changes to replace scx agent with omsagent

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -51,6 +51,7 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/bin/configure_syslog.sh;                        installer/scripts/configure_syslog.sh;                 755; root; root
 /opt/microsoft/omsagent/bin/tailfilereader.rb;                          installer/scripts/tailfilereader.rb;                   744; root; root
 /opt/microsoft/omsagent/bin/hdinsightmanifestreader.rb;                 installer/scripts/hdinsightmanifestreader.rb;          744; root; root
+/opt/microsoft/omsagent/bin/regenerate_scom_cert.sh;                    installer/scripts/regenerate_scom_cert.sh;             755; root; root
 
 /opt/microsoft/omsagent/plugin/filter_syslog.rb;                        source/code/plugins/filter_syslog.rb;                  744; root; root
 /opt/microsoft/omsagent/plugin/out_oms.rb;                              source/code/plugins/out_oms.rb;                        744; root; root
@@ -111,6 +112,14 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/agent_maintenance_script.rb;             source/code/plugins/agent_maintenance_script.rb;       744; root; root
 
 /opt/microsoft/omsagent/plugin/filter_hdinsight.rb;                     source/code/plugins/filter_hdinsight.rb;               744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_simple_match.rb;             source/code/plugins/filter_scom_simple_match.rb;       744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_excl_match.rb;               source/code/plugins/filter_scom_excl_match.rb;         744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_cor_match.rb;                source/code/plugins/filter_scom_cor_match.rb;          744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_repeated_cor.rb;             source/code/plugins/filter_scom_repeated_cor.rb;          744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_excl_correlation.rb;         source/code/plugins/filter_scom_excl_correlation.rb;          744; root; root
+/opt/microsoft/omsagent/plugin/scom_common.rb;                          source/code/plugins/scom_common.rb;                    744; root; root
+/opt/microsoft/omsagent/plugin/scom_configuration.rb;                   source/code/plugins/scom_configuration.rb;                    744; root; root
+/opt/microsoft/omsagent/plugin/out_scom.rb;                             source/code/plugins/out_scom.rb;                        744; root; root
 
 %Links
 /opt/microsoft/omsagent/bin/omsagent; /opt/microsoft/omsagent/ruby/bin/fluentd; 755; root; root
@@ -152,7 +161,6 @@ mkdir -m 755 /var/opt/microsoft/omsagent        2> /dev/null || true
 chown -R omsagent:omiusers /var/opt/microsoft/omsagent
 
 # Ditto for conf directory in /etc/opt/microsoft/omsagent/conf ...
-
 
 %Postinstall_200
 /opt/microsoft/omsagent/bin/omsadmin.sh -M

--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -102,6 +102,7 @@ ${{OMS_SERVICE}} start
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
     ${{OMS_SERVICE}} disable
+    ${{OMS_SERVICE}} disable scom
     ${{CONF_SYSLOG}} purge
 fi
 

--- a/installer/scripts/regenerate_scom_cert.sh
+++ b/installer/scripts/regenerate_scom_cert.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+set -e
+
+SCX_SSL_CONFIG=/opt/microsoft/scx/bin/tools/scxsslconfig
+SCOM_CERT_DIR=/etc/opt/microsoft/omsagent/scom/certs
+HOSTNAME=""
+DOMAIN_NAME=""
+
+usage()
+{
+    local basename=`basename $0`
+    echo "SCOM Certificate Regeneration Utility"
+    echo
+    echo "Regenerate certificate:"
+    echo "$basename [-h <hostname>] [-d <domain name>]"
+    echo 
+    echo "Help:"
+    echo "$basename -?"
+}
+
+parse_args()
+{
+    local OPTIND opt
+    while getopts "?h:d:" opt; do
+        case "$opt" in
+        \?)
+            usage
+            exit 0
+            ;;
+        h)
+            HOSTNAME=$OPTARG
+            ;;
+        d)
+            DOMAIN_NAME=$OPTARG
+            ;;
+        esac
+    done
+    shift $((OPTIND-1))
+}
+
+check_user()
+{
+    if [ `id -u` -ne "0" -a `id -un` != "omsagent" ]; then
+        echo "This script must be run as root or as the omsagent user."
+        exit 1
+    fi
+}
+
+regenerate_cert()
+{
+    echo "Regenerating SCOM certs"
+    # Generate client auth cert using scxsslconfig tool.
+    $SCX_SSL_CONFIG -c -g $SCOM_CERT_DIR -h "$HOSTNAME" -d "$DOMAIN_NAME"
+    if [ $? -ne 0 ]; then
+        echo "Error generating certs"
+        exit 1
+    fi
+    # Rename cert/key to more meaningful name
+    mv $SCOM_CERT_DIR/omi-host-*.pem $SCOM_CERT_DIR/scom-cert.pem
+    mv $SCOM_CERT_DIR/omikey.pem $SCOM_CERT_DIR/scom-key.pem
+    rm -f $SCOM_CERT_DIR/omi.pem
+    chown omsagent:omiusers $SCOM_CERT_DIR/scom-cert.pem
+    chown omsagent:omiusers $SCOM_CERT_DIR/scom-key.pem
+}
+
+check_user
+parse_args $@
+regenerate_cert

--- a/source/code/plugins/filter_scom_cor_match.rb
+++ b/source/code/plugins/filter_scom_cor_match.rb
@@ -1,0 +1,88 @@
+module Fluent
+  class SCOMCorrelatedMatchFilter < Filter
+    #Filter plugin that generates an event when first regex matches and 
+    #sceond regex matches before given time interval
+    Fluent::Plugin.register_filter('filter_scom_cor_match', self)
+    
+    desc 'stores regex on whose match timer starts'    
+    config_param :regexp1, :string, :default => nil
+    desc 'stores regex which needs to match after match for regexp1'
+    config_param :regexp2, :string, :default => nil
+    desc 'time interval before which regexp2 needs to match'
+    config_param :time_interval, :integer, :default => 0
+    desc 'event number to be sent to SCOM'
+    config_param :event_id, :string, :default => nil
+    desc 'event description to be sent to SCOM'
+    config_param :event_desc, :string, :default => nil
+        
+    attr_reader :expression1
+    attr_reader :key1
+    attr_reader :expression2
+    attr_reader :key2
+    attr_reader :time_interval
+
+    def initialize()
+      super
+      require_relative 'scom_common'
+      @exp1_found = false
+      @timer = nil
+      @lock = Mutex.new
+    end
+    
+    def start
+      super
+    end
+    
+    def shutdown
+      super
+    end
+        
+    def configure(conf)
+      super
+            
+      raise ConfigError, "Configuration does not contain 2 expressions" unless @regexp1 and @regexp2
+      raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
+      raise ConfigError, "Configuration does not have a time interval" unless @time_interval
+      @key1, exp1 = @regexp1.split(/ /,2)
+      raise ConfigError, "regexp1 does not contain 2 parameters" unless exp1
+      @expression1 = Regexp.compile(exp1)
+      @key2, exp2 = @regexp2.split(/ /,2)
+      raise ConfigError, "regexp2 does not contain 2 parameters" unless exp2
+      @expression2 = Regexp.compile(exp2)
+    end
+        
+    def flip_state()
+      @lock.synchronize {
+        @exp1_found = !@exp1_found
+      }
+    end
+        
+    def filter(tag, time, record)
+      result = record
+      #Check if a match is found for regexp1
+      if !@exp1_found and @expression1.match(record[key1].to_s)
+        # Match found, change state to exp1_found and start timer
+        flip_state()
+        @timer = Thread.new { sleep @time_interval; timer_expired() }
+        $log.debug "Match found for regex #{@regexp1} ID #{@event_id}. Timer Started."
+      end # if
+      #Check for regexp2 match if regexp1 was found
+      if @exp1_found and @expression2.match(record[key2].to_s)
+        # Match found: Change state, stop timer and form SCOM event
+        flip_state()
+        @timer.terminate()
+        @timer = nil
+        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+        $log.debug "Event found for ID #{@event_id}"
+      end # if
+      result
+    end # method filter
+        
+    def timer_expired()
+      $log.debug "Timer expired waiting for event ID #{@event_id}"
+      flip_state()
+    end
+        
+  end # class SCOMCorrelatedMatchFilter
+end # module Fluent
+

--- a/source/code/plugins/filter_scom_excl_correlation.rb
+++ b/source/code/plugins/filter_scom_excl_correlation.rb
@@ -1,0 +1,83 @@
+module Fluent
+  class SCOMExclusiveCorrelationFilter < Filter
+    #Filter plugin that generates an event when first regex matches and 
+    #sceond regex does not match before given time interval
+    Fluent::Plugin.register_filter('filter_scom_excl_correlation', self)
+    
+    desc 'stores regex on whose match timer starts'    
+    config_param :regexp1, :string, :default => nil
+    desc 'stores regex which should not match after match for regexp1'
+    config_param :regexp2, :string, :default => nil
+    desc 'time interval in which regexp2 should not occur'
+    config_param :time_interval, :integer, :default => 0
+    desc 'event number to be sent to SCOM'
+    config_param :event_id, :string, :default => nil
+    desc 'event description to be sent to SCOM'
+    config_param :event_desc, :string, :default => nil
+        
+    attr_reader :expression1
+    attr_reader :key1
+    attr_reader :expression2
+    attr_reader :key2
+    attr_reader :time_interval
+        
+    def initialize()
+      super
+      require_relative 'scom_common'
+      @exp1_found = false
+      @timer = nil
+      @lock = Mutex.new
+    end
+        
+    def configure(conf)
+      super
+            
+      raise ConfigError, "Configuration does not contain 2 expressions" unless @regexp1 and @regexp2
+      raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
+      raise ConfigError, "Configuration does not have a time interval" unless @time_interval
+      @key1, exp1 = @regexp1.split(/ /,2)
+      raise ConfigError, "regexp1 does not contain 2 parameters" unless exp1
+      @expression1 = Regexp.compile(exp1)
+      @key2, exp2 = @regexp2.split(/ /,2)
+      raise ConfigError, "regexp2 does not contain 2 parameters" unless exp2
+      @expression2 = Regexp.compile(exp2)
+    end
+        
+    def flip_state()
+      @lock.synchronize {
+        @exp1_found = !@exp1_found
+      }
+    end
+        
+    def filter(tag, time, record)
+      #Check if a match is found for regexp1
+      if !@exp1_found and @expression1.match(record[key1].to_s)
+        # Match found, change state to exp1_found and start timer
+        flip_state()
+        @timer = Thread.new { sleep @time_interval; timer_expired() }
+        $log.debug "Match found for regex #{@regexp1} ID #{@event_id}. Timer Started."
+      end # if
+      #Check for regexp2 match if regexp1 was found
+      if @exp1_found and @expression2.match(record[key2].to_s)
+        #Match found: change state and stop timer
+        flip_state()
+        @timer.terminate()
+        @timer = nil
+      end # if
+      record
+    end
+        
+    def timer_expired()
+      flip_state()
+      time = Engine.now
+      # Match for regexp2 not found within time, form SCOM event
+      result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+      $log.debug "Event found for ID #{@event_id}"
+      router.emit("scom.event", time, result)
+    end
+        
+  end # class SCOMExclusiveCorrelationFilter
+end # module Fluent
+
+
+

--- a/source/code/plugins/filter_scom_excl_match.rb
+++ b/source/code/plugins/filter_scom_excl_match.rb
@@ -1,0 +1,50 @@
+module Fluent
+  class SCOMExclusiveMatchFilter < Filter
+    #Filter plugin that generates an event when first regex matches and 
+    #sceond regex does not match in the same record
+    Fluent::Plugin.register_filter('filter_scom_excl_match', self)
+        
+    def initialize
+      super
+      require_relative 'scom_common'
+    end
+    
+    desc 'regex that needs to be match'    
+    config_param :regexp1, :string, :default => nil
+    desc 'regex that should not match'
+    config_param :regexp2, :string, :default => nil
+    desc 'event number to be sent to SCOM'
+    config_param :event_id, :string, :default => nil
+    desc 'event description to be sent to SCOM'
+    config_param :event_desc, :string, :default => nil
+        
+    attr_reader :expression1
+    attr_reader :key1
+    attr_reader :expression2
+    attr_reader :key2
+        
+    def configure(conf)
+      super
+      raise ConfigError, "Configuration does not contain 2 expressions" unless @regexp1 and @regexp2
+      raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
+      @key1, exp1 = @regexp1.split(/ /,2)
+      raise ConfigError, "regexp1 does not contain 2 parameters" unless exp1
+      @expression1 = Regexp.compile(exp1)
+      @key2, exp2 = @regexp2.split(/ /,2)
+      raise ConfigError, "regexp2 does not contain 2 parameters" unless exp2
+      @expression2 = Regexp.compile(exp2)
+    end
+        
+    def filter(tag, time, record)
+      result = record
+      #Check if regexp1 matches and regexp2 doesn't in the same record
+      if @expression1.match(record[key1].to_s) and !(@expression2.match(record[key2].to_s))
+        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+        $log.debug "Event found for ID #{@event_id}"
+      end
+      result
+    end
+        
+  end # class SCOMExclusiveMatchFilter
+end # module Fluent
+

--- a/source/code/plugins/filter_scom_repeated_cor.rb
+++ b/source/code/plugins/filter_scom_repeated_cor.rb
@@ -1,0 +1,91 @@
+module Fluent
+  class SCOMRepeatedCorrelationFilter < Filter
+    #Filter plugin that generates event when a regex matches a given 
+    #number of time in a given time interval.
+    Fluent::Plugin.register_filter('filter_scom_repeated_cor', self)
+     
+    desc 'regex that needs to match'    
+    config_param :regexp1, :string, :default => nil
+    desc 'Number of times the  regex should match'
+    config_param :num_occurences, :integer, :default => 0
+    desc 'time interval in which the match should occur'
+    config_param :time_interval, :integer, :default => 0
+    desc 'event number to be sent to SCOM'
+    config_param :event_id, :string, :default => nil
+    desc 'event description to be sent to SCOM'
+    config_param :event_desc, :string, :default => nil
+        
+    attr_reader :expression
+    attr_reader :key
+    attr_reader :time_interval
+    attr_reader :num_occurences
+        
+    def initialize()
+      super
+      require_relative 'scom_common'
+      @exp1_found = false
+      @timer = nil
+      @lock = Mutex.new
+      @counter = 0
+    end
+        
+    def configure(conf)
+      super
+            
+      raise ConfigError, "Configuration does not contain an expression" unless @regexp1
+      raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
+      raise ConfigError, "Configuration does not have a time interval" unless (@time_interval > 0)
+      raise ConfigError, "Configuration must give a value greater than 0 for num_occurences" unless (@num_occurences > 0)
+      @key, exp = @regexp1.split(/ /,2)
+      raise ConfigError, "regexp1 does not contain 2 parameters" unless exp
+      @expression = Regexp.compile(exp)
+    end
+        
+    def flip_state()
+      @lock.synchronize {
+        @exp1_found = !@exp1_found
+      }
+    end
+        
+    def reset_counter()
+      @lock.synchronize {
+        @counter = 0
+      }
+    end
+        
+    def filter(tag, time, record)
+      result = record
+       # Check if a match found for regexp1     
+      if !@exp1_found and @expression.match(record[key].to_s)
+        # Match found, change state to exp1_found and start timer
+        flip_state()
+        @counter += 1
+        $log.debug "Match found for regex #{@regexp1} ID #{@event_id}. Timer Started."
+        @timer = Thread.new { sleep @time_interval; timer_expired() }
+      elsif @exp1_found and @expression.match(record[key].to_s) 
+        @counter += 1
+      end # if
+      # Check if expected number of occurences reached
+      if @counter == @num_occurences
+        # Reset state and counter. Form SCOM event.
+        flip_state()
+        reset_counter()
+        @timer.terminate()
+        @timer = nil
+        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+        $log.debug "Event found for ID #{@event_id}"
+      end # if
+      result
+    end
+        
+    def timer_expired()
+      $log.debug "Timer expired waiting for event ID #{@event_id}"
+      flip_state()
+      reset_counter()
+    end
+        
+  end # class SCOMRepeatedCorrelationFilter
+end # module Fluent
+
+
+

--- a/source/code/plugins/filter_scom_simple_match.rb
+++ b/source/code/plugins/filter_scom_simple_match.rb
@@ -1,0 +1,66 @@
+module Fluent
+  class SCOMSimpleMatchFilter < Filter
+    # Filter plugin to generate event whenever any of the pattern 
+    # matches
+    Fluent::Plugin.register_filter('filter_scom_simple_match', self)
+    
+    def initialize
+      super
+      require_relative 'scom_common'
+    end
+    
+    REGEXP_MAX_NUM = 20
+    # List of regex for which events needs to be generated
+    (1..REGEXP_MAX_NUM).each {|i| config_param :"regexp#{i}", :string, :default => nil}
+    # Corresponding event numbers to be sent to SCOM
+    (1..REGEXP_MAX_NUM).each {|i| config_param :"event_id#{i}", :string, :default => nil}
+    # Corresponding event description to be sent to SCOM
+    (1..REGEXP_MAX_NUM).each {|i| config_param :"event_desc#{i}", :string, :default => nil}
+    
+    attr_reader :regexps
+    
+    def configure(conf)
+      super
+        
+      @regexps = {}
+
+      (1..REGEXP_MAX_NUM).each do |i|
+        next unless conf["regexp#{i}"]
+        key, regexp = conf["regexp#{i}"].split(/ /,2)
+        raise ConfigError, "regexp#{i} does not contain 2 parameters" unless regexp
+        event_id = conf["event_id#{i}"]
+        raise ConfigError, "regexp#{i} does not have corresponding event ID" unless event_id
+        event_desc = conf["event_desc#{i}"] ? conf["event_desc#{i}"] : nil
+        event = SCOM::EventHolder.new(Regexp.compile(regexp), event_id, event_desc)
+        unless @regexps[key]
+          @regexps[key] = []
+        end
+        @regexps[key].push(event)
+      end
+    end
+    
+    def start
+      super
+    end
+    
+    def shutdown
+      super
+    end
+    
+    def filter(tag, time, record)
+      result = record
+      @regexps.each do |key, events|
+        events.each do |event|
+          if event.regexp.match(record[key].to_s)
+            result = SCOM::Common.get_scom_record(time, event.event_id, event.event_desc)
+            $log.debug "Event found for ID #{event.event_id}"
+            return result
+          end # if
+        end # do |event|
+      end # do |key, events|
+      result
+    end
+    
+  end  # class SCOMSimpleMatchFilter
+end # module Fluent
+

--- a/source/code/plugins/out_scom.rb
+++ b/source/code/plugins/out_scom.rb
@@ -1,0 +1,89 @@
+module Fluent
+
+  class OutputSCOM < BufferedOutput
+
+    Plugin.register_output('out_scom', self)
+
+    def initialize
+      super
+      require 'net/http'
+      require 'net/https'
+      require 'uri'
+      require_relative 'omslog'
+      require_relative 'scom_configuration'
+      require_relative 'scom_common'
+    end
+
+    def configure(conf)
+      super
+    end
+
+    def start
+      super
+    end
+
+    def shutdown
+      super
+    end
+
+    def handle_record(tag, record)
+      @log.trace "Handling record with tag #{tag} #{record}"
+      scom_endpoint = nil
+      if record.has_key? 'CustomEvents'
+        scom_endpoint = SCOM::Configuration.scom_event_endpoint
+      elsif record.has_key? 'PerformanceDataList'
+        scom_endpoint = SCOM::Configuration.scom_perf_endpoint
+      else
+        raise 'Invalid Record: #{record}'
+      end
+      @log.debug "SCOM endpoint: #{scom_endpoint}" 
+      req = SCOM::Common.create_request(scom_endpoint.path, record)
+      unless req.nil?
+        http = SCOM::Common.create_http(scom_endpoint)
+        start = Time.now
+          
+        # This method will raise on failure alerting the engine to retry sending this data
+        SCOM::Common.start_request(req, http)
+          
+        ends = Time.now
+        time = ends - start
+        @log.debug "Success sending #{tag} in #{time.round(2)}s"
+        return true
+      end
+    rescue SCOM::RetryRequestException => e
+      @log.info "Encountered retryable exception. Will retry sending data later."
+      @log.debug "Error:'#{e}'"
+      # Re-raise the exception to inform the fluentd engine we want to retry sending this chunk of data later.
+      raise e.message
+    rescue => e
+      OMS::Log.error_once("Unexpected exception, dropping record #{record}. Error:'#{e}'")
+    end
+
+    # This method is called when an event reaches to Fluentd.
+    # Convert the event to a raw string.
+    def format(tag, time, record)
+      if (record != {}) && ((record.has_key? 'CustomEvents') || (record.has_key? 'PerformanceDataList'))
+        @log.trace "Buffering #{tag}"
+        return [tag, record].to_msgpack
+      else
+        return ""
+      end
+    end
+
+    # This method is called every flush interval.
+    # NOTE! This method is called by internal thread, not Fluentd's main thread. So IO wait doesn't affect other plugins.
+    def write(chunk)
+      # Quick exit if we are missing something
+      if !SCOM::Configuration.load_scom_configuration()
+        raise SCOM::RetryRequestException, 'Missing configuration. Make sure to run discovery.'
+      end
+      @log.trace "Writing chunk"
+      #TBD: Club similar records before sending to SCOM server
+      chunk.msgpack_each do |(tag, record)|
+        handle_record(tag, record)
+      end
+    end
+
+  end # class OutputSCOM
+
+end # module Fluent

--- a/source/code/plugins/scom_common.rb
+++ b/source/code/plugins/scom_common.rb
@@ -1,0 +1,116 @@
+module SCOM
+
+  class RetryRequestException < Exception
+    # Throw this exception to tell the fluentd engine to retry and
+    # inform the output plugin that it is indeed retryable
+  end
+
+  class EventHolder
+    def initialize(regexp, event_id, event_desc)
+      @regexp = regexp
+      @event_id = event_id
+      @event_desc = event_desc
+    end
+            
+    attr_reader :regexp
+    attr_reader :event_id
+    attr_reader :event_desc
+  end
+
+  class Common
+    require 'socket'
+    require_relative 'scom_configuration'
+    require_relative 'omslog'
+        
+    def self.get_scom_record(time, event_id, event_desc)
+      scom_record = {
+          "CustomMessage"=>event_desc,
+          "EventID"=>event_id,
+          "TimeGenerated"=>time.to_s,
+      }
+      scom_event = {
+          "HostName"=>Socket.gethostname,
+          "CustomEvents"=>[scom_record]
+      }
+      scom_event
+    end
+        
+    def self.create_request(path, record, extra_headers=nil, serializer=method(:parse_json_record_encoding))
+      headers = extra_headers.nil? ? {} : extra_headers
+      req = Net::HTTP::Post.new(path)
+      json_msg = serializer.call(add_monitoring_id(record))
+      if json_msg.nil?
+        return nil
+      end
+      req.body = json_msg
+      req['Content-Type'] = 'application/json'
+      return req
+    end
+
+    def self.add_monitoring_id(record)
+      record["MonitoringId"]=SCOM::Configuration.monitoring_id
+      event = {
+          "events"=>record
+      }
+      event
+    end
+      
+    def self.parse_json_record_encoding(record)
+      msg = nil
+      begin
+        msg = JSON.dump(record)
+      rescue => error 
+        OMS::Log.warn_once("Skipping due to failed encoding for #{record}: #{error}")
+      end
+      return msg
+    end
+      
+    def self.create_secure_http(uri)
+      http = Net::HTTP.new( uri.host, uri.port )
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.open_timeout = 30
+      return http
+    end
+
+    def self.create_http(uri)
+      http = create_secure_http(uri)
+      http.cert = SCOM::Configuration.cert
+      http.key = SCOM::Configuration.key
+      return http
+    end
+      
+    def self.start_request(req, secure_http, ignore404 = false)
+      # Tries to send the passed in request
+      # Raises an exception if the request fails.
+      # This exception should only be caught by the fluentd engine so that it retries sending this 
+      begin
+        res = nil
+        res = secure_http.start { |http|  http.request(req) }
+      rescue => e # rescue all StandardErrors
+        # Server didn't respond
+        raise RetryRequestException, "Net::HTTP.#{req.method.capitalize} raises exception: #{e.class}, '#{e.message}'"
+      else
+        if res.nil?
+          raise RetryRequestException, "Failed to #{req.method} at #{req.to_s} (res=nil)"
+        end # if
+
+        if res.is_a?(Net::HTTPSuccess)
+          return res.body
+        end # if
+
+        if ignore404 and res.code == "404"
+          return ''
+        end # if
+
+        if res.code != "200"
+          # Retry all failure error codes...
+          res_summary = "class=#{res.class.name}; code=#{res.code}; message=#{res.message}; body=#{res.body};)"
+          raise RetryRequestException, "HTTP error: #{res_summary}"
+        end # if
+
+      end # end begin
+    end # method start_request
+      
+  end # class Common
+end # module SCOM

--- a/source/code/plugins/scom_configuration.rb
+++ b/source/code/plugins/scom_configuration.rb
@@ -1,0 +1,101 @@
+module SCOM
+
+  class Configuration
+    require 'openssl'
+    require 'uri'
+        
+    require_relative 'oms_configuration'
+    require_relative 'omslog'
+        
+    @@configuration_loaded = false
+    @@scom_conf_path = '/etc/opt/microsoft/omsagent/scom/conf/omsadmin.conf'
+    @@cert_path = '/etc/opt/microsoft/omsagent/scom/certs/scom-cert.pem'
+    @@key_path =  '/etc/opt/microsoft/omsagent/scom/certs/scom-key.pem'     
+  
+    @@cert = nil
+    @@key = nil
+        
+    @@scom_endpoint = nil
+    @@scom_event_endpoint = nil
+    @@scom_perf_endpoint = nil
+    
+    @@monitoring_id = nil    
+      
+    def self.load_scom_configuration
+      return true if @@configuration_loaded
+      return false if !OMS::Configuration.test_onboard_file(@@scom_conf_path) or !OMS::Configuration.test_onboard_file(@@cert_path) or !OMS::Configuration.test_onboard_file(@@key_path) 
+            
+      begin
+        scom_endpoint_url = get_value_from_conf("SCOM_ENDPOINT")
+        if(!scom_endpoint_url)
+          return false
+        end
+        @@scom_endpoint = URI.parse( scom_endpoint_url )
+        @@scom_event_endpoint = @@scom_endpoint.clone
+        @@scom_event_endpoint.path = '/OMEDService/events'
+        @@scom_perf_endpoint = @@scom_endpoint.clone
+        @@scom_perf_endpoint.path = '/OMEDService/perf'
+      rescue => e
+        OMS::Log.error_once("Error parsing endpoint url. #{e}")
+        return false
+      end # begin
+      
+      begin
+        @@monitoring_id = get_value_from_conf("MONITORING_ID")
+        if(!monitoring_id)
+          return false
+        end
+      rescue => e
+        OMS::Log.error_once("Error parsing monitoring id. #{e}")
+        return false
+      end # begin
+             
+      begin
+        raw = File.read @@cert_path
+        @@cert = OpenSSL::X509::Certificate.new raw
+        raw = File.read @@key_path
+        @@key = OpenSSL::PKey::RSA.new raw
+      rescue => e
+        OMS::Log.error_once("Failed to read certificate or key from #{@@cert_path} #{@@key_path}")
+        return false
+      end # begin
+              
+      @@configuration_loaded = true
+      return true
+
+    end
+    
+    def self.get_value_from_conf(key)
+      lines = IO.readlines(@@scom_conf_path).select{ |line| line.start_with?(key)}
+      if lines.size == 0
+        OMS::Log.error_once("Could not find #{key} in #{conf_path}")
+        return nil
+      elsif lines.size > 1
+        OMS::Log.warn_once("Found more than one #{key} setting in #{conf_path}, will use the first one.")
+      end
+      return lines[0].split("=")[1].strip
+    end
+
+    def self.scom_event_endpoint
+      @@scom_event_endpoint
+    end
+
+    def self.cert
+      @@cert
+    end
+
+    def self.key
+      @@key
+    end
+
+    def self.monitoring_id
+      @@monitoring_id
+    end
+
+    def self.scom_perf_endpoint
+      @@scom_perf_endpoint
+    end
+
+  end # class Configuration
+end # module SCOM
+

--- a/test/code/plugins/filter_scom_cor_match_test.rb
+++ b/test/code/plugins/filter_scom_cor_match_test.rb
@@ -1,0 +1,48 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/filter_scom_cor_match'
+require 'socket'
+
+  class SCOMCorMatchTest < Test::Unit::TestCase
+    
+    def setup
+      Fluent::Test.setup
+    end
+    
+    def teardown
+    end
+    
+    CONFIG = %[
+      regexp1 message Installing package [A-Za-z0-9]*
+      regexp2 message Install failed for package [A-Za-z0-9]*
+      event_id 0001
+      event_desc TestDesc
+      time_interval 5
+    ]
+    
+    def create_driver(conf=CONFIG)
+      Fluent::Test::FilterTestDriver.new(Fluent::SCOMCorrelatedMatchFilter).configure(conf)
+    end
+    
+    def test_configure
+      d = create_driver
+      assert_equal(d.instance.expression1, Regexp.compile('Installing package [A-Za-z0-9]*'))
+      assert_equal(d.instance.expression2, Regexp.compile('Install failed for package [A-Za-z0-9]*'))
+      assert_equal(d.instance.key1, 'message')
+      assert_equal(d.instance.key2, 'message')
+      assert_equal(d.instance.time_interval, 5)
+    end
+    
+    def test_filter
+      d = create_driver
+      
+      d.run do
+        d.emit({"message"=>"Installing package Unittest1"})
+        d.emit({"message"=>"Install failed for package Unittest1"})
+      end
+      
+      assert_equal(d.emits.length, 2)
+      assert_equal(d.emits[0][2], {"message"=>"Installing package Unittest1"})
+      assert_equal(d.emits[1][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
+    end
+    
+  end

--- a/test/code/plugins/filter_scom_excl_correlation_test.rb
+++ b/test/code/plugins/filter_scom_excl_correlation_test.rb
@@ -1,0 +1,36 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/filter_scom_excl_correlation'
+require 'socket'
+
+  class SCOMExclCorTest < Test::Unit::TestCase
+    
+    def setup
+      Fluent::Test.setup
+    end
+    
+    def teardown
+    end
+    
+    CONFIG = %[
+      regexp1 message Stopping test process
+      regexp2 message Starting test process
+      event_id 0001
+      event_desc TestDesc
+      time_interval 5
+    ]
+    
+    def create_driver(conf=CONFIG)
+      Fluent::Test::FilterTestDriver.new(Fluent::SCOMExclusiveCorrelationFilter).configure(conf)
+    end
+    
+    def test_configure
+      d = create_driver
+      assert_equal(d.instance.expression1, Regexp.compile('Stopping test process'))
+      assert_equal(d.instance.expression2, Regexp.compile('Starting test process'))
+      assert_equal(d.instance.key1, 'message')
+      assert_equal(d.instance.key2, 'message')
+      assert_equal(d.instance.time_interval, 5)
+    end
+    
+  end
+

--- a/test/code/plugins/filter_scom_excl_match_test.rb
+++ b/test/code/plugins/filter_scom_excl_match_test.rb
@@ -1,0 +1,46 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/filter_scom_excl_match'
+require 'socket'
+
+  class SCOMExclMatchTest < Test::Unit::TestCase
+    
+    def setup
+      Fluent::Test.setup
+    end
+    
+    def teardown
+    end
+    
+    CONFIG = %[
+      regexp1 message Insertion of [a-z0-9]*
+      regexp2 status succeeded
+      event_id 0001
+      event_desc TestDesc
+    ]
+    
+    def create_driver(conf=CONFIG)
+      Fluent::Test::FilterTestDriver.new(Fluent::SCOMExclusiveMatchFilter).configure(conf)
+    end
+    
+    def test_configure
+      d = create_driver
+      assert_equal(d.instance.expression1, Regexp.compile('Insertion of [a-z0-9]*'))
+      assert_equal(d.instance.expression2, Regexp.compile('succeeded'))
+      assert_equal(d.instance.key1, 'message')
+      assert_equal(d.instance.key2, 'status')
+    end
+    
+    def test_filter
+      d = create_driver
+      
+      d.run do
+        d.emit({"message"=>"Insertion of doc1", "status"=>"succeeded"})
+        d.emit({"message"=>"Insertion of doc2", "status"=>"failed"})
+      end
+      
+      assert_equal(d.emits.length, 2)
+      assert_equal(d.emits[1][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
+      assert_equal(d.emits[0][2], {"message"=>"Insertion of doc1", "status"=>"succeeded"})
+    end
+    
+  end

--- a/test/code/plugins/filter_scom_repeated_cor_test.rb
+++ b/test/code/plugins/filter_scom_repeated_cor_test.rb
@@ -1,0 +1,49 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/filter_scom_repeated_cor'
+require 'socket'
+
+  class SCOMCorMatchTest < Test::Unit::TestCase
+    
+    def setup
+      Fluent::Test.setup
+    end
+    
+    def teardown
+    end
+    
+    CONFIG = %[
+      regexp1 message Authentication Failed
+      event_id 0001
+      event_desc TestDesc
+      time_interval 5
+      num_occurences 3
+    ]
+    
+    def create_driver(conf=CONFIG)
+      Fluent::Test::FilterTestDriver.new(Fluent::SCOMRepeatedCorrelationFilter).configure(conf)
+    end
+    
+    def test_configure
+      d = create_driver
+      assert_equal(d.instance.expression, Regexp.compile('Authentication Failed'))
+      assert_equal(d.instance.key, 'message')
+      assert_equal(d.instance.time_interval, 5)
+      assert_equal(d.instance.num_occurences, 3)
+    end
+    
+    def test_filter
+      d = create_driver
+      
+      d.run do
+        d.emit({"message"=>"Authentication Failed"})
+        d.emit({"message"=>"Authentication Failed"})
+        d.emit({"message"=>"Authentication Failed"})
+      end
+      
+      assert_equal(d.emits.length, 3)
+      assert_equal(d.emits[0][2], {"message"=>"Authentication Failed"})
+      assert_equal(d.emits[1][2], {"message"=>"Authentication Failed"})
+      assert_equal(d.emits[2][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
+    end
+    
+  end

--- a/test/code/plugins/filter_scom_simple_match_test.rb
+++ b/test/code/plugins/filter_scom_simple_match_test.rb
@@ -1,0 +1,51 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/filter_scom_simple_match'
+require 'socket'
+
+  class SCOMSimpleMatchTest < Test::Unit::TestCase
+    
+    def setup
+      Fluent::Test.setup
+    end
+    
+    def teardown
+    end
+    
+    CONFIG = %[
+      regexp1 message TestRegex1
+      event_id1 0001
+      event_desc1 TestDesc1
+      regexp2 message TestRegex2
+      event_id2 0002
+      event_desc2 TestDesc2
+    ]
+    
+    def create_driver(conf=CONFIG)
+      Fluent::Test::FilterTestDriver.new(Fluent::SCOMSimpleMatchFilter).configure(conf)
+    end
+    
+    def test_configure
+      d = create_driver
+      regexps = d.instance.regexps
+      assert_equal(regexps.length,1)
+      assert_equal(regexps.has_key?('message'), true)
+      assert_equal(regexps['message'].length, 2)
+    end
+    
+    def test_event
+      d = create_driver
+      
+      d.run do
+        d.emit({"message"=>"TestRegex1"})
+        d.emit({"message"=>"WrongRegex"})
+        d.emit({"message"=>"TestRegex2"})
+      end
+      
+      assert_equal(d.emits.length, 3)
+      assert_equal(d.emits[0][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc1", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[0][1]}"}]})
+      assert_equal(d.emits[2][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc2", "EventID"=>"0002", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
+      assert_equal(d.emits[1][2], {"message"=>"WrongRegex"})
+    end
+    
+  end
+

--- a/test/code/plugins/omstestlib.rb
+++ b/test/code/plugins/omstestlib.rb
@@ -10,8 +10,10 @@ module OMS
     def clear
       @logs = []
     end
-
-    def trace(message)
+    
+    #Making message optional here because a Fluentd call was throwing ArgumentError
+    # $log.trace { "registered #{name} plugin '#{type}'" } (fluentd-0.12.24/lib/fluent/plugin.rb:122)
+    def trace(message="")
       @logs << message
     end
     

--- a/test/code/plugins/out_scom_test.rb
+++ b/test/code/plugins/out_scom_test.rb
@@ -1,0 +1,69 @@
+require 'fluent/test'
+require_relative '../../../source/ext/fluentd/test/helper'
+require_relative '../../../source/code/plugins/scom_configuration'
+require_relative '../../../source/code/plugins/out_scom'
+require_relative 'omstestlib'
+
+class OutSCOMPluginTest < Test::Unit::TestCase
+  class Fluent::OutputSCOM
+
+    attr_reader :mock_data
+
+    def initialize
+      super
+      @mock_data = {}
+    end
+
+    def handle_record(tag, record)
+        unless @mock_data[tag]
+          @mock_data[tag] = []
+        end
+        @mock_data[tag].push(record)
+    end
+  end
+
+  class SCOM::Configuration
+    class << self
+      def config_loaded=(configLoaded)
+        @@configuration_loaded = configLoaded
+      end
+    end
+  end
+
+  def setup
+    Fluent::Test.setup
+    $log = OMS::MockLog.new
+  end
+
+  def teardown
+  end
+
+  def test_batch_data
+    # mock the configuration to be loaded
+    SCOM::Configuration.config_loaded = true
+
+    plugin = Fluent::OutputSCOM.new
+
+    buffer = Fluent::MemoryBufferChunk.new('memory')
+
+    chunk = ''
+    chunk << ['scom.event', {"HostName": "scomtest","CustomEvents": [{"EventID":"6000","CustomMessage": "My Message","TimeGenerated": "1476098630"}]}].to_msgpack
+    chunk << ['scom.perf', {"PerformanceDataList": [{"InstanceName": "MongoDB","ObjectName": "dnstest","TimeSampled": "1476274284","Counters": [{"CounterName": "Counter1","Value": "15"},{"CounterName": "Counter2","Value": "25"}]}]}].to_msgpack
+    chunk << ['scom.perf', {"PerformanceDataList": [{"InstanceName": "MongoDB","ObjectName": "dnstest","TimeSampled": "1476274284","Counters": [{"CounterName": "Counter1","Value": "10"},{"CounterName": "Counter2","Value": "20"}]}]}].to_msgpack
+    chunk << ['scom.event', {"HostName": "scomtest","CustomEvents": [{"EventID":"6001","CustomMessage": "My Message 1","TimeGenerated": "1476098631"}]}].to_msgpack
+    chunk << ['scom.event', {"HostName": "scomtest","CustomEvents": [{"EventID":"6002","CustomMessage": "My Message 2","TimeGenerated": "1476098632"}]}].to_msgpack
+
+    buffer << chunk
+
+    assert_nothing_raised(RuntimeError, "Failed to send data : '#{$log.logs}'") do
+      plugin.write(buffer)
+
+      assert_equal(3, plugin.mock_data['scom.event'].length)
+      assert_equal(2, plugin.mock_data['scom.perf'].length)
+      assert(plugin.mock_data['scom.event'][0].has_key?('CustomEvents'), "CustomEvents should be there")
+      assert(plugin.mock_data['scom.perf'][0].has_key?('PerformanceDataList'), "PerformanceDataList should be there")
+    end
+
+  end
+end
+


### PR DESCRIPTION
@Microsoft/omsagent-devs 
@jeffaco 

These changes allows scx agent to be replaced by omsagent on Linux platforms so that it can be used to enhance log file monitoring of SCOM XPlat monitoring.

Description:
1. Do not disable OMI port 1270 so that agent machine can be discovered by SCOM.
2. Register a secondary workspace for SCOM on the agent machine. The Fluentd process of this secondary workspace will be managed through SCOM.
3. 5 Fluentd filter plugins has been added that will generate events to be send to SCOM server.
4. An output plugin(similar to out_oms plugin) has been added to send the data to SCOM server's endpoint. 

Tests done:
1. PBUILD has been run successfully.
2. Following scenarios are tested:
        i. Only OMS (Primary workspace)
       ii. First OMS(Primary workspace) then SCOM
      iii. First SCOM then OMS(Primary workspace)
      iv. Only SCOM 