### PR TITLE
Stop requiring OMI packages to be in bundle

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -343,15 +343,6 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 
 	@echo "========================= Performing Building .tar file"
 
-	# Note: We take care to only copy the latest version of OMI if there are multiple versions
-	$(RM) $(INTERMEDIATE_DIR)/098/omi-*.{rpm,deb} $(INTERMEDIATE_DIR)/100/omi-*.{rpm,deb}
-
-	cd $(OMI_ROOT)/output_openssl_0.9.8/release; $(COPY) `ls omi-*.rpm | sort | tail -1` $(INTERMEDIATE_DIR)/098
-	cd $(OMI_ROOT)/output_openssl_0.9.8/release; $(COPY) `ls omi-*.deb | sort | tail -1` $(INTERMEDIATE_DIR)/098
-
-	cd $(OMI_ROOT)/output_openssl_1.0.0/release; $(COPY) `ls omi-*.rpm | sort | tail -1` $(INTERMEDIATE_DIR)/100
-	cd $(OMI_ROOT)/output_openssl_1.0.0/release; $(COPY) `ls omi-*.deb | sort | tail -1` $(INTERMEDIATE_DIR)/100
-
 	# Gather the DSC bits that we need
 	$(RM) $(INTERMEDIATE_DIR)/098/omsconfig-*.{rpm,deb} $(INTERMEDIATE_DIR)/100/omsconfig-*.{rpm,deb}
 


### PR DESCRIPTION
@Microsoft/omsagent-devs @jeffaco 

The OMSAgent bundle no longer uses OMI packages since this commit: https://github.com/Microsoft/OMS-Agent-for-Linux/commit/cf1e6a9d9d65aaed7d6c7e7c1dd6d4726230560e
The OMI project no longer builds packages by default since this commit, not yet in their stable branch: https://github.com/Microsoft/omi/commit/bdade32932ac41a7906cd15fc1ea83867a19197d
This change is merely to stop copying them into our directory to be tarred. Without this change, once the OMI commit goes into stable branch, or builds will fail.

Unit and system tests have run successfully. Basic onboarding and sending data to OMS portal have been verified.