### PR TITLE
Bugfixes for logrotate

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -2,7 +2,7 @@
 SHELL_HEADER:            '#!/bin/sh'
 OMSHOME:                 '/opt/microsoft/omsagent'
 CONF_DIR:                '/etc/opt/microsoft/omsagent/conf'
-
+SYSCONF_DIR:             '/etc/opt/microsoft/omsagent/sysconf'
 SHORT_NAME:              'omsagent'
 SHORT_NAME_PREFIX:       'MSFT'
 LONG_NAME:               'Microsoft Operations Management Suite for UNIX/Linux agent'
@@ -168,6 +168,13 @@ chown -R omsagent:omiusers /var/opt/microsoft/omsagent
 %Postinstall_300
 if [ -f /etc/omsagent-onboard.conf ]; then
     /opt/microsoft/omsagent/bin/omsadmin.sh
+else
+    # Create a logrotate conf file for the Primary workspace if it does not already exist
+    # This is needed when upgrading from old omsagent to multi-homing enabled version
+    PRIMARY_WSID=`grep WORKSPACE_ID ${{CONF_DIR}}/omsadmin.conf | cut -d= -f2` > /dev/null 2>&1
+    if [ "$PRIMARY_WSID" -a ! -f /etc/logrotate.d/omsagent-$PRIMARY_WSID ]; then
+        cat ${{SYSCONF_DIR}}/logrotate.conf | sed "s/%WORKSPACE_ID%/$PRIMARY_WSID/g" > /etc/logrotate.d/omsagent-$PRIMARY_WSID
+    fi
 fi
 
 %Postuninstall_10
@@ -190,6 +197,9 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
    rm -rf /etc/opt/microsoft/omsagent 2> /dev/null
    rmdir /etc/opt/microsoft 2> /dev/null
    rmdir /etc/opt 2> /dev/null
+
+   # Clean up logrotate
+   rm -f /etc/logrotate.d/omsagent*
 fi
 
 %Preinstall_0

--- a/installer/datafiles/linux_rpm.data
+++ b/installer/datafiles/linux_rpm.data
@@ -40,8 +40,8 @@ if [ -e /usr/sbin/semodule ]; then
         exit 0
     fi
 
-    echo "  Labeling omsagent log files ..."
-    /sbin/restorecon -R -v /var/opt/microsoft/omsagent/*/log
+    # Labeling omsagent log files 
+    /sbin/restorecon -R /var/opt/microsoft/omsagent/*/log > /dev/null 2>&1
 fi
 
 %Postuninstall_5
@@ -49,6 +49,5 @@ if [ -e /usr/sbin/semodule ]; then
     if [ ! -z "$(/usr/sbin/semodule -l | grep omsagent-logrotate)" ]; then
         echo "Removing selinux policy module for omsagent-logrotate ..."
         /usr/sbin/semodule -r omsagent-logrotate
-        /sbin/restorecon -R -v /var/opt/microsoft/omsagent/*/log
     fi
 fi

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -860,11 +860,11 @@ configure_logrotate()
         cat $SYSCONF_DIR/logrotate.conf | sed "s/%WORKSPACE_ID%/$WORKSPACE_ID/g" > /etc/logrotate.d/omsagent-$WORKSPACE_ID
     fi
 
-    # Load selinux policy module for logrotate for secondary workspace if selinux is present
+    # Label omsagent log files according to selinux policy module for logrotate if selinux is present
     SEPKG_DIR_OMSAGENT=/usr/share/selinux/packages/omsagent-logrotate
-    if [ -n "$MULTI_HOMING_MARKER" -a -e /usr/sbin/semodule -a -d "$SEPKG_DIR_OMSAGENT" ]; then
-        echo "  Labeling omsagent log file for workspace $WORKSPACE_ID ..."
-        /sbin/restorecon -R -v $VAR_DIR/*/log
+    if [ -e /usr/sbin/semodule -a -d "$SEPKG_DIR_OMSAGENT" ]; then
+        # Label omsagent log file for this $WORKSPACE_ID 
+        /sbin/restorecon -R $VAR_DIR/*/log > /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
 - Create new logrotate conf for primaryWS during
   --upgrade from an old agent to a newer agent
   that has multihoming enabled
 - Remove multi-homing condition when labeling
   omsagent log files with selinux policy. Now,
   the log files are labelled even in cases where
   --install is run without onboarding, and then
   omsadmin.sh is run to onboard
 - Clean up all /etc/logrotate.d/omsagent-WSID files

@Microsoft/omsagent-devs 