### PR TITLE
Include to_s for CaseSensitiveString for Ruby 2.3

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -904,6 +904,9 @@ module OMS
     def capitalize
         self
     end
+    def to_s
+        self
+    end
   end
 
 end # module OMS


### PR DESCRIPTION
@Microsoft/omsagent-devs 

This preserves our header string capitalization, which matters for Custom Logs.

After Ruby 2.3 upgrade, Custom Logs did not have a Computer field in the OMS portal because Ruby uses to_s to convert headers. Our headers must remain cased as they are for the workflow to handle them correctly (see Robbie's commit about this issue before Ruby 2.3 [here](https://github.com/Microsoft/OMS-Agent-for-Linux/commit/67deffb142526344b0bb85af5f299ffdda70eb65))

This has been tested; it does ensure the Computer shows as a field in the OMS portal.

Unit and system tests pass.
pBuild running now.