### PR TITLE
Regenerate in_exec.patch to re-apply from old verison

### DIFF
--- a/source/ext/patches/fluentd/in_exec.patch
+++ b/source/ext/patches/fluentd/in_exec.patch
@@ -1,14 +1,14 @@
---- ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb	2017-03-02 15:44:49.000000000 -0800
-+++ ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb.new	2017-03-02 15:49:09.000000000 -0800
-@@ -133,17 +133,19 @@
-      @parser.call(@io)
-+     Process.waitpid(@io.pid)
-    end
-
-    def run_periodic
-      sleep @run_interval
-      until @finished
-        begin
+--- ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb	2017-06-09 10:04:25.000000000 -0700
++++ ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb.new	2017-06-09 10:03:00.000000000 -0700
+@@ -131,6 +131,7 @@
+ 
+     def run
+       @parser.call(@io)
++      Process.waitpid(@io.pid)
+     end
+ 
+     def run_periodic
+@@ -140,10 +141,11 @@
            io = IO.popen(@command, "r")
            @parser.call(io)
            Process.waitpid(io.pid)


### PR DESCRIPTION
@Microsoft/omsagent-devs @ikanni 

With commit https://github.com/Microsoft/OMS-Agent-for-Linux/commit/913ef16994a0729e4a7b74b59cd30eab2e4d3763 this patch was not getting applied correctly.
I have re-generated this patch file and verified that it now patches the in_exec.rb file correctly from the FluentD version.