### PR TITLE
add temporary workaround

### DIFF
--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -137,13 +137,16 @@ The proxy configuration value has the following syntax:
 Property|Description
 -|-
 Protocol|http or https
-user|Optional username for proxy authentication
-password|Optional password for proxy authentication
+user|username for proxy authentication
+password|password for proxy authentication
 proxyhost|Address or FQDN of the proxy server
 port|Optional port number for the proxy server
 
 For example:
 http://user01:password@proxy01.contoso.com:8080
+
+*Note: Although you do not have any user/password set for the proxy, you will still need to add a psuedo user/password. This can be any username or password.    
+(This will be enhanced in future so that these psuedo user/password will not be necessary)*
 
 The proxy server can be specified during installation or directly in a file (at any point). 
 


### PR DESCRIPTION
@NarineM @lagalbra 

removed "Optional" on http proxy until we have fixed the user/password. Also added pseudo user/password usage for customers who does not have user/password set on proxy. This is based on a customer ICM call. 

Please go thru and see whether it reads better. 