### PR TITLE
Remove default perf counters

### DIFF
--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -12,29 +12,13 @@
   run_interval 20m
 </source>
 
-<source>
-  type oms_omi
-  object_name "Logical Disk"
-  instance_regex ".*"
-  counter_name_regex "(% Used Inodes|Free Megabytes|% Used Space|Disk Reads/sec|Disk Transfers/sec|Disk Writes/sec)"
-  interval 5m
-</source>
-
-<source>
-  type oms_omi
-  object_name "Processor"
-  instance_regex ".*"
-  counter_name_regex "(% Privileged Time|% Processor Time)"
-  interval 30s
-</source>
-
-<source>
-  type oms_omi
-  object_name "Memory"
-  instance_regex ".*"
-  counter_name_regex "(% Used Memory|% Used Swap Space|Available MBytes Memory)"
-  interval 30s
-</source>
+#<source>
+#  type oms_omi
+#  object_name "Memory"
+#  instance_regex ".*"
+#  counter_name_regex "(% Used Memory|% Used Swap Space|Available MBytes Memory)"
+#  interval 30s
+#</source>
 
 #<source>
 #  type tail


### PR DESCRIPTION
This PR resolves the issue with omsagent default perf counters being out of sync with OMs workspace defaults. Before the fix omsagent after clean installation will send data for 3 perf counters: Memory, Processor and LogicalDisk, when by default OMS workspace in the portal is setup without any defaults.

@Microsoft/omsagent-devs 