### PR TITLE
Fix in_exec patch file reference so that it gets applied during configure

### DIFF
--- a/source/ext/patches/fluentd/in_exec.patch
+++ b/source/ext/patches/fluentd/in_exec.patch
@@ -1,5 +1,5 @@
---- in_exec_old.rb	2017-02-08 11:08:11.000000000 -0800
-+++ in_exec.rb	2017-02-08 11:11:22.000000000 -0800
+--- ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb	2017-03-02 15:44:49.000000000 -0800
++++ ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb.new	2017-03-02 15:49:09.000000000 -0800
 @@ -140,10 +140,11 @@
            io = IO.popen(@command, "r")
            @parser.call(io)


### PR DESCRIPTION
@Microsoft/omsagent-devs @sugr4 

The paths in the patch file needed to be relative to the directory that the apply_patch method was checked.