### PR TITLE
Refactor proxy related test cases

### DIFF
--- a/test/installer/scripts/maintenance_systestbase.rb
+++ b/test/installer/scripts/maintenance_systestbase.rb
@@ -36,6 +36,13 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
     }
   end
 
+  def check_proxy_server_working
+    output = `curl --proxy #{TEST_PROXY_SETTING} example.com 2>/dev/null`
+    return_code = $?.to_i
+    assert_equal(0, return_code)
+    assert_match(/Example Domain/, output)
+  end
+
   def prep_omsadmin
     # Setup test onboarding script and folder
     @omsadmin_test_dir = `#{@prep_omsadmin} #{@base_dir} #{@ruby_test_dir}`.strip()
@@ -58,6 +65,7 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
     assert(@omsadmin_test_dir, "No test directory setup")
     File.write(@proxy_conf, proxy_setting)
     assert(File.file?(@proxy_conf), "Proxy conf file missing!")
+    check_proxy_server_working
   end
 
   def do_onboard(workspace_id, shared_key, should_succeed = true)

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -39,13 +39,6 @@ class OmsadminTest < MaintenanceSystemTestBase
     assert_equal("proxy_host:8080", proxy_setting, "Did not find the expected setting in the proxy conf file.")
   end
 
-  def test_proxy_server_working
-    output = `curl --proxy #{TEST_PROXY_SETTING} example.com 2>/dev/null`
-    return_code = $?.to_i
-    assert_equal(0, return_code)
-    assert_match(/Example Domain/, output)
-  end
-
   def test_onboard_proxy_sucess
     prep_proxy(TEST_PROXY_SETTING)
     output = do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)


### PR DESCRIPTION
Move proxy testing to specific tests in agent_maintenance_script_systest.rb
Call check_proxy_server_working before all system tests involving proxy.