### PR TITLE
Add plugin to convert record into SCOM event format

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -118,11 +118,12 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/filter_scom_simple_match.rb;             source/code/plugins/filter_scom_simple_match.rb;       744; root; root
 /opt/microsoft/omsagent/plugin/filter_scom_excl_match.rb;               source/code/plugins/filter_scom_excl_match.rb;         744; root; root
 /opt/microsoft/omsagent/plugin/filter_scom_cor_match.rb;                source/code/plugins/filter_scom_cor_match.rb;          744; root; root
-/opt/microsoft/omsagent/plugin/filter_scom_repeated_cor.rb;             source/code/plugins/filter_scom_repeated_cor.rb;          744; root; root
-/opt/microsoft/omsagent/plugin/filter_scom_excl_correlation.rb;         source/code/plugins/filter_scom_excl_correlation.rb;          744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_repeated_cor.rb;             source/code/plugins/filter_scom_repeated_cor.rb;       744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_excl_correlation.rb;         source/code/plugins/filter_scom_excl_correlation.rb;   744; root; root
+/opt/microsoft/omsagent/plugin/filter_scom_converter.rb;                source/code/plugins/filter_scom_converter.rb;          744; root; root
 /opt/microsoft/omsagent/plugin/scom_common.rb;                          source/code/plugins/scom_common.rb;                    744; root; root
-/opt/microsoft/omsagent/plugin/scom_configuration.rb;                   source/code/plugins/scom_configuration.rb;                    744; root; root
-/opt/microsoft/omsagent/plugin/out_scom.rb;                             source/code/plugins/out_scom.rb;                        744; root; root
+/opt/microsoft/omsagent/plugin/scom_configuration.rb;                   source/code/plugins/scom_configuration.rb;             744; root; root
+/opt/microsoft/omsagent/plugin/out_scom.rb;                             source/code/plugins/out_scom.rb;                       744; root; root
 
 %Links
 /opt/microsoft/omsagent/bin/omsagent; /opt/microsoft/omsagent/ruby/bin/fluentd; 755; root; root

--- a/source/code/plugins/filter_scom_converter.rb
+++ b/source/code/plugins/filter_scom_converter.rb
@@ -1,0 +1,38 @@
+module Fluent
+  class SCOMConverter < Filter
+  # Filter plugin to covert the input records to SCOM event format
+  Fluent::Plugin.register_filter('filter_scom_converter', self)
+
+  desc 'event number to be sent to SCOM'
+  config_param :event_id, :string, :default => nil
+  desc 'event description to be sent to SCOM'
+  config_param :event_desc, :string, :default => nil
+
+  def initialize()
+    super
+    require_relative 'scom_common'
+  end
+
+  def configure(conf)
+    super
+    raise ConfigError, "Configuration does not have corresponding event ID" unless @event_id
+  end
+
+  def start()
+    super
+  end
+
+  def shutdown()
+    super
+  end
+
+  def filter(tag, time, record)
+    $log.debug "Generating SCOM Event with id: #{@event_id} and data: #{record}" 
+    result = SCOM::Common.get_scom_record(time, @event_id, @event_desc, record)
+    result
+  end
+  
+  end # class SCOMConverter
+end # module Fluent
+  
+  

--- a/source/code/plugins/filter_scom_cor_match.rb
+++ b/source/code/plugins/filter_scom_cor_match.rb
@@ -53,7 +53,7 @@ module Fluent
       if @exp1_found and @expression2.match(record[key2].to_s)
         # Match found: Change state, stop timer and form SCOM event
         reset_timer()
-        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc, record)
         $log.debug "Event found for ID #{@event_id}"
       end # if
       result

--- a/source/code/plugins/filter_scom_excl_correlation.rb
+++ b/source/code/plugins/filter_scom_excl_correlation.rb
@@ -19,6 +19,7 @@ module Fluent
         
     def initialize()
       super
+      @event_record = nil;
     end
         
     def configure(conf)
