### PR TITLE
Cleanup bin symbolic links

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -203,7 +203,8 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
     do
         echo "Deleting certs and conf directories for workspace $ws_id if empty..."
         rmdir /etc/opt/microsoft/omsagent/$ws_id/certs/ 2> /dev/null
-        rmdir /etc/opt/microsoft/omsagent/$ws_id/conf/ 2> /dev/null       
+        rmdir /etc/opt/microsoft/omsagent/$ws_id/conf/ 2> /dev/null
+        rm /opt/microsoft/omsagent/bin/omsagent-$ws_id 2> /dev/null		
     done
    
    # Clean up installinfo.txt file (registered as "conf" file to pass rpmcheck)
@@ -220,7 +221,8 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
    rmdir /etc/opt/microsoft/omsagent 2> /dev/null
    rmdir /etc/opt/microsoft 2> /dev/null
    rmdir /etc/opt 2> /dev/null
-
+   rmdir /opt/microsoft/omsagent/bin/ 2> /dev/null
+   rmdir /opt/microsoft/omsagent/ 2> /dev/null
    # Clean up logrotate
    rm -f /etc/logrotate.d/omsagent*
    rm -f /etc/cron.d/omsagent


### PR DESCRIPTION
This is a fix for a regression after multi-homing integration where omsagent no longer  removes /opt/Microsoft/omsagent path due to bin folder content leftovers. After multi homing, bin  contains additional symbolic links like:
omsagent-9aa420aa-73c3-4d9e-bf39-8466a11e37c4 -> /opt/microsoft/omsagent/bin/omsagent

and when --remove is used, the rest of /opt/microsoft/omsagent/bin/ is removed, but /opt/microsoft/omsagent/bin/ is left with symbolic links to non existing omsagent folder . These links should be removed.