### PR TITLE
Add --enable-opsmgr flag in omsagent bundle to open port 1270

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -74,6 +74,7 @@ usage()
     echo "  --restart-deps             Reconfigure and restart dependent service(s)."
     echo "  --source-references        Show source code reference hashes."
     echo "  --upgrade                  Upgrade the package in the system."
+    echo "  --enable-opsmgr            Enable port 1270 for usage with opsmgr."
     echo "  --version                  Version of this shell bundle."
     echo "  --version-check            Check versions already installed to see if upgradable."
     echo "  --debug                    use shell debug mode."
@@ -613,6 +614,11 @@ do
             shift 2
             ;;
 
+        --enable-opsmgr)
+            enableOMFlag=true
+            shift 1
+            ;;
+
         -\? | -h | --help)
             usage `basename $0` >&2
             cleanup_and_exit 0
@@ -883,7 +889,8 @@ case "$installMode" in
             # Install SCX (and OMI)
             [ -n "${forceFlag}" ] && FORCE="--force" || FORCE=""
             [ -n "${debugMode}" ] && DEBUG="--debug" || DEBUG=""
-            ./bundles/${SCX_INSTALLER} --install $FORCE $DEBUG
+            [ -n "${enableOMFlag}" ] && ENABLE_OM="--enable-opsmgr" || ENABLE_OM=""
+            ./bundles/${SCX_INSTALLER} --install $FORCE $DEBUG $ENABLE_OM
             TEMP_STATUS=$?
             if [ $TEMP_STATUS -ne 0 ]; then
                 echo "$SCX_INSTALLER package failed to install and exited with status $TEMP_STATUS"
@@ -963,7 +970,8 @@ case "$installMode" in
         # Install SCX (and OMI)
         [ -n "${forceFlag}" ] && FORCE="--force" || FORCE=""
         [ -n "${debugMode}" ] && DEBUG="--debug" || DEBUG=""
-        ./bundles/${SCX_INSTALLER} --upgrade $FORCE $DEBUG
+        [ -n "${enableOMFlag}" ] && ENABLE_OM="--enable-opsmgr" || ENABLE_OM=""
+        ./bundles/${SCX_INSTALLER} --upgrade $FORCE $DEBUG $ENABLE_OM
         TEMP_STATUS=$?
         if [ $TEMP_STATUS -ne 0 ]; then
             echo "$SCX_INSTALLER package failed to upgrade and exited with status $TEMP_STATUS"

--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -135,7 +135,6 @@ ${{OMS_SERVICE}} start
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
     ${{OMS_SERVICE}} disable
-    ${{OMS_SERVICE}} disable scom
     ${{CONF_SYSLOG}} purge
 fi
 

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -22,6 +22,9 @@ BIN_DIR=/opt/microsoft/omsagent/bin
 
 WORKSPACE_REGEX='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
 
+# Space seperated list of non oms workspaces
+NON_OMS_WS="scom"
+
 setup_variables()
 {
     if [ -z "$1" ]; then
@@ -321,6 +324,18 @@ disable_omsagent_service()
     rm -f $CONF_DIR/.service_registered
 }
 
+check_ws_and_invoke()
+{
+    for ws_id in $NON_OMS_WS
+    do
+        ls -1 $ETC_DIR | grep -w ${ws_id} > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            setup_variables ${ws_id}
+            $1
+        fi
+    done
+}
+
 start_all_omsagent()
 {
     for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
@@ -328,6 +343,8 @@ start_all_omsagent()
        setup_variables ${ws_id}
        start_omsagent
     done
+
+    check_ws_and_invoke start_omsagent
 }
 
 stop_all_omsagent()
@@ -337,6 +354,8 @@ stop_all_omsagent()
        setup_variables ${ws_id}
        stop_omsagent
     done
+
+    check_ws_and_invoke stop_omsagent
 }
 
 restart_all_omsagent()
@@ -346,6 +365,8 @@ restart_all_omsagent()
        setup_variables ${ws_id}
        restart_omsagent
     done
+
+    check_ws_and_invoke restart_omsagent
 }
 
 enable_all_omsagent_services()
@@ -355,6 +376,8 @@ enable_all_omsagent_services()
        setup_variables ${ws_id}
        enable_omsagent_service
     done
+
+    check_ws_and_invoke enable_omsagent_service
 }
 
 disable_all_omsagent_services()
@@ -364,6 +387,8 @@ disable_all_omsagent_services()
        setup_variables ${ws_id}
        disable_omsagent_service
     done
+
+    check_ws_and_invoke disable_omsagent_service
 }
 
 case "$1" in

--- a/source/code/plugins/filter_scom_cor_match.rb
+++ b/source/code/plugins/filter_scom_cor_match.rb
@@ -1,5 +1,7 @@
+require_relative 'scom_common'
+
 module Fluent
-  class SCOMCorrelatedMatchFilter < Filter
+  class SCOMCorrelatedMatchFilter < SCOMTimerFilterPlugin
     #Filter plugin that generates an event when first regex matches and 
     #sceond regex matches before given time interval
     Fluent::Plugin.register_filter('filter_scom_cor_match', self)
