### PR TITLE
Add option to enable SCOM server authentication

### DIFF
--- a/source/code/plugins/out_scom.rb
+++ b/source/code/plugins/out_scom.rb
@@ -14,6 +14,9 @@ module Fluent
       require_relative 'scom_common'
     end
 
+    desc 'Set this parameter to true to validate server certificate'
+    config_param :enable_server_auth, :bool, :default => false
+
     def configure(conf)
       super
     end
@@ -74,7 +77,7 @@ module Fluent
     # NOTE! This method is called by internal thread, not Fluentd's main thread. So IO wait doesn't affect other plugins.
     def write(chunk)
       # Quick exit if we are missing something
-      if !SCOM::Configuration.load_scom_configuration()
+      if !SCOM::Configuration.load_scom_configuration(@enable_server_auth)
         raise SCOM::RetryRequestException, 'Missing configuration. Make sure to run discovery.'
       end
       @log.trace "Writing chunk"

--- a/source/code/plugins/scom_common.rb
+++ b/source/code/plugins/scom_common.rb
@@ -66,7 +66,13 @@ module SCOM
     def self.create_secure_http(uri)
       http = Net::HTTP.new( uri.host, uri.port )
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      if SCOM::Configuration.enable_server_auth
+        OMS::Log.info_once("Enabling server certificate validation")
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      else
+        OMS::Log.info_once("Disabling server certificate validation")
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end # if
       http.open_timeout = 30
       return http
     end

--- a/source/code/plugins/scom_configuration.rb
+++ b/source/code/plugins/scom_configuration.rb
@@ -21,9 +21,10 @@ module SCOM
     @@scom_perf_endpoint = nil
     
     @@monitoring_id = nil
-    @@fqdn = nil    
+    @@fqdn = nil
+    @@enable_server_auth = false   
       
-    def self.load_scom_configuration
+    def self.load_scom_configuration(enable_server_auth)
       return true if @@configuration_loaded
       return false if !OMS::Configuration.test_onboard_file(@@scom_conf_path) or !OMS::Configuration.test_onboard_file(@@cert_path) or !OMS::Configuration.test_onboard_file(@@key_path) 
             
@@ -66,7 +67,9 @@ module SCOM
       if(!@@fqdn)
         return false
       end # if
-              
+      
+      @@enable_server_auth = enable_server_auth
+       
       @@configuration_loaded = true
       return true
     end # method load_configuration
@@ -104,6 +107,10 @@ module SCOM
     
     def self.fqdn
       @@fqdn
+    end
+
+    def self.enable_server_auth
+      @@enable_server_auth
     end
 
   end # class Configuration


### PR DESCRIPTION
@Microsoft/omsagent-devs 

SCOM, being an OnPrem server, cannot enable server authentication
by default. To make it work the should should generate a
certificate with their enterprise CA and and replac default
cert on server. Also the CA should be provisioned on the Linux
machines.
If a customer does these, he can enable server authentication
by setting enable_server_auth parameter to true in SCOM's
output plugin.