### PR TITLE
omsagent installer logging and documentation improvements

### DIFF
--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -71,7 +71,7 @@ The OMS agent for Linux is provided in a self-extracting and installable shell s
 **Installing the agent**
 
 1. Transfer the appropriate bundle (x86 or x64) to your Linux computer, using scp/sftp.
-2. Install the bundle by using the `--install` or `--upgrade` argument. Note: use the `--upgrade` argument if any existing packages are installed, as would be the case if the system Center Operations Manager agent for Linux is already installed. To onboard to Operations Management Suite during installation, provide the `-w <WorkspaceID>` and `-s <Shared Key>` parameters.
+2. Install the bundle by using the `--install` or `--upgrade` argument. Note: must use the `--upgrade` argument if any dependent packages such as omi, scx, omsconfig or their older versions are installed, as would be the case if the system Center Operations Manager agent for Linux is already installed. To onboard to Operations Management Suite during installation, provide the `-w <WorkspaceID>` and `-s <Shared Key>` parameters.
 
 **To install and onboard directly:**
 ```

--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -380,7 +380,7 @@ import ctypes
 EOF
 
     chmod u+x $tempFile
-    $tempFile 1> /dev/null 2> /dev/null
+    $tempFile 1> /dev/null
     [ $? -eq 0 ] && hasCtypes=0
     rm $tempFile
 


### PR DESCRIPTION
This PR has the following changes:
1. Update omsagent installation step to clearly state when to call --install vs --upgrade.
2. In some environments where SELinux policy is on for /tmp folder for sudo user, bundle installer fails if the required user does not have write access to default temp directory. Since error log was redirected to null, the permission related messages are not logged making system hard to diagnose. With this change agent installer will only redirect logs from successful operations to null.