@@ -38,12 +39,14 @@ module Fluent
       if !@exp1_found and @expression1.match(record[key1].to_s)
         # Match found, change state to exp1_found and start timer
         set_timer()
+        @event_record = record;
         $log.debug "Match found for regex #{@regexp1} ID #{@event_id}. Timer Started."
       end # if
       #Check for regexp2 match if regexp1 was found
       if @exp1_found and @expression2.match(record[key2].to_s)
         #Match found: change state and stop timer
         reset_timer()
+        @event_record = nil;
       end # if
       record
     end
@@ -52,7 +55,8 @@ module Fluent
       super
       time = Engine.now
       # Match for regexp2 not found within time, form SCOM event
-      result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+      result = SCOM::Common.get_scom_record(time, @event_id, @event_desc, @event_record)
+      @event_record = nil;
       $log.debug "Event found for ID #{@event_id}"
       router.emit("scom.event", time, result)
     end

--- a/source/code/plugins/filter_scom_excl_match.rb
+++ b/source/code/plugins/filter_scom_excl_match.rb
@@ -39,7 +39,7 @@ module Fluent
       result = record
       #Check if regexp1 matches and regexp2 doesn't in the same record
       if @expression1.match(record[key1].to_s) and !(@expression2.match(record[key2].to_s))
-        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc, record)
         $log.debug "Event found for ID #{@event_id}"
       end
       result

--- a/source/code/plugins/filter_scom_repeated_cor.rb
+++ b/source/code/plugins/filter_scom_repeated_cor.rb
@@ -52,7 +52,7 @@ module Fluent
         # Reset state and counter. Form SCOM event.
         reset_timer()
         reset_counter()
-        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc)
+        result = SCOM::Common.get_scom_record(time, @event_id, @event_desc, record)
         $log.debug "Event found for ID #{@event_id}"
       end # if
       result

--- a/source/code/plugins/filter_scom_simple_match.rb
+++ b/source/code/plugins/filter_scom_simple_match.rb
@@ -52,7 +52,7 @@ module Fluent
       @regexps.each do |key, events|
         events.each do |event|
           if event.regexp.match(record[key].to_s)
-            result = SCOM::Common.get_scom_record(time, event.event_id, event.event_desc)
+            result = SCOM::Common.get_scom_record(time, event.event_id, event.event_desc, record)
             $log.debug "Event found for ID #{event.event_id}"
             return result
           end # if

--- a/source/code/plugins/scom_common.rb
+++ b/source/code/plugins/scom_common.rb
@@ -21,10 +21,11 @@ module SCOM
     require_relative 'scom_configuration'
     require_relative 'omslog'
         
