### PR TITLE
Adding shutdown -r command to omsagent

### DIFF
--- a/installer/conf/sudoers
+++ b/installer/conf/sudoers
@@ -34,6 +34,9 @@ omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsagent/ruby/bin/ruby /opt/microsof
 # Enable nxOMSAuditdResource
 omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsconfig/Scripts/OMSAuditdPlugin.sh
 
+#Enable shutdown for update management
+omsagent ALL=(ALL) NOPASSWD: /sbin/shutdown -r *
+
 #run update management commands
 omsagent ALL=(ALL) NOPASSWD: /usr/bin/apt-get dist-upgrade *
 omsagent ALL=(ALL) NOPASSWD: /usr/bin/apt-get update


### PR DESCRIPTION
@omsagent-devs

Update management through automation worker restarts the system after installation of the updates.
this change will allow the patch runbook to initiate a restart.  

the change will be removed once the automation worker specific user is added