### PR TITLE
Improve warning message from service_control when onboarding fails

### DIFF
--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -35,7 +35,7 @@ setup_variables()
         if [ -f $ETC_DIR/$1/conf/omsadmin.conf ]; then
             . "$ETC_DIR/$1/conf/omsadmin.conf"
         else
-            echo "Warning: Specified workspace $1 doesn't exist"
+            echo "Warning: Specified workspace $1 does not exist on the machine. Check the correctness of the workspace ID and that onboarding succeeded."
             exit 0
         fi
     fi


### PR DESCRIPTION
@sugr4 @Microsoft/omsagent-devs 

This warning message is shown when the bundle is installed but onboarding fails; service_control is called and gives the message that the workspace "doesn't exist", when in fact it does, just not in the context of the machine.