### PR TITLE
Only log that created directories exist in verbose case

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -904,7 +904,9 @@ make_dir()
     if [ ! -d $1 ]; then
         mkdir -m 755 $1
     else
-        echo "Directory $1 already exists."
+        if [ $VERBOSE -eq 1 ]; then
+            echo "Directory $1 already exists."
+        fi
         chmod 755 $1
     fi
 


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Decreases the unneeded verbosity of the onboarding logs; this is a message that doesn't need to be logged most of the time.