### PR TITLE
npmd: make sure npmdclient sock is reset in shutdown

### DIFF
--- a/source/code/plugins/in_npmd_server.rb
+++ b/source/code/plugins/in_npmd_server.rb
@@ -121,6 +121,10 @@ module Fluent
             # Stopping the npmd_agent
             stop_npmd()
 
+            # Set the npmd client socket as nil as npmd_reader might not do so in time
+            @npmdClientSock.close() if !@npmdClientSock.nil?
+            @npmdClientSock = nil
+
             # Stop server
             stop_server()
 


### PR DESCRIPTION
Certain times the npmdClientSock might not be set back to nil
in unit tests as the npmd_reader thread might not set it in
time. This is more of a fail safe for unit tests.