### PR TITLE
Copy container.conf to conf directory if the file exists

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -752,6 +752,7 @@ copy_omsagent_d_conf()
     cp $SYSCONF_DIR/omsagent.d/operation.conf $OMSAGENTD_DIR
     cp $SYSCONF_DIR/omi_mapping.json $OMSAGENTD_DIR
     cp $SYSCONF_DIR/omsagent.d/oms_audits.xml $OMSAGENTD_DIR
+    cp $SYSCONF_DIR/omsagent.d/container.conf $OMSAGENTD_DIR 2>/dev/null
 
     update_path $OMSAGENTD_DIR/monitor.conf
     update_path $OMSAGENTD_DIR/heartbeat.conf


### PR DESCRIPTION
@Microsoft/omsagent-devs @keikhara 
The multi-homing change resulted in `container.conf` for docker support not being accounted for when copying conf files to /etc/opt/microsoft/omsagent/**conf**/omsagent.d/ during onboarding. This change is to resolve that issue. Corresponding change to move the container.conf to `/etc/opt/microsoft/omsagent/**sysconf**/omsagent.d/ will be made in the Docker-Provider repo.