-    def self.get_scom_record(time, event_id, event_desc)
+    def self.get_scom_record(time, event_id, event_desc, event_data)
       scom_record = {
           "CustomMessage"=>event_desc,
           "EventID"=>event_id,
+          "EventData"=>event_data.to_s,
           "TimeGenerated"=>time.to_s,
       }
       scom_event = {

--- a/test/code/plugins/filter_scom_converter_test.rb
+++ b/test/code/plugins/filter_scom_converter_test.rb
@@ -1,0 +1,41 @@
+require 'fluent/test'
+require_relative '../../../source/code/plugins/filter_scom_converter'
+
+  class SCOMConverterTest < Test::Unit::TestCase
+    
+    def setup
+      Fluent::Test.setup
+    end
+    
+    def teardown
+    end
+    
+    CONFIG = %[
+      event_id 0001
+      event_desc TestDesc
+    ]
+    
+    def create_driver(conf=CONFIG)
+      Fluent::Test::FilterTestDriver.new(Fluent::SCOMConverter).configure(conf)
+    end
+    
+    def test_configure
+      d = create_driver
+      assert_equal(d.instance.instance_variable_get(:@event_id), '0001')
+      assert_equal(d.instance.instance_variable_get(:@event_desc), 'TestDesc')
+    end
+    
+    def test_filter
+      d = create_driver
+      
+      d.run do
+        d.emit({"key1"=>"value1", "key2"=>"value2"})
+        d.emit({"key1"=>"value1", "key2"=>[{"key11"=>"value11"}, {"key12"=>"value12"}]})
+      end
+      
+      assert_equal(d.emits.length, 2)
+      assert_equal(d.emits[0][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "EventData"=>"{\"key1\"=>\"value1\", \"key2\"=>\"value2\"}", "TimeGenerated"=>"#{d.emits[0][1]}"}]})
+      assert_equal(d.emits[1][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "EventData"=>"{\"key1\"=>\"value1\", \"key2\"=>[{\"key11\"=>\"value11\"}, {\"key12\"=>\"value12\"}]}", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
+    end
+    
+  end

--- a/test/code/plugins/filter_scom_cor_match_test.rb
+++ b/test/code/plugins/filter_scom_cor_match_test.rb
@@ -42,7 +42,7 @@ require 'socket'
       
       assert_equal(d.emits.length, 2)
       assert_equal(d.emits[0][2], {"message"=>"Installing package Unittest1"})
-      assert_equal(d.emits[1][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
+      assert_equal(d.emits[1][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "EventData"=>"{\"message\"=>\"Install failed for package Unittest1\"}", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
     end
     
   end

--- a/test/code/plugins/filter_scom_excl_match_test.rb
+++ b/test/code/plugins/filter_scom_excl_match_test.rb
@@ -39,7 +39,7 @@ require 'socket'
       end
       
       assert_equal(d.emits.length, 2)
-      assert_equal(d.emits[1][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
+      assert_equal(d.emits[1][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "EventData"=>"{\"message\"=>\"Insertion of doc2\", \"status\"=>\"failed\"}", "TimeGenerated"=>"#{d.emits[1][1]}"}]})
       assert_equal(d.emits[0][2], {"message"=>"Insertion of doc1", "status"=>"succeeded"})
     end
     

--- a/test/code/plugins/filter_scom_repeated_cor_test.rb
+++ b/test/code/plugins/filter_scom_repeated_cor_test.rb
@@ -43,7 +43,7 @@ require 'socket'
       assert_equal(d.emits.length, 3)
       assert_equal(d.emits[0][2], {"message"=>"Authentication Failed"})
       assert_equal(d.emits[1][2], {"message"=>"Authentication Failed"})
-      assert_equal(d.emits[2][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
+      assert_equal(d.emits[2][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc", "EventID"=>"0001", "EventData"=>"{\"message\"=>\"Authentication Failed\"}", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
     end
     
   end

--- a/test/code/plugins/filter_scom_simple_match_test.rb
+++ b/test/code/plugins/filter_scom_simple_match_test.rb
@@ -42,8 +42,8 @@ require 'socket'
       end
       
       assert_equal(d.emits.length, 3)
-      assert_equal(d.emits[0][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc1", "EventID"=>"0001", "TimeGenerated"=>"#{d.emits[0][1]}"}]})
-      assert_equal(d.emits[2][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc2", "EventID"=>"0002", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
+      assert_equal(d.emits[0][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc1", "EventID"=>"0001", "EventData"=>"{\"message\"=>\"TestRegex1\"}", "TimeGenerated"=>"#{d.emits[0][1]}"}]})
+      assert_equal(d.emits[2][2], {"CustomEvents"=>[{"CustomMessage"=>"TestDesc2", "EventID"=>"0002", "EventData"=>"{\"message\"=>\"TestRegex2\"}", "TimeGenerated"=>"#{d.emits[2][1]}"}]})
       assert_equal(d.emits[1][2], {"message"=>"WrongRegex"})
     end
     


### PR DESCRIPTION
@Microsoft/omsagent-devs 

A new filter plugin (filter_scom_converter) is added that
will convert the records it receive into SCOM event format.
It will enable the customers to generate events using
other Fluentd plugins.

Also existing SCOM plugins will sent log record, that
triggered the event, along with other event data.