### PR TITLE
npmd: check if agentid file exists to get omsagent guid

### DIFF
--- a/source/code/plugins/in_npmd_server.rb
+++ b/source/code/plugins/in_npmd_server.rb
@@ -15,6 +15,7 @@ module Fluent
             require 'securerandom'
             require 'etc'
             require 'enumerator'
+            require 'pathname'
 
             require_relative 'npmd_config_lib'
             require_relative 'oms_common'
@@ -49,6 +50,12 @@ module Fluent
         NPMD_AGENT_CAPABILITY = "cap_net_raw+ep"
         NPMD_STATE_DIR = "/var/opt/microsoft/omsagent/npm_state"
         NPMD_VERSION_FILE_NAME = "npm_version"
+
+        OMS_AGENTGUID_FILE = "/etc/opt/microsoft/omsagent/agentid"
+        OMS_ADMIN_CONF_PATH_COMP_TOTAL = 8
+        OMS_ADMIN_CONF_PATH_COMP_WS_IDX = 5
+        GUID_LEN = 36
+
 
         config_param :omsadmin_conf_path,     :string, :default => "/etc/opt/microsoft/omsagent/conf/omsadmin.conf"
         config_param :location_unix_endpoint, :string, :default => "#{NPMD_STATE_DIR}/npmdagent.sock"
@@ -408,7 +415,35 @@ module Fluent
 
         end
 
+        def get_workspace_id()
+            if !@omsadmin_conf_path.nil?
+                path = nil
+                begin
+                    path = Pathname.new(@omsadmin_conf_path).cleanpath
+                rescue
+                    return nil
+                end
+                _arr = "#{path}".split('/')
+                if (_arr.length == OMS_ADMIN_CONF_PATH_COMP_TOTAL and _arr[OMS_ADMIN_CONF_PATH_COMP_WS_IDX].length == GUID_LEN)
+                    return _arr[OMS_ADMIN_CONF_PATH_COMP_WS_IDX]
+                end
+            end
+            nil
+        end
+
+        def get_agent_id_from_guid_file()
+            ws_id = get_workspace_id()
+            if !ws_id.nil? and File.exist?(OMS_AGENTGUID_FILE)
+                computer_id = File.read(OMS_AGENTGUID_FILE, GUID_LEN).strip
+                return "#{computer_id}##{ws_id}" if computer_id.length == GUID_LEN
+            end
+            nil
+        end
+
         def get_agent_id
+            agentguid = get_agent_id_from_guid_file()
+            return agentguid if !agentguid.nil?
+
             agentid_lines = IO.readlines(@omsadmin_conf_path).select { |line| line.start_with?("AGENT_GUID=")}
             if agentid_lines.size == 0
                 return nil


### PR DESCRIPTION
If agentid file exists then utilize that for computer id.
To identify an instance of omsagent we utilize computer id and
workspace id.