### PR TITLE
Explictly create new directories as 755

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -858,7 +858,10 @@ create_workspace_directories()
 make_dir()
 {
     if [ ! -d $1 ]; then
-        mkdir $1
+        mkdir -m 755 $1
+    else
+        echo "Directory $1 already exists."
+        chmod 755 $1
     fi
 
     chown_omsagent $1

--- a/source/code/plugins/in_dsc_monitor.rb
+++ b/source/code/plugins/in_dsc_monitor.rb
@@ -1,6 +1,7 @@
 require 'fluent/input'
 require 'fluent/config/error'
 require 'yaml/store'
+require 'fileutils'
 
 module Fluent
   class DscMonitoringInput < Input
@@ -24,7 +25,12 @@ module Fluent
       @finished_check_status = false
       @thread_check_install = Thread.new(&method(:run_check_install))
       @thread_check_status = Thread.new(&method(:run_check_status))
-      @dsc_cache = YAML::Store.new(dsc_cache_file) #Creates the file if it doesn't exist; otherwise, the existing file will be read.
+      if !File.exists?(dsc_cache_file)
+        File.new(dsc_cache_file, "w", 0644)
+      else
+        File.chmod(0644, dsc_cache_file)
+      end
+      @dsc_cache = YAML::Store.new(dsc_cache_file) # The existing file will be read.
     end
 
     def check_install


### PR DESCRIPTION
Before multi-homing, these directories were created as 755
See code at https://github.com/Microsoft/OMS-Agent-for-Linux/blob/467e845719215e2d4e0e24b9bec95eac4e999e29/installer/datafiles/base_omsagent.data

Restrict file permissions for in_dsc_monitor cache file

@Microsoft/omsagent-devs @FayzaSultan