### PR TITLE
Simplify python ctypes detection

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -371,21 +371,8 @@ python_ctypes_installed() {
     # Check for Python ctypes library (required for omsconfig)
     hasCtypes=1
     echo "Checking for ctypes python module ..."
-
-    # Check #1: Attempt to create and execute a temporary file importing ctypes
-    tempFile=`mktemp`
-
-    cat <<EOF > $tempFile
-#! /usr/bin/python
-import ctypes
-EOF
-
-    chmod u+x $tempFile
-    $tempFile 1> /dev/null
-    [ $? -eq 0 ] && hasCtypes=0
-    rm $tempFile
-
-    # Check #2: Attempt to run python with the single import command
+	
+    # Attempt to run python with the single import command
     python -c "import ctypes" 1> /dev/null 2> /dev/null
     [ $? -eq 0 ] && hasCtypes=0
 


### PR DESCRIPTION
This PR is to simplify python ctypes module detection to enable customers who have SELinux policy on in their environments and cover scenarios where sudo user does not have write or execute access to default /tmp location. 

Executing the python file in addition to running python command from commandline is not necessary in pre-install step. python scripts get installed under DSC paths, and when it comes to that , oms or omi user would already have correct write and execute permissions to given dsc folder.  Running import ctypes code sits only in dsc python scripts that call into ctypes APIs, so if there are systems where python and ctypes are installed, and running python commands from commandline succeeds, then that would also work from a python file, and even if it does not work (would probably never happen), then the corresponding error would be thrown from a dsc script that has a call to ctypes API which should be sufficient. 

@KrisBash, @Microsoft/omsagent-devs 