### PR TITLE
persist confs and agentID in VM extension upgrade scenarios

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -191,13 +191,33 @@ fi
 #   6. Run the %postun hook of the old package.
 #
 # Thus, if we're an upgrade, skip all of this cleanup
+ETC_DIR=/etc/opt/microsoft/omsagent
+WORKSPACE_REGEX='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
 if ${{PERFORMING_UPGRADE_NOT}}; then
-   # Clean up directory tree (created via PostInstall) if dirs are empty
+   # Clean up /var directory tree
    rm -rf /var/opt/microsoft/omsagent 2> /dev/null
-
+   
+   # Clean up /etc/opt directory tree (created via PostInstall) if dirs are empty
+   # If multi-workspace scenario
+   for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
+    do
+        echo "Deleting certs and conf directories for workspace $ws_id if empty..."
+        rmdir /etc/opt/microsoft/omsagent/$ws_id/certs/ 2> /dev/null
+        rmdir /etc/opt/microsoft/omsagent/$ws_id/conf/ 2> /dev/null       
+    done
+   
    # Clean up installinfo.txt file (registered as "conf" file to pass rpmcheck)
    rm -f /etc/opt/microsoft/omsagent/sysconf/installinfo.txt*
-   rm -rf /etc/opt/microsoft/omsagent 2> /dev/null
+   rmdir /etc/opt/microsoft/omsagent/sysconf 2> /dev/null
+   # Clean up symbolic links if multi-workspace scenario
+   rm /etc/opt/microsoft/omsagent/certs/ 2> /dev/null
+   rm /etc/opt/microsoft/omsagent/conf/ 2> /dev/null
+   
+   # Clean up directory tree if agent installed or upgraded without onboarding. No symbolic links.
+   rmdir /etc/opt/microsoft/omsagent/certs/ 2> /dev/null
+   rmdir /etc/opt/microsoft/omsagent/conf/ 2> /dev/null
+   # Remove parent folders
+   rmdir /etc/opt/microsoft/omsagent 2> /dev/null
    rmdir /etc/opt/microsoft 2> /dev/null
    rmdir /etc/opt 2> /dev/null
 

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -401,7 +401,7 @@ onboard()
     if [ -f $FILE_KEY -a -f $FILE_CRT -a -f $CONF_OMSADMIN ]; then
         # Keep the same agent GUID by loading it from the previous conf
         AGENT_GUID=`grep AGENT_GUID $CONF_OMSADMIN | cut -d= -f2`
-        log_info "Reusing previous agent GUID"
+        log_info "Reusing previous agent GUID $AGENT_GUID"
     else
         AGENT_GUID=`$RUBY -e "require 'securerandom'; print SecureRandom.uuid"`
         $RUBY $MAINTENANCE_TASKS_SCRIPT -c "$CONF_OMSADMIN" "$FILE_CRT" "$FILE_KEY" "$RUN_DIR/omsagent.pid" "$CONF_PROXY" "$OS_INFO" "$INSTALL_INFO" -w "$WORKSPACE_ID" -a "$AGENT_GUID" $CURL_VERBOSE
@@ -414,6 +414,8 @@ onboard()
     if [ -z "$AGENT_GUID" ]; then
         log_error "AGENT_GUID should not be empty"
         return 1
+    else
+        log_info "Agent GUID is $AGENT_GUID"
     fi
 
     if [ "$VERBOSE" = "1" ]; then


### PR DESCRIPTION
This PR contains the following fixes:
1. Updated omsadmin script to log agentID for Azure VM extension diagnostic purposes.
2. Fixed the regression caused by multi-homing integration where the customer files and omsagent conf files along with certificates get removed with bundle --remove. They should be only removed if in --purge.
3. Fixed the regression caused by multi -homing integration where agent_guid getting re-generated in VM extension upgrade scenarios for the same workspace. This impacts telemetry and SourceComputerID releated arm searches.

@Microsoft/omsagent-devs