### PR TITLE
Patching FluentD in_exec plugin with ensure sleep

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -174,7 +174,7 @@ clean-auoms : clean
 distclean : clean clean-ruby clean-dsc clean-scx clean-auoms
 	-$(RMDIR) $(OMI_ROOT)/output*
 
-	cd $(BASE_DIR)/source/ext/fluentd; git checkout -- lib/fluent/env.rb
+	cd $(BASE_DIR)/source/ext/fluentd; git checkout -- lib/fluent/env.rb lib/fluent/plugin/in_exec.rb
 	cd $(BASE_DIR)/source/ext/ruby; git checkout -- ext/openssl/ossl_ssl.c ext/openssl/extconf.rb
 	-$(RM) $(BASE_DIR)/build/Makefile.version
 	-$(RM) $(BASE_DIR)/build/config.mak

--- a/build/configure
+++ b/build/configure
@@ -230,6 +230,10 @@ apply_patch ${base_dir}/source/ext/patches/ruby/clear_options.patch ${base_dir}/
 # Upgrading to a version higher than Ruby 2.3 may already include this patch
 apply_patch ${base_dir}/source/ext/patches/ruby/SSLv2_SSLv3_method.patch ${base_dir}/source/ext/ruby/ext/openssl/extconf.rb
 
+# This patch is borrowed from FluentD 0.12.32 to resolve in_exec plugin failing repeatedly with command or parsing failing
+# Updating FluentD to version 0.12.32 or later may already include this patch
+apply_patch ${base_dir}/source/ext/patches/fluentd/in_exec.patch ${base_dir}/source/ext/fluentd/lib/fluent/plugin/in_exec.rb
+
 # No errors allowed from this point forward
 set -e
 

--- a/source/ext/patches/fluentd/in_exec.patch
+++ b/source/ext/patches/fluentd/in_exec.patch
@@ -1,0 +1,15 @@
+--- in_exec_old.rb	2017-02-08 11:08:11.000000000 -0800
++++ in_exec.rb	2017-02-08 11:11:22.000000000 -0800
+@@ -140,10 +140,11 @@
+           io = IO.popen(@command, "r")
+           @parser.call(io)
+           Process.waitpid(io.pid)
+-          sleep @run_interval
+         rescue
+           log.error "exec failed to run or shutdown child process", error: $!.to_s, error_class: $!.class.to_s
+           log.warn_backtrace $!.backtrace
++        ensure
++          sleep @run_interval
+         end
+       end
+     end


### PR DESCRIPTION
This patch is from FluentD commit https://github.com/fluent/fluentd/commit/0d5b43452a3d4dc19bb78aaa7dae50a4bba6585c

@Microsoft/omsagent-devs 

This resolves the in_exec error explosions we've seen. pBuild is running now.