### PR TITLE
Enable rotation of omsagent log with SELinux

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -34,6 +34,10 @@ PLUGINS_DIR := $(BASE_DIR)/source/code/plugins
 INTERMEDIATE_DIR=$(BASE_DIR)/intermediate/$(BUILD_CONFIGURATION)
 TARGET_DIR := $(BASE_DIR)/target/$(BUILD_CONFIGURATION)
 
+SEPOLICY_SRC_DIR=$(BASE_DIR)/installer/selinux
+SEPOLICY_DIR=$(INTERMEDIATE_DIR)/selinux
+SEPOLICY_DIR_EL6=$(INTERMEDIATE_DIR)/selinux.el6
+
 ifeq ($(ULINUX),1)
 # Doesn't matter what version of SSL/Ruby we use to compile or link the OMI plugin
 RUBY_DEST_DIR := $(INTERMEDIATE_DIR)/098/ruby
@@ -117,11 +121,13 @@ SYSTEST_CONFIG := $(BASE_DIR)/test/config/systest.conf
 .PHONY: all clean clean-ruby distclean clean-status kit
 .PHONY: tests test omstest unittest systemtest systemtestrb systemtestsh
 
-all : $(SCX_INTERMEDIATE_DIR) $(DSC_TARGET_DIR) $(RUBY_TESTING_DIR) $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) $(AUOMS_TARGET_DIR)/auoms-bundle-test.sh kit
+all : $(SCX_INTERMEDIATE_DIR) $(DSC_TARGET_DIR) $(RUBY_TESTING_DIR) $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) sepolicy $(AUOMS_TARGET_DIR)/auoms-bundle-test.sh kit
         # After a successful make, undo the Ruby patches for sequential builds from old branches
 	@echo "Cleaning patched Ruby files..."
 	cd $(BASE_DIR)/source/ext/ruby; git checkout -- ext/openssl/ossl_ssl.c ext/openssl/extconf.rb
 
+sepolicy : $(SEPOLICY_DIR_EL6)/omsagent-logrotate.pp $(SEPOLICY_DIR)/omsagent-logrotate.pp 
+  
 clean : clean-status
 	$(RMDIR) $(INTERMEDIATE_DIR)/source/code
 
@@ -201,6 +207,34 @@ ifeq ($(ULINUX),1)
 	$(MAKE) -C $(DSC_DIR) dsc100
 	$(MAKE) -C $(DSC_DIR) dsckit100
 	cd $(OMI_ROOT); $(RMDIR) output
+endif
+
+#--------------------------------------------------------------------------------
+# Build SELinux policy modules for omsagent-logrotate
+
+ifeq ($(ULINUX),1)
+$(SEPOLICY_DIR_EL6)/omsagent-logrotate.pp : $(SEPOLICY_SRC_DIR)/omsagent-logrotate.el6.te $(SEPOLICY_SRC_DIR)/omsagent-logrotate.fc
+	@echo "========================= Building EL6 selinux policy module for omsagent-logrotate"
+	$(MKPATH) $(SEPOLICY_DIR_EL6)
+	$(COPY) $(SEPOLICY_SRC_DIR)/omsagent-logrotate.el6.te $(SEPOLICY_DIR_EL6)/omsagent-logrotate.te
+	$(COPY) $(SEPOLICY_SRC_DIR)/omsagent-logrotate.fc $(SEPOLICY_DIR_EL6)
+	cd $(SEPOLICY_DIR_EL6); make -f /usr/share/selinux/devel/Makefile
+
+$(SEPOLICY_DIR)/omsagent-logrotate.pp : $(SEPOLICY_SRC_DIR)/omsagent-logrotate.te $(SEPOLICY_SRC_DIR)/omsagent-logrotate.fc
+	@echo "========================= Building selinux policy module for omsagent-logrotate"
+	$(MKPATH) $(SEPOLICY_DIR)
+	$(COPY) $(SEPOLICY_SRC_DIR)/omsagent-logrotate.te $(SEPOLICY_SRC_DIR)/omsagent-logrotate.fc $(SEPOLICY_DIR)
+	cd $(SEPOLICY_DIR); make -f /usr/share/selinux/devel/Makefile
+else
+$(SEPOLICY_DIR_EL6)/omsagent-logrotate.pp : $(SEPOLICY_SRC_DIR)/omsagent-logrotate.el6.te $(SEPOLICY_SRC_DIR)/omsagent-logrotate.fc
+	@echo "========================= Building EL6 selinux policy module"
+	$(MKPATH) $(SEPOLICY_DIR_EL6)
+	touch $(SEPOLICY_DIR_EL6)/omsagent-logrotate.pp
+
+$(SEPOLICY_DIR)/omsagent-logrotate.pp : $(SEPOLICY_SRC_DIR)/omsagent-logrotate.te $(SEPOLICY_SRC_DIR)/omsagent-logrotate.fc
+	@echo "========================= Building selinux policy module"
+	$(MKPATH) $(SEPOLICY_DIR)
+	touch $(SEPOLICY_DIR)/omsagent-logrotate.pp
 endif
 
 #--------------------------------------------------------------------------------

