### PR TITLE
npmd: checking if subnet id with 0.0.0.0 and big prefix is ipv6

### DIFF
--- a/source/code/plugins/npmd_config_lib.rb
+++ b/source/code/plugins/npmd_config_lib.rb
@@ -161,7 +161,17 @@ module NPMDConfig
             _h["IDs"] = Hash.new
             begin
                 subnetHash.each do |key, value|
-                    _tempIp = IPAddr.new(value)
+                    _tempIp = nil
+                    begin
+                        _tempIp = IPAddr.new(value)
+                    rescue StandardError => e
+                        _tempArr = value.split('/')
+                        if (_tempArr[0] == "0.0.0.0" and !_tempArr[1].nil?)
+                            _tempIp = IPAddr.new("::/#{_tempArr[1]}")
+                        else
+                            raise e
+                        end
+                    end
                     _h["Masks"][key] = getNetMask(_tempIp)
                     _h["IDs"][key] = _tempIp.to_s
                 end


### PR DESCRIPTION
Trying to see if 0.0.0.0 with prefix like 128 is ipv6.