### PR TITLE
Send FQDN in place of Hostname to SCOM server

### DIFF
--- a/source/code/plugins/filter_scom_repeated_cor.rb
+++ b/source/code/plugins/filter_scom_repeated_cor.rb
@@ -7,7 +7,7 @@ module Fluent
     desc 'regex that needs to match'    
     config_param :regexp1, :string, :default => nil
     desc 'Number of times the  regex should match'
-    config_param :num_occurences, :integer, :default => 0
+    config_param :num_occurrences, :integer, :default => 0
     desc 'time interval in which the match should occur'
     config_param :time_interval, :integer, :default => 0
     desc 'event number to be sent to SCOM'
@@ -18,7 +18,7 @@ module Fluent
     attr_reader :expression
     attr_reader :key
     attr_reader :time_interval
-    attr_reader :num_occurences
+    attr_reader :num_occurrences
         
     def initialize()
       super
@@ -35,7 +35,7 @@ module Fluent
       raise ConfigError, "Configuration does not contain an expression" unless @regexp1
       raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
       raise ConfigError, "Configuration does not have a time interval" unless (@time_interval > 0)
-      raise ConfigError, "Configuration must give a value greater than 0 for num_occurences" unless (@num_occurences > 0)
+      raise ConfigError, "Configuration must give a value greater than 0 for num_occurrences" unless (@num_occurrences > 0)
       @key, exp = @regexp1.split(/ /,2)
       raise ConfigError, "regexp1 does not contain 2 parameters" unless exp
       @expression = Regexp.compile(exp)
@@ -66,7 +66,7 @@ module Fluent
         @counter += 1
       end # if
       # Check if expected number of occurences reached
-      if @counter == @num_occurences
+      if @counter == @num_occurrences
         # Reset state and counter. Form SCOM event.
         flip_state()
         reset_counter()

--- a/source/code/plugins/scom_common.rb
+++ b/source/code/plugins/scom_common.rb
@@ -18,7 +18,6 @@ module SCOM
   end
 
   class Common
-    require 'socket'
     require_relative 'scom_configuration'
     require_relative 'omslog'
         
@@ -29,16 +28,14 @@ module SCOM
           "TimeGenerated"=>time.to_s,
       }
       scom_event = {
-          "HostName"=>Socket.gethostname,
           "CustomEvents"=>[scom_record]
       }
       scom_event
     end
         
     def self.create_request(path, record, extra_headers=nil, serializer=method(:parse_json_record_encoding))
-      headers = extra_headers.nil? ? {} : extra_headers
       req = Net::HTTP::Post.new(path)
-      json_msg = serializer.call(add_monitoring_id(record))
+      json_msg = serializer.call(add_scom_data(record))
       if json_msg.nil?
         return nil
       end
@@ -47,8 +44,9 @@ module SCOM
       return req
     end
 
-    def self.add_monitoring_id(record)
+    def self.add_scom_data(record)
       record["MonitoringId"]=SCOM::Configuration.monitoring_id
+      record["HostName"]=SCOM::Configuration.fqdn
       event = {
           "events"=>record
       }

--- a/source/code/plugins/scom_configuration.rb
+++ b/source/code/plugins/scom_configuration.rb
@@ -6,6 +6,7 @@ module SCOM
         
     require_relative 'oms_configuration'
     require_relative 'omslog'
+    require_relative 'oms_common'
         
     @@configuration_loaded = false
     @@scom_conf_path = '/etc/opt/microsoft/omsagent/scom/conf/omsadmin.conf'
@@ -19,7 +20,8 @@ module SCOM
     @@scom_event_endpoint = nil
     @@scom_perf_endpoint = nil
     
-    @@monitoring_id = nil    
+    @@monitoring_id = nil
+    @@fqdn = nil    
       
     def self.load_scom_configuration
       return true if @@configuration_loaded
@@ -59,11 +61,15 @@ module SCOM
         OMS::Log.error_once("Failed to read certificate or key from #{@@cert_path} #{@@key_path}")
         return false
       end # begin
