### PR TITLE
Adding nxautomation user and changing oms cert permission

### DIFF
--- a/installer/conf/sudoers
+++ b/installer/conf/sudoers
@@ -37,6 +37,14 @@ omsagent ALL=(ALL) NOPASSWD: /opt/microsoft/omsconfig/Scripts/OMSAuditdPlugin.sh
 #Enable shutdown for update management
 omsagent ALL=(ALL) NOPASSWD: /sbin/shutdown -r *
 
+# Enable nxAutomationWorker scenarios
+Defaults:nxautomation !requiretty
+Defaults:nxautomation lecture = never
+nxautomation ALL=(ALL) NOPASSWD: ALL
+omsagent ALL=(ALL) NOPASSWD: /usr/bin/python /opt/microsoft/omsconfig/modules/nxOMSAutomationWorker/DSCResources/MSFT_nxOMSAutomationWorkerResource/automationworker/worker/main.py *
+omsagent ALL=(ALL) NOPASSWD: /usr/bin/python /opt/microsoft/omsconfig/modules/nxOMSAutomationWorker/DSCResources/MSFT_nxOMSAutomationWorkerResource/automationworker/worker/omsutil.py *
+omsagent ALL=(ALL) NOPASSWD: /usr/bin/pkill -u nxautomation *
+
 #run update management commands
 omsagent ALL=(ALL) NOPASSWD: /usr/bin/apt-get dist-upgrade *
 omsagent ALL=(ALL) NOPASSWD: /usr/bin/apt-get update

--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -74,6 +74,24 @@ fi
 # Ensure omsagent is in the omiusers group, but leave omsagent as a group
 /usr/sbin/usermod -g omiusers omsagent 1> /dev/null 2> /dev/null
 
+# Add the 'nxautomation' group if it does not already exist
+# (Can't use useradd with -U since that doesn't exist on older systems)
+egrep -q "^nxautomation:" /etc/group
+if [ $? -ne 0 ]; then
+    echo "Creating nxautomation group ..."
+    groupadd -r nxautomation
+fi
+
+# Add the 'nxautomation' service account if it does not already exist
+egrep -q "^nxautomation:" /etc/passwd
+if [ $? -ne 0 ]; then
+    echo "Creating nxautomation service account ..."
+    useradd -r -c "nxOMSAutomation" -d /var/opt/microsoft/omsagent/run -g nxautomation -s /bin/bash nxautomation
+fi
+
+# Ensure nxautomation is in the nxautomation group (primary), omsagent group (secondary) and omiusers group (secondary)
+/usr/sbin/usermod -g nxautomation -a -G omsagent -G omiusers nxautomation 1> /dev/null 2> /dev/null
+
 %Postinstall_500
 #include Sudoer_Functions
 
@@ -94,6 +112,12 @@ else
 fi
 
 chmod 440 /etc/opt/microsoft/omsagent/sysconf/sudoers
+
+# Set group read permission on OMS cert and key files used by the primary workspace
+OMS_CERTS_DIR="/etc/opt/microsoft/omsagent/certs"
+if [ -d "$OMS_CERTS_DIR" ]; then
+    chmod -R 750 "$OMS_CERTS_DIR"
+fi
 
 %Postinstall_600
 ${{OMS_SERVICE}} start
@@ -118,12 +142,19 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
     # Unconfigure sudo if it's already configured
     RemoveSudoersSupport
 
-    # Remove the service account
+    # Remove the service accounts
+    echo "Deleting nxautomation service account ..."
+    userdel nxautomation 2> /dev/null
     echo "Deleting omsagent service account ..."
     userdel omsagent 2> /dev/null
 
     if [ $? -eq 0 ]; then
-        # Depending on system settings, the group may not have been deleted
+        # Depending on system settings, the groups may not have been deleted
+        egrep -q "^nxautomation:" /etc/group
+        if [ $? -eq 0 ]; then
+            echo "Deleting nxautomation group ..."
+            groupdel nxautomation
+        fi
         egrep -q "^omsagent:" /etc/group
         if [ $? -eq 0 ]; then
             echo "Deleting omsagent group ..."

--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -398,8 +398,8 @@ module MaintenanceModule
       # Set safe certificate permissions before to prevent timing attacks
       key_file = File.new(@key_path, "w")
       cert_file = File.new(@cert_path, "w")
-      File.chmod(0600, @key_path)
-      File.chmod(0600, @cert_path)
+      File.chmod(0640, @key_path)
+      File.chmod(0640, @cert_path)
       chown_omsagent([@key_path, @cert_path])
 
       begin


### PR DESCRIPTION
These changes will allow Azure automation hybrid scenarios (update, take action, hybrid diy). The Linux hybrid worker will now run as it's own user and the worker will be started by the omsagent user through the main.py entrypoint). By default runbook have to be signed to be executed.

These changes were built and tested many time (tested for both install and uninstall).

Included in this review : 
- nxautomation user creation / deletion in install script
- change certificate folder permission to allow group read / folder execute 

These change were already reviewed (at high-level) by @KrisBash and Lee Holmes.

@Microsoft/omsagent-devs, @D1v38om83r, @sourabhguha 