--- a/installer/datafiles/linux_rpm.data
+++ b/installer/datafiles/linux_rpm.data
@@ -1,6 +1,7 @@
 %Variables
 PERFORMING_UPGRADE_NOT: '[ "$1" -ne 1 ]'
 PACKAGE_TYPE: 'RPM'
+SEPKG_DIR_OMSAGENT: '/usr/share/selinux/packages/omsagent-logrotate'
 
 %Dependencies
 %% In omsadmin.sh: 'curl' requires 'curl',
@@ -8,3 +9,46 @@ curl
 
 omi >= 1.0.8-6
 scx >= 1.6.2-129
+
+%Files
+${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.fc;                       installer/selinux/omsagent-logrotate.fc;                                 644; root; root
+${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.te;                       installer/selinux/omsagent-logrotate.te;                                 644; root; root
+${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.el6.te;                   installer/selinux/omsagent-logrotate.el6.te;                             644; root; root
+${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.pp;                       intermediate/${{BUILD_CONFIGURATION}}/selinux/omsagent-logrotate.pp;     755; root; root
+${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.el6.pp;                   intermediate/${{BUILD_CONFIGURATION}}/selinux.el6/omsagent-logrotate.pp; 755; root; root
+
+%Directories
+/usr/share/selinux/packages;                                         755; root; root; sysdir
+/usr/share/selinux/packages/omsagent-logrotate;                      755; root; root
+
+%Postinstall_550
+if [ -e /usr/sbin/semodule ]; then
+    echo "System appears to have SELinux installed, attempting to install selinux policy module for logrotate"
+
+    SUCCESS=0
+    for POLICY_FILE in ${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.pp ${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.el6.pp; do
+        echo "  Trying ${POLICY_FILE} ..."
+        /usr/sbin/semodule -i ${POLICY_FILE} >/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            SUCCESS=1
+            break
+        fi
+    done
+
+    if [ $SUCCESS -eq 0 ]; then
+        echo "ERROR: None of the available omsagent-logrotate selinux policy module versions could be installed"
+        exit 0
+    fi
+
+    echo "  Labeling omsagent log files ..."
+    /sbin/restorecon -R -v /var/opt/microsoft/omsagent/*/log
+fi
+
+%Postuninstall_5
+if [ -e /usr/sbin/semodule ]; then
+    if [ ! -z "$(/usr/sbin/semodule -l | grep omsagent-logrotate)" ]; then
+        echo "Removing selinux policy module for omsagent-logrotate ..."
+        /usr/sbin/semodule -r omsagent-logrotate
+        /sbin/restorecon -R -v /var/opt/microsoft/omsagent/*/log
+    fi
+fi

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -859,6 +859,13 @@ configure_logrotate()
     if [ ! -f /etc/logrotate.d/omsagent-$WORKSPACE_ID ]; then
         cat $SYSCONF_DIR/logrotate.conf | sed "s/%WORKSPACE_ID%/$WORKSPACE_ID/g" > /etc/logrotate.d/omsagent-$WORKSPACE_ID
     fi
+
+    # Load selinux policy module for logrotate for secondary workspace if selinux is present
+    SEPKG_DIR_OMSAGENT=/usr/share/selinux/packages/omsagent-logrotate
+    if [ -n "$MULTI_HOMING_MARKER" -a -e /usr/sbin/semodule -a -d "$SEPKG_DIR_OMSAGENT" ]; then
+        echo "  Labeling omsagent log file for workspace $WORKSPACE_ID ..."
+        /sbin/restorecon -R -v $VAR_DIR/*/log
+    fi
 }
 
 main()

--- a/installer/selinux/omsagent-logrotate.el6.te
+++ b/installer/selinux/omsagent-logrotate.el6.te
@@ -1,0 +1,14 @@
+module omsagent-logrotate 1.0;
+
+require {
+        type var_log_t;
+        type logrotate_t;
+        class file getattr;
+        class dir write;
+}
+
+#============= logrotate_t ==============
+
+allow logrotate_t var_log_t:dir write;
+allow logrotate_t var_log_t:file getattr;
+

--- a/installer/selinux/omsagent-logrotate.fc
+++ b/installer/selinux/omsagent-logrotate.fc
@@ -1,0 +1,1 @@
+/var/opt/microsoft/omsagent/[^/]*/log(/.*)?         system_u:object_r:var_log_t:s0

--- a/installer/selinux/omsagent-logrotate.te
+++ b/installer/selinux/omsagent-logrotate.te
@@ -1,0 +1,13 @@
+module omsagent-logrotate 1.0;
+
+require {
+        type user_tmp_t;
+        type var_log_t;
+        type logrotate_t;
+        class file { getattr write };
+}
+
+#============= logrotate_t ==============
+allow logrotate_t user_tmp_t:file write;
+allow logrotate_t var_log_t:file getattr;
+


### PR DESCRIPTION
@Microsoft/omsagent-devs 
same PR as https://github.com/Microsoft/OMS-Agent-for-Linux/pull/373, which wasn't merged
This PR has additional change in the onboarding script that labels the omsagent log folder and its files with the selinux policy for omsagent-logrotate for every new secondary workspace that is added.