### PR TITLE
Remove forward slash in sympolic path from Postuninstall_10

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -210,8 +210,8 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
    rm -f /etc/opt/microsoft/omsagent/sysconf/installinfo.txt*
    rmdir /etc/opt/microsoft/omsagent/sysconf 2> /dev/null
    # Clean up symbolic links if multi-workspace scenario
-   rm /etc/opt/microsoft/omsagent/certs/ 2> /dev/null
-   rm /etc/opt/microsoft/omsagent/conf/ 2> /dev/null
+   rm /etc/opt/microsoft/omsagent/certs 2> /dev/null
+   rm /etc/opt/microsoft/omsagent/conf 2> /dev/null
    
    # Clean up directory tree if agent installed or upgraded without onboarding. No symbolic links.
    rmdir /etc/opt/microsoft/omsagent/certs/ 2> /dev/null


### PR DESCRIPTION
Removed forward slash in sympolic path from Postuninstall_10. I had this typo in my previous commit after I re-arranged the sequence of uninstall. Fixing it now. 
@Microsoft/omsagent-devs 