### PR TITLE
Fix erroneous No Workspace in omsadmin list command

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -743,8 +743,8 @@ list_workspaces()
     fi
     # check scom workspace
     list_scom_workspace
-    if [ $found_ws -eq 0 ]; then
-        found_ws=$?
+    if [ $? -eq 1 ]; then
+        found_ws=1
     fi
 
     if [ $found_ws -eq 0 ]; then


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Listing workspaces using omsadmin.sh when only SCOM Workspace is present printed No Workspace
along with the SCOM workspace status.
Fixed the issue to not print No Workspace.