### PR TITLE
Restrict default file permissions for buffer vulnerability

### DIFF
--- a/source/ext/patches/fluentd/env.rb
+++ b/source/ext/patches/fluentd/env.rb
@@ -19,6 +19,6 @@ module Fluent
   DEFAULT_PLUGIN_DIR = ENV['FLUENT_PLUGIN'] || '/opt/microsoft/omsagent/plugin'
   DEFAULT_SOCKET_PATH = ENV['FLUENT_SOCKET'] || '/var/opt/microsoft/omsagent/run/omsagent.sock'
   DEFAULT_LISTEN_PORT = 25224
-  DEFAULT_FILE_PERMISSION = 0644
+  DEFAULT_FILE_PERMISSION = 0640
   DEFAULT_DIR_PERMISSION = 0755
 end


### PR DESCRIPTION
@Microsoft/omsagent-devs @KrisBash 

This change is intended to restrict access to files, such as output buffer files, to root and the omsagent user.

Unit and system tests pass; onboarding succeeds and heartbeat data is sent to the portal.