### PR TITLE
Ensure that omsadmin.conf is removed in remove scenario

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -204,6 +204,8 @@ if ${{PERFORMING_UPGRADE_NOT}}; then
         echo "Deleting certs and conf directories for workspace $ws_id if empty..."
         rmdir /etc/opt/microsoft/omsagent/$ws_id/certs/ 2> /dev/null
         rmdir /etc/opt/microsoft/omsagent/$ws_id/conf/ 2> /dev/null
+        echo "Deleting omsadmin.conf for workspace $ws_id..."
+        rm -f /etc/opt/microsoft/omsagent/$ws_id/conf/omsadmin.conf
         rm /opt/microsoft/omsagent/bin/omsagent-$ws_id 2> /dev/null		
     done
    


### PR DESCRIPTION
@Microsoft/omsagent-devs @NarineM 

The existence of omsadmin.conf is assumed to mean that a workspace is onboarded. However, with PR https://github.com/Microsoft/OMS-Agent-for-Linux/pull/444 some conf files may still exist on the machine, but omsadmin.conf should be removed when --remove is called.

This change enforces that omsadmin.conf is deleted for each remaining workspace with configuration on the machine.

--remove has been tested
--remove then --upgrade has been tested, ensuring that omsadmin.sh -l shows "No Workspace"
Unit and system tests passed
pBuild running now