### PR TITLE
update omsagent bundle version

### DIFF
--- a/installer/scripts/onboard_agent.sh
+++ b/installer/scripts/onboard_agent.sh
@@ -6,9 +6,9 @@
 
 
 # Values to be updated upon each new release
-GITHUB_RELEASE="https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent-201702-v1.3.1-15/"
-BUNDLE_X64="omsagent-1.3.1-15.universal.x64.sh"
-BUNDLE_X86="omsagent-1.3.1-15.universal.x86.sh"
+GITHUB_RELEASE="https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent-201704-v1.3.3-15/"
+BUNDLE_X64="omsagent-1.3.3-15.universal.x64.sh"
+BUNDLE_X86="omsagent-1.3.3-15.universal.x86.sh"
 
 usage()
 {


### PR DESCRIPTION
@Microsoft/omsagent-devs ; @lagalbra 
Update bundle version used in agent onboarding link used in OMS portal .
Will be committed only after the new GitHub release with this version is available on download page.