+       
+      @@fqdn = OMS::Common.get_fully_qualified_domain_name
+      if(!@@fqdn)
+        return false
+      end # if
               
       @@configuration_loaded = true
       return true
-
-    end
+    end # method load_configuration
     
     def self.get_value_from_conf(key)
       lines = IO.readlines(@@scom_conf_path).select{ |line| line.start_with?(key)}
@@ -94,6 +100,10 @@ module SCOM
 
     def self.scom_perf_endpoint
       @@scom_perf_endpoint
+    end
+    
+    def self.fqdn
+      @@fqdn
     end
 
   end # class Configuration

--- a/test/code/plugins/filter_scom_cor_match_test.rb
+++ b/test/code/plugins/filter_scom_cor_match_test.rb
@@ -42,7 +42,7 @@ require 'socket'
       
       assert_equal(d.emits.length, 2)
       assert_equal(d.emits[0][2], {"message"=>"Installing package Unittest1"})
-      assert_equal(d.emits[1][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
+      assert_equal(d.emits[1][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
     end
     
   end

--- a/test/code/plugins/filter_scom_excl_match_test.rb
+++ b/test/code/plugins/filter_scom_excl_match_test.rb
@@ -39,7 +39,7 @@ require 'socket'
       end
       
       assert_equal(d.emits.length, 2)
-      assert_equal(d.emits[1][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
+      assert_equal(d.emits[1][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
       assert_equal(d.emits[0][2], {"message"=>"Insertion of doc1", "status"=>"succeeded"})
     end
     

--- a/test/code/plugins/filter_scom_repeated_cor_test.rb
+++ b/test/code/plugins/filter_scom_repeated_cor_test.rb
@@ -2,7 +2,7 @@ require 'fluent/test'
 require_relative '../../../source/code/plugins/filter_scom_repeated_cor'
 require 'socket'
 
-  class SCOMCorMatchTest < Test::Unit::TestCase
+  class SCOMRepeatedCorTest < Test::Unit::TestCase
     
     def setup
       Fluent::Test.setup
@@ -16,7 +16,7 @@ require 'socket'
       event_id 0001
       event_desc TestDesc
       time_interval 5
-      num_occurences 3
+      num_occurrences 3
     ]
     
     def create_driver(conf=CONFIG)
@@ -28,7 +28,7 @@ require 'socket'
       assert_equal(d.instance.expression, Regexp.compile('Authentication Failed'))
       assert_equal(d.instance.key, 'message')
       assert_equal(d.instance.time_interval, 5)
-      assert_equal(d.instance.num_occurences, 3)
+      assert_equal(d.instance.num_occurrences, 3)
     end
     
     def test_filter
@@ -43,7 +43,7 @@ require 'socket'
       assert_equal(d.emits.length, 3)
       assert_equal(d.emits[0][2], {"message"=>"Authentication Failed"})
       assert_equal(d.emits[1][2], {"message"=>"Authentication Failed"})
-      assert_equal(d.emits[2][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
+      assert_equal(d.emits[2][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
     end
     
   end

--- a/test/code/plugins/filter_scom_simple_match_test.rb
+++ b/test/code/plugins/filter_scom_simple_match_test.rb
@@ -42,8 +42,8 @@ require 'socket'
       end
       
       assert_equal(d.emits.length, 3)
-      assert_equal(d.emits[0][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc1", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[0][1]}"}]})
-      assert_equal(d.emits[2][2], {"HostName"=>"#{Socket.gethostname}", "CustomEvents"=>[{"CustomMessage"=>"TestDesc2", "EventID"=>"0002", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
+      assert_equal(d.emits[0][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc1", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[0][1]}"}]})
+      assert_equal(d.emits[2][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc2", "EventID"=>"0002", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
       assert_equal(d.emits[1][2], {"message"=>"WrongRegex"})
     end
     


### PR DESCRIPTION
@lagalbra 
@Microsoft/omsagent-devs 

Short description of changes:
1. FQDN needs to be send in place of Hostname to SCOM server.
2. Resolved few warnings occurring in SCOM plugins unittest.
3. Corrected a typo in repeated correlation plugin 

PBUILD has been run successfully for these changes.