### PR TITLE
Fix bug: OMS agent logs are filling the hard disk.

### DIFF
--- a/installer/conf/omsagent.d/security_baseline.conf
+++ b/installer/conf/omsagent.d/security_baseline.conf
@@ -10,7 +10,7 @@
 <source> 
     type exec
     tag oms.security_baseline
-    command /opt/microsoft/omsagent/plugin/omsbaseline -d /etc/opt/microsoft/omsagent/conf/omsagent.d/ 
+    command sleep 60 && /opt/microsoft/omsagent/plugin/omsbaseline -d /etc/opt/microsoft/omsagent/conf/omsagent.d/ 
     format json
     run_interval 24h
 </source>

--- a/source/code/plugins/security_baseline_lib.rb
+++ b/source/code/plugins/security_baseline_lib.rb
@@ -99,7 +99,8 @@ module OMS
                         "InformationalFailedRules" => informational_failed_rules,
                         "PercentageOfPassedRules" => percentage_of_passed_rules,
                         "AssessmentId" => assessment_id,
-                        "OSName" => "Linux"
+                        "OSName" => "Linux",
+                        "BaselineType" => "Linux"
                     }
                 ] 
             }
@@ -119,7 +120,9 @@ module OMS
                 "AssessmentId" => assessment_id,
                 "OSName" => "Linux",
                 "RuleType" => "Command",
-                "RuleId" => asm_baseline_result["ruleId"]
+                "RuleId" => asm_baseline_result["ruleId"],
+                "BaselineType" => "Linux",
+                "ActualResult" => asm_baseline_result["error_text"]
             }
             return oms
         end # transform_asm_2_oms


### PR DESCRIPTION
Add Sleep to mitigate the error and log filling in case of old OMS Agent.
Add BaselineType and ActualResult attributes