### PR TITLE
Improve detection of MDSD

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -627,9 +627,10 @@ if [ "$installMode" = "R" -o "$installMode" = "P" ]; then
 
         MDSD_INSTALLED=1
         check_if_pkg_is_installed azsec-mdsd
-        if [ $? -eq 0 -o -d /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-*/mdsd ]; then
-            MDSD_INSTALLED=0
-        fi
+        [ $? -eq 0 ] && MDSD_INSTALLED=0
+        [ -d /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-*/mdsd ] && MDSD_INSTALLED=0
+        [ -f /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-*/bin/mdsd ] && MDSD_INSTALLED=0
+        [ -f /var/lib/waagent/Microsoft.Azure.Diagnostics.LinuxDiagnostic-*/bin/mdsd ] && MDSD_INSTALLED=0
 
         if [ $MDSD_INSTALLED -ne 0 -o "$installMode" = "P" ]; then
             if [ -f /opt/microsoft/scx/bin/uninstall ]; then

--- a/installer/scripts/uninstall.sh
+++ b/installer/scripts/uninstall.sh
@@ -68,9 +68,11 @@ pkg_rm omsagent
 
 MDSD_INSTALLED=1
 check_if_pkg_is_installed azsec-mdsd
-if [ $? -eq 0 -o -d /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-*/mdsd ]; then
-    MDSD_INSTALLED=0
-fi
+[ $? -eq 0 ] && MDSD_INSTALLED=0
+[ -d /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-*/mdsd ] && MDSD_INSTALLED=0
+[ -f /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-*/bin/mdsd ] && MDSD_INSTALLED=0
+[ -f /var/lib/waagent/Microsoft.Azure.Diagnostics.LinuxDiagnostic-*/bin/mdsd ] && MDSD_INSTALLED=0
+
 if [ $MDSD_INSTALLED -ne 0 -o "$installMode" = "P" ]; then
     if [ -f /opt/microsoft/scx/bin/uninstall ]; then
 	/opt/microsoft/scx/bin/uninstall $installMode


### PR DESCRIPTION
@Microsoft/omsagent-devs @hosungsmsft 

This change is to improve the detection of mdsd on the machine when removing OMSAgent.
If OMSAgent is removed (and not purged), then SCX/OMI packages will not be removed if mdsd is detected on the machine. This will be true when LinuxAsm or LinuxDiagnostic extensions are installed on the machine, which are dependent on SCX/OMI packages.
Those teams have been notified and their explicit package dependencies will also be improved from their side.

I have verified that the omsagent built with this change does detect and does not remove SCX/OMI packages in the --remove scenario.
Unit and system tests have passed.
pBuild is currently running.