@@ -8,25 +10,15 @@ module Fluent
     config_param :regexp1, :string, :default => nil
     desc 'stores regex which needs to match after match for regexp1'
     config_param :regexp2, :string, :default => nil
-    desc 'time interval before which regexp2 needs to match'
-    config_param :time_interval, :integer, :default => 0
-    desc 'event number to be sent to SCOM'
-    config_param :event_id, :string, :default => nil
-    desc 'event description to be sent to SCOM'
-    config_param :event_desc, :string, :default => nil
         
     attr_reader :expression1
     attr_reader :key1
     attr_reader :expression2
     attr_reader :key2
     attr_reader :time_interval
-
+    
     def initialize()
       super
-      require_relative 'scom_common'
-      @exp1_found = false
-      @timer = nil
-      @lock = Mutex.new
     end
     
     def start
@@ -41,8 +33,6 @@ module Fluent
       super
             
       raise ConfigError, "Configuration does not contain 2 expressions" unless @regexp1 and @regexp2
-      raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
-      raise ConfigError, "Configuration does not have a time interval" unless @time_interval
       @key1, exp1 = @regexp1.split(/ /,2)
       raise ConfigError, "regexp1 does not contain 2 parameters" unless exp1
       @expression1 = Regexp.compile(exp1)
@@ -51,37 +41,23 @@ module Fluent
       @expression2 = Regexp.compile(exp2)
     end
         
-    def flip_state()
-      @lock.synchronize {
-        @exp1_found = !@exp1_found
-      }
-    end
-        
     def filter(tag, time, record)
       result = record
       #Check if a match is found for regexp1
       if !@exp1_found and @expression1.match(record[key1].to_s)
         # Match found, change state to exp1_found and start timer
-        flip_state()
-        @timer = Thread.new { sleep @time_interval; timer_expired() }
+        set_timer()
         $log.debug "Match found for regex #{@regexp1} ID #{@event_id}. Timer Started."
       end # if
       #Check for regexp2 match if regexp1 was found
       if @exp1_found and @expression2.match(record[key2].to_s)
         # Match found: Change state, stop timer and form SCOM event
-        flip_state()
-        @timer.terminate()
-        @timer = nil
+        reset_timer()
         result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
         $log.debug "Event found for ID #{@event_id}"
       end # if
       result
     end # method filter
-        
-    def timer_expired()
-      $log.debug "Timer expired waiting for event ID #{@event_id}"
-      flip_state()
-    end
         
   end # class SCOMCorrelatedMatchFilter
 end # module Fluent

--- a/source/code/plugins/filter_scom_excl_correlation.rb
+++ b/source/code/plugins/filter_scom_excl_correlation.rb
@@ -1,5 +1,7 @@
+require_relative 'scom_common'
+
 module Fluent
-  class SCOMExclusiveCorrelationFilter < Filter
+  class SCOMExclusiveCorrelationFilter < SCOMTimerFilterPlugin
     #Filter plugin that generates an event when first regex matches and 
     #sceond regex does not match before given time interval
     Fluent::Plugin.register_filter('filter_scom_excl_correlation', self)
@@ -8,12 +10,6 @@ module Fluent
     config_param :regexp1, :string, :default => nil
     desc 'stores regex which should not match after match for regexp1'
     config_param :regexp2, :string, :default => nil
-    desc 'time interval in which regexp2 should not occur'
-    config_param :time_interval, :integer, :default => 0
-    desc 'event number to be sent to SCOM'
-    config_param :event_id, :string, :default => nil
-    desc 'event description to be sent to SCOM'
-    config_param :event_desc, :string, :default => nil
         
     attr_reader :expression1
     attr_reader :key1
@@ -23,18 +19,12 @@ module Fluent
         
     def initialize()
       super
-      require_relative 'scom_common'
-      @exp1_found = false
-      @timer = nil
-      @lock = Mutex.new
     end
         
     def configure(conf)
       super
             
       raise ConfigError, "Configuration does not contain 2 expressions" unless @regexp1 and @regexp2
-      raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
-      raise ConfigError, "Configuration does not have a time interval" unless @time_interval
       @key1, exp1 = @regexp1.split(/ /,2)
       raise ConfigError, "regexp1 does not contain 2 parameters" unless exp1
       @expression1 = Regexp.compile(exp1)
@@ -43,32 +33,23 @@ module Fluent
       @expression2 = Regexp.compile(exp2)
     end
         
-    def flip_state()
-      @lock.synchronize {
-        @exp1_found = !@exp1_found
-      }
-    end
-        
     def filter(tag, time, record)
       #Check if a match is found for regexp1
       if !@exp1_found and @expression1.match(record[key1].to_s)
         # Match found, change state to exp1_found and start timer
