### PR TITLE
Update VM Extension doc and improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@
 Welcome to the OMS Agent for Linux! The OMS Agent for Linux enables rich and real-time analytics for operational data (Syslog, Performance, Alerts, Inventory) from Linux servers, Docker Containers and monitoring tools like Nagios, Zabbix and System Center.
 
 ## Quick Install guide
-Run the following commands to download the omsagent, validate the checksum, and install+onboard the agent. *Commands are for 64-bit*. The Workspace ID and Primary Key can be found inside the OMS Portal under Settings in the **connected sources** tab.
+Run the following command to download the omsagent, validate the checksum, and install+onboard the agent. The Workspace ID and Primary Key can be found inside the OMS Portal under Settings in the **Connected Sources** tab.
 ```
 $> wget https://raw.githubusercontent.com/Microsoft/OMS-Agent-for-Linux/master/installer/scripts/onboard_agent.sh && sh onboard_agent.sh -w <YOUR OMS WORKSPACE ID> -s <YOUR OMS WORKSPACE PRIMARY KEY>
 ```
+The latest agent bundle can also be downloaded manually from our [Releases page](https://github.com/Microsoft/OMS-Agent-for-Linux/releases).
+
 ## Azure Install guide
 If you are an Azure customer, we have an Azure VM Extension that allows you to onboard with a couple of clicks.
-* [OMS Agent for Linux Azure VM Extension Documentation](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/VM-Extension.md)
+* [OMS Agent for Linux Azure VM Extension Documentation](docs/VM-Extension.md)
 * [Azure Video walkthrough](https://www.youtube.com/watch?v=mF1wtHPEzT0)
 
 ## [Full installation guide](docs/OMS-Agent-for-Linux.md#install-the-oms-agent-for-linux)
 
-### [Video Walkthrough](https://www.youtube.com/watch?v=7b4KxL7E5fw)
+## [Video Walkthrough](https://www.youtube.com/watch?v=7b4KxL7E5fw)
 
-## [Download Latest OMS Agent for Linux (64-bit)](https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent-201702-v1.3.1-15/omsagent-1.3.1-15.universal.x64.sh)
-## [Download Latest OMS Agent for Linux (32-bit)](https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent-201702-v1.3.1-15/omsagent-1.3.1-15.universal.x86.sh)
 ## Feedback
 
 We love feedback!  Whether it be good, bad or indifferent, it really helps us build a better product for you.  There are a few different routes to give feedback:

--- a/docs/VM-Extension.md
+++ b/docs/VM-Extension.md
@@ -1,46 +1,60 @@
 # Operations Management Suite (OMS) Agent for Linux Azure VM Extension
 
 Azure VM Extensions are an easy way to deploy dynamic feature sets from Microsoft and other third party providers. 
-For additional information about Azure VM Extensions and a list of those available refer to the following [Learn more: Azure Virtual Machine Extensions](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-extensions-features/)
+For additional information about Azure VM Extensions, and a list of those available, refer to the following: [Learn more: Azure Virtual Machine Extensions](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-extensions-features/)
 
-Latest Version of OMS Agent for Linux Extension: **1.0**
+Latest Version of OMS Agent for Linux Extension: **1.3**
 
 The OMS Agent for Linux Extension can:
 * Install the OMS Agent for Linux
-* Onboard supported Linux VM to an OMS workspace
+* Onboard supported Linux VM to an OMS workspace (see list of supported Linux distributions [below](#supported-linux-distributions))
 
 # User Guide
+
 ## 1. Configuration schema
+
 ### 1.1. Public configuration
+
 Schema for the public configuration file looks like this:
+
 * `workspaceId`: (required, string) the OMS workspace id to onboard to
+* `stopOnMultipleConnections`: (optional, true/false) warn and stop onboarding if the machine already has a workspace connection; defaults to false
+ 
 ```json
 {
-  "workspaceId": "<workspace-id (guid)>"
+  "workspaceId": "<workspace-id (guid)>",
+  "stopOnMultipleConnections": true/false
 }
 ```
+
 ### 1.2. Protected configuration
+
 Schema for the protected configuration file looks like this:
+
 * `workspaceKey`: (required, string) the primary/secondary shared key of the workspace
+* `proxy`: (optional, string) the proxy connection string - of the form \[user:pass@\]host\[:port\]
+* `vmResourceId`: (optional, string) the full azure resource id of the vm - of the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}
+
 ```json
 {
-  "workspaceKey": "<workspace-key>"
+  "workspaceKey": "<workspace-key>",
+  "proxy": "<proxy-string>",
+  "vmResourceId": "<vm-resource-id>"
 }
 ```
 
 ## 2. Deploying the OMS Agent for Linux Extension
 
-> **Note:** if you are using Linux Azure Diagnostics the latest version 2.2 is required before installing the Operations Management Suite Agent for Linux. For more information refer to the [Known Limitations section](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/develop/docs/OMS-Agent-for-Linux.md#known-limitations)
+> **Note:** If you are using Linux Azure Diagnostics the latest version 2.2 is required before installing the Operations Management Suite Agent for Linux. For more information refer to the [Known Limitations section](docs/OMS-Agent-for-Linux.md#known-limitations)
 
 You can deploy the OMS Agent for Linux Extension using Azure CLI, Azure Powershell, or an ARM template.
 
-> **Note:** Creating VM in Azure has two deployment model: Classic and [Resource Manager][arm-overview].
+> **Note:** Creating VM in Azure has two deployment models: Classic and [Resource Manager][arm-overview].
 In different models, the deploying commands have different syntaxes. Select the right
 one in section 2.1 and 2.2 below.
  
 ### 2.1. Using [**Azure CLI**][azure-cli]
 Before deploying OMS Agent for Linux Extension, you should configure your `public.json` and `protected.json` with the respective OMS workspace ID, and OMS workspace key (in section 1.1 and 1.2 above). Both of these properties can be found in the OMS Portal under Settings > Connected Sources.
-
 
 #### 2.1.1 Classic
 The Classic mode is also called Azure Service Management mode. You can change to it by running:
@@ -51,9 +65,11 @@ $ azure config mode asm
 You can deploy the OMS Agent for Linux Extension by running:
 ```
 $ azure vm extension set <vm-name> \
-OmsAgentForLinux Microsoft.EnterpriseCloud.Monitoring <version> \
---public-config-path public.json  \
---private-config-path protected.json
+                         OmsAgentForLinux \
+                         Microsoft.EnterpriseCloud.Monitoring
+                         <version> \
+                         --public-config-path public.json  \
+                         --private-config-path protected.json
 ```
 
 In the command above, you can change version with `'*'` to use latest
@@ -69,15 +85,41 @@ You can change to Azure Resource Manager mode by running:
 $ azure config mode arm
 ```
 
-You can deploy the OmsAgent Extension by running:
+You can deploy the OMS Agent for Linux Extension by running:
 ```
-$ azure vm extension set <resource-group> <vm-name> \
-OmsAgentForLinux Microsoft.EnterpriseCloud.Monitoring <version> \
---public-config-path public.json  \
---private-config-path protected.json
+$ azure vm extension set <resource-group> \
+                         <vm-name> \
+                         OmsAgentForLinux \
+                         Microsoft.EnterpriseCloud.Monitoring  \
+                         <version> \
+                         --public-config-path public.json  \
+                         --private-config-path protected.json
 ```
 
 > **Note:** In ARM mode, `azure vm extension list` is not available for now.
+
+#### 2.1.3 Azure CLI 2.0
+Learn more about Azure CLI 2.0 [here][azure-cli-2.0]
+
+You can deploy the OMS Agent for Linux Extension by running:
+```
+$ az vm extension set --name OmsAgentForLinux \
+                      --publisher Microsoft.EnterpriseCloud.Monitoring \
+                      --resource-group <resource-group> \
+                      --vm-name <vm-name> \
+                      --protected-settings protected.json \
+                      --settings public.json \
+                      --version <version>
+```
+
+To list the available extension versions using Azure CLI 2.0:
+```
+$ az vm extension image list-versions --location <location> \
+                                      --name OmsAgentForLinux \
+                                      --publisher Microsoft.EnterpriseCloud.Monitoring
+```
+
+> **Note:** Azure CLI 2.0 does not support the Classic deployment model.
 
 
 ### 2.2. Using [**Azure Powershell**][azure-powershell]
@@ -90,7 +132,7 @@ You can login to your Azure account (Azure Service Management mode) by running:
 Add-AzureAccount
 ```
 
-You can deploy the OmsAgent Extension by running:
+You can deploy the OMS Agent for Linux Extension by running:
 
 ```powershell
 $VmName = '<vm-name>'
@@ -101,10 +143,13 @@ $Publisher = 'Microsoft.EnterpriseCloud.Monitoring'
 $Version = '<version>'
 
 $PublicConf = '{
-    "workspaceId": "<workspace id>"
+    "workspaceId": "<workspace id>",
+    "stopOnMultipleConnections": true/false
 }'
 $PrivateConf = '{
-    "workspaceKey": "<workspace key>"
+    "workspaceKey": "<workspace key>",
+    "proxy": "<proxy string>",
+    "vmResourceId": "<vm resource id>"
 }'
 
 Set-AzureVMExtension -ExtensionName $ExtensionName -VM $vm `
@@ -123,7 +168,7 @@ Login-AzureRmAccount
 
 Click [**HERE**](https://azure.microsoft.com/en-us/documentation/articles/powershell-azure-resource-manager/) to learn more about how to use Azure Powershell with Azure Resource Manager.
 
-You can deploy the OmsAgent Extension by running:
+You can deploy the OMS Agent for Linux Extension by running:
 
 ```powershell
 $RGName = '<resource-group-name>'
@@ -135,10 +180,13 @@ $Publisher = 'Microsoft.EnterpriseCloud.Monitoring'
 $Version = '<version>'
 
 $PublicConf = '{
-    "workspaceId": "<workspace id>"
+    "workspaceId": "<workspace id>",
+    "stopOnMultipleConnections": true/false
 }'
 $PrivateConf = '{
-    "workspaceKey": "<workspace key>"
+    "workspaceKey": "<workspace key>",
+    "proxy": "<proxy string>",
+    "vmResourceId": "<vm resource id>"
 }'
 
 Set-AzureRmVMExtension -ResourceGroupName $RGName -VMName $VmName -Location $Location `
@@ -160,12 +208,15 @@ Set-AzureRmVMExtension -ResourceGroupName $RGName -VMName $VmName -Location $Loc
   "properties": {
     "publisher": "Microsoft.EnterpriseCloud.Monitoring",
     "type": "OmsAgentForLinux",
-    "typeHandlerVersion": "1.0",
+    "typeHandlerVersion": "1.3",
     "settings": {
-      "workspaceId": "<workspace id>"
+      "workspaceId": "<workspace id>",
+      "stopOnMultipleConnections": true/false
     },
     "protectedSettings": {
-      "workspaceKey": "<workspace key>"
+      "workspaceKey": "<workspace key>",
+      "proxy": "<proxy string>",
+      "vmResourceId": "<vm resource id>"
     }
   }
 }
@@ -176,24 +227,27 @@ Set-AzureRmVMExtension -ResourceGroupName $RGName -VMName $VmName -Location $Loc
 ### 3.1 Onboard to OMS workspace
 ```json
 {
-  "workspaceId": "MyWorkspaceId"
+  "workspaceId": "MyWorkspaceId",
+  "stopOnMultipleConnections": true
 }
 ```
 ```json
 {
-  "workspaceKey": "MyWorkspaceKey"
+  "workspaceKey": "MyWorkspaceKey",
+  "proxy": "proxyuser:proxypassword@proxyserver:8080",
+  "vmResourceId": "/subscriptions/c90fcea1-7cd5-4255-9e2e-25d627a2a259/resourceGroups/RGName/providers/Microsoft.Compute/virtualMachines/VMName"
 }
 ```
 
 ## Supported Linux Distributions
-- CentOS Linux 5,6, and 7 (x86/x64)
-- Oracle Linux 5,6, and 7 (x86/x64)
-- Red Hat Enterprise Linux Server 5,6 and 7 (x86/x64)
-- Debian GNU/Linux 6, 7, and 8 (x86/x64)
-- Ubuntu 12.04 LTS, 14.04 LTS, 15.04 (x86/x64)
-- SUSE Linux Enterprise Server 11 and 12 (x86/x64)
+* CentOS Linux 5,6, and 7 (x86/x64)
+* Oracle Linux 5,6, and 7 (x86/x64)
+* Red Hat Enterprise Linux Server 5,6 and 7 (x86/x64)
+* Debian GNU/Linux 6, 7, and 8 (x86/x64)
+* Ubuntu 12.04 LTS, 14.04 LTS, 15.04, 15.10, 16.04 LTS (x86/x64)
+* SUSE Linux Enteprise Server 11 and 12 (x86/x64)
 
-## Debug
+## Troubleshooting
 
 * The status of the extension is reported back to Azure so that user can
 see the status on Azure Portal
@@ -203,11 +257,11 @@ the following directories -
 and the tail of the output is logged into the log directory specified
 in HandlerEnvironment.json and reported back to Azure
 * The operation log of the extension is `/var/log/azure/<extension-name>/<version>/extension.log` file.
-
+* Find error codes and their meanings in our [troubleshooting guide](docs/Troubleshooting.md#installation-error-codes)
 
 
 [azure-powershell]: https://azure.microsoft.com/en-us/documentation/articles/powershell-install-configure/
 [azure-cli]: https://azure.microsoft.com/en-us/documentation/articles/xplat-cli/
 [arm-template]: http://azure.microsoft.com/en-us/documentation/templates/ 
 [arm-overview]: https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/
-[Set-AzureVMExtension-ARM]: https://msdn.microsoft.com/en-us/library/mt163544.aspx
+[azure-cli-2.0]: https://docs.microsoft.com/en-us/cli/azure/overview


### PR DESCRIPTION
@Microsoft/omsagent-devs 

VM-Extension.md has been updated from the latest changes [here](https://github.com/Azure/azure-linux-extensions/blob/master/OmsAgent/README.md)

Download links removed from README.md. This change is up for discussion; currently those links must be updated with each new release, which should be avoided since [onboard_agent.sh](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/installer/scripts/onboard_agent.sh) was created.