### PR TITLE
Correct URL linking in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ We love feedback!  Whether it be good, bad or indifferent, it really helps us bu
 
 ## Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct]
-(https://opensource.microsoft.com/codeofconduct/).  For more
-information see the [Code of Conduct FAQ]
-(https://opensource.microsoft.com/codeofconduct/faq/) or contact
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).  For more
+information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
 [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
 additional questions or comments.


### PR DESCRIPTION
@Microsoft/omsagent-devs @keikhara
The URLs are now displayed separately from the text they're supposed to be associated with.

Same type of changes as superproject PR https://github.com/Microsoft/Build-OMS-Agent-for-Linux/pull/22