### PR TITLE
Remove VERIFY_NONE from SSL verification process

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -672,7 +672,7 @@ module OMS
                                 proxy[:addr], proxy[:port], proxy[:user], proxy[:pass])
         end
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         http.open_timeout = 30
         return http
       end # create_secure_http


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Prevent unknown endpoints from accepting data from the agent by checking the SSL certificate in HTTP requests.