-        flip_state()
-        @timer = Thread.new { sleep @time_interval; timer_expired() }
+        set_timer()
         $log.debug "Match found for regex #{@regexp1} ID #{@event_id}. Timer Started."
       end # if
       #Check for regexp2 match if regexp1 was found
       if @exp1_found and @expression2.match(record[key2].to_s)
         #Match found: change state and stop timer
-        flip_state()
-        @timer.terminate()
-        @timer = nil
+        reset_timer()
       end # if
       record
     end
         
     def timer_expired()
-      flip_state()
+      super
       time = Engine.now
       # Match for regexp2 not found within time, form SCOM event
       result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)

--- a/source/code/plugins/filter_scom_repeated_cor.rb
+++ b/source/code/plugins/filter_scom_repeated_cor.rb
@@ -1,5 +1,7 @@
+require_relative 'scom_common'
+
 module Fluent
-  class SCOMRepeatedCorrelationFilter < Filter
+  class SCOMRepeatedCorrelationFilter < SCOMTimerFilterPlugin
     #Filter plugin that generates event when a regex matches a given 
     #number of time in a given time interval.
     Fluent::Plugin.register_filter('filter_scom_repeated_cor', self)
@@ -8,24 +10,13 @@ module Fluent
     config_param :regexp1, :string, :default => nil
     desc 'Number of times the  regex should match'
     config_param :num_occurrences, :integer, :default => 0
-    desc 'time interval in which the match should occur'
-    config_param :time_interval, :integer, :default => 0
-    desc 'event number to be sent to SCOM'
-    config_param :event_id, :string, :default => nil
-    desc 'event description to be sent to SCOM'
-    config_param :event_desc, :string, :default => nil
         
     attr_reader :expression
     attr_reader :key
     attr_reader :time_interval
-    attr_reader :num_occurrences
         
     def initialize()
       super
-      require_relative 'scom_common'
-      @exp1_found = false
-      @timer = nil
-      @lock = Mutex.new
       @counter = 0
     end
         
@@ -33,18 +24,10 @@ module Fluent
       super
             
       raise ConfigError, "Configuration does not contain an expression" unless @regexp1
-      raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
-      raise ConfigError, "Configuration does not have a time interval" unless (@time_interval > 0)
       raise ConfigError, "Configuration must give a value greater than 0 for num_occurrences" unless (@num_occurrences > 0)
       @key, exp = @regexp1.split(/ /,2)
       raise ConfigError, "regexp1 does not contain 2 parameters" unless exp
       @expression = Regexp.compile(exp)
-    end
-        
-    def flip_state()
-      @lock.synchronize {
-        @exp1_found = !@exp1_found
-      }
     end
         
     def reset_counter()
@@ -58,20 +41,17 @@ module Fluent
        # Check if a match found for regexp1     
       if !@exp1_found and @expression.match(record[key].to_s)
         # Match found, change state to exp1_found and start timer
-        flip_state()
+        set_timer()
         @counter += 1
         $log.debug "Match found for regex #{@regexp1} ID #{@event_id}. Timer Started."
-        @timer = Thread.new { sleep @time_interval; timer_expired() }
       elsif @exp1_found and @expression.match(record[key].to_s) 
         @counter += 1
       end # if
       # Check if expected number of occurences reached
       if @counter == @num_occurrences
         # Reset state and counter. Form SCOM event.
-        flip_state()
+        reset_timer()
         reset_counter()
-        @timer.terminate()
-        @timer = nil
         result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
         $log.debug "Event found for ID #{@event_id}"
       end # if
@@ -79,8 +59,7 @@ module Fluent
     end
         
     def timer_expired()
-      $log.debug "Timer expired waiting for event ID #{@event_id}"
-      flip_state()
+      super
       reset_counter()
     end
         

--- a/test/code/plugins/filter_scom_repeated_cor_test.rb
+++ b/test/code/plugins/filter_scom_repeated_cor_test.rb
@@ -28,7 +28,7 @@ require 'socket'
       assert_equal(d.instance.expression, Regexp.compile('Authentication Failed'))
       assert_equal(d.instance.key, 'message')
       assert_equal(d.instance.time_interval, 5)
-      assert_equal(d.instance.num_occurrences, 3)
+      assert_equal(d.instance.instance_variable_get(:@num_occurrences), 3)
     end
     
     def test_filter


### PR DESCRIPTION
@Microsoft/omsagent-devs 
@jeffaco 
@uashok 

In order for omsagent to be able to connect to SCOM, port 1270
nees to be opened. A new flag (--enable-opsmgr) has been added
in omsagent bundle for opening port 1270. If someone intends to
use omsagent with SCOM, he will now have an option to pass the
flag during install/upgrade of the agent. Also the port 1270 will
be opened(if not already open) when scom workspace is created.

Following changes are also done:
1. Added scom workpsace in aggregate commands (start all, stop all etc.)
2. Removed code duplicity in timer based plugins.
3. Removed a warning in scom plugin's unittest.

Following tests are done:
1. PBuild was successful.
2. Successful onboarding on both OMS and SCOM
3. Verified functionality of changed plugins