### PR TITLE
Split mysql logs from mysql and update docs

### DIFF
--- a/docs/OMS-MySQL-Logs-Instructions.md
+++ b/docs/OMS-MySQL-Logs-Instructions.md
@@ -1,4 +1,4 @@
-# MySQL Server and Log Monitoring Solution for Operations Management Suite
+# MySQL Server Log Monitoring Solution for Operations Management Suite
 
 1. Setup a supported Linux machine and install [MySQL](http://dev.mysql.com/doc/refman/5.7/en/installing.html).
 
@@ -11,21 +11,12 @@
 
 4. Configure MySQL to generate [slow](http://dev.mysql.com/doc/refman/5.7/en/slow-query-log.html), [error](http://dev.mysql.com/doc/refman/5.7/en/error-log.html), and [general](http://dev.mysql.com/doc/refman/5.7/en/query-log.html) logs.
 
-5. Verify and update the MySQL log file path in the configuration file `/etc/opt/microsoft/omsagent/<workspace id>/conf/omsagent.d/mysql.conf`  
-If `mysql.conf` is not present in the above location, move it:  
-`sudo cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/mysql.conf /etc/opt/microsoft/omsagent/<workspace id>/conf/omsagent.d/`  
-`sudo chown omsagent:omiusers /etc/opt/microsoft/omsagent/<workspace id>/conf/omsagent.d/mysql.conf`
+5. Verify and update the MySQL log file path in the configuration file `/etc/opt/microsoft/omsagent/<workspace id>/conf/omsagent.d/mysql_logs.conf`  
+If `mysql_logs.conf` is not present in the above location, move it:  
+`sudo cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/mysql_logs.conf /etc/opt/microsoft/omsagent/<workspace id>/conf/omsagent.d/`  
+`sudo chown omsagent:omiusers /etc/opt/microsoft/omsagent/<workspace id>/conf/omsagent.d/mysql_logs.conf`
 
   ```config
-  # MySQL Workload
-  
-  <source>
-    ...
-    username <MySQL-username>
-    password <MySQL-password-for-username>
-    ...
-  </source>
-  
   # MySQL General Log
   
   <source>

--- a/installer/conf/omsagent.d/mysql.conf
+++ b/installer/conf/omsagent.d/mysql.conf
@@ -1,4 +1,7 @@
 # MySQL Workload
+# Sample configuration that defines all required input parameters to enable MySQL ruby plugin which is an alternative solution to omsagent default MySQL CIM provider: https://github.com/Microsoft/SCXcore-osskits/tree/7bedcd2fd0322b39349d429cb530db07a8dad522
+# To use MySQL ruby plugin, install mysql2 gem from omsagent local ruby gem path, then copy this configuration file to omsagent local folder:
+# sudo cp /etc/opt/microsoft/omsagent/sysconf/omsagent.d/mysql.conf /etc/opt/microsoft/omsagent/<workspace id>/conf/omsagent.d/
 
 <source>
   type            mysql_workload
@@ -9,97 +12,3 @@
   interval        30s                 # Optional (default: 1m)
   tag             oms.mysql_workload  # Required
 </source>
-
-
-# MySQL General Log
-
-<source>
-  type tail
-  tag oms.api.MySQL.General.logs
-  format /^((?<Timestamp>[\d\-]{4,10}\s{0,4}\d{0,2}:\d{0,2}:\d{0,2}|[\d\-T:\.Z]{20,30})|\s{0,10})\s+(?<Id>\d+)\s+(?<Command>\w+)\s+(?<Arguments>\z|.+)$/
-  path /var/log/mysql/mysql.log
-  pos_file /var/opt/microsoft/omsagent/state/var_log_mysql_log.pos
-</source>
-
-# MySQL Error Log
-
-<source>
-  type tail
-  tag oms.api.MySQL.Error.logs
-  format /^(?<Timestamp>[\d\-]{4,10}\s{0,4}\d{0,2}:\d{0,2}:\d{0,2}|[\d\-T:\.Z]{20,30})\s{0,4}(?<Id>\d+)?\s{0,4}(\[(?<Command>[A-Za-z]+)\])?\s+(?<Arguments>.*)$/
-  path /var/log/mysql/error.log
-  pos_file /var/opt/microsoft/omsagent/state/var_log_mysql_error_log.pos
-</source>
-
-# MySQL Slow Query Log
-
-<source>
-  type tail
-  tag oms.api.MySQL.SlowQuery.logs
-  format multiline
-  format_firstline /^\s{0,2}\#\s{0,2}User@Host/
-  format1 /^\s{0,2}\#\s{0,2}User@Host: +(?<UserHost>.+\])\s*(Id\:\s*(?<Id>\d+))?\n/
-  format2 /^\#\s{0,4}Query_time\:\s{0,4}(?<QueryTime>[\-\+]?[\.\d]*)\s{0,4}Lock_time\:\s{0,4}(?<LockTime>[\-\+]?[\.\d]*)\s{0,4}Rows_sent\:\s{0,4}(?<RowsSent>\d*)\s{0,4}Rows_examined\:\s{0,4}(?<RowsExamined>\d*)[^;]*(\;)?\n/
-  format3 /^\s{0,4}SET\s{0,4}timestamp\=(?<Timestamp>\d*)\;\s{0,4}\n/
-  format4 /^(?<Query>[^;]*;)/
-  multiline_flush_interval 4s
-  path /var/log/mysql/mysql-slow.log
-  pos_file /var/opt/microsoft/omsagent/state/var_log_mysql_slow_log.pos
-  types QueryTime:float,LockTime:float,RowsSent:integer,RowsExamined:integer
-</source>
-
-# Filter Plugins
-
-# All MySQL Logs
-<filter oms.api.MySQL.**>
-  type record_transformer
-  enable_ruby
-  <record>
-    ResourceName MySQL
-    ResourceType ${tag.split('.')[3]}
-    Computer ${OMS::Common.get_hostname}
-    ResourceId ${OMS::Common.get_hostname}
-  </record>
-</filter>
-
-# General Logs
-<filter oms.api.MySQL.General.logs>
-  type record_transformer
-  enable_ruby
-  <record>
-    Timestamp ${DateTime.parse(record["Timestamp"]).strftime("%FT%H:%M:%S.%3NZ") if record["Timestamp"]}
-  </record>
-</filter>
-
-# Slow Query Logs
-<filter oms.api.MySQL.SlowQuery.logs>
-  type record_transformer
-  enable_ruby
-  <record>
-    Timestamp ${OMS::Common.format_time(record["Timestamp"].to_i)}
-  </record>
-</filter>
-
-#Error Logs
-<filter oms.api.MySQL.Error.logs>
-  type record_transformer
-  enable_ruby
-  <record>
-    Timestamp ${DateTime.parse(record["Timestamp"]).strftime("%FT%H:%M:%S.%3NZ")}
-  </record>
-</filter>
-
-# Output Plugin
-
-<match oms.api.MySQL.**>
-  type out_oms_api
-  log_level info
-  buffer_chunk_limit 5m
-  buffer_type file
-  buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_mysql_logs*.buffer
-  buffer_queue_limit 10
-  flush_interval 20s
-  retry_limit 10
-  retry_wait 5s
-  max_retry_wait 5m
-</match>

--- a/installer/conf/omsagent.d/mysql_logs.conf
+++ b/installer/conf/omsagent.d/mysql_logs.conf
@@ -1,0 +1,92 @@
+# MySQL General Log
+
+<source>
+  type tail
+  tag oms.api.MySQL.General.logs
+  format /^((?<Timestamp>[\d\-]{4,10}\s{0,4}\d{0,2}:\d{0,2}:\d{0,2}|[\d\-T:\.Z]{20,30})|\s{0,10})\s+(?<Id>\d+)\s+(?<Command>\w+)\s+(?<Arguments>\z|.+)$/
+  path /var/log/mysql/mysql.log
+  pos_file /var/opt/microsoft/omsagent/state/var_log_mysql_log.pos
+</source>
+
+# MySQL Error Log
+
+<source>
+  type tail
+  tag oms.api.MySQL.Error.logs
+  format /^(?<Timestamp>[\d\-]{4,10}\s{0,4}\d{0,2}:\d{0,2}:\d{0,2}|[\d\-T:\.Z]{20,30})\s{0,4}(?<Id>\d+)?\s{0,4}(\[(?<Command>[A-Za-z]+)\])?\s+(?<Arguments>.*)$/
+  path /var/log/mysql/error.log
+  pos_file /var/opt/microsoft/omsagent/state/var_log_mysql_error_log.pos
+</source>
+
+# MySQL Slow Query Log
+
+<source>
+  type tail
+  tag oms.api.MySQL.SlowQuery.logs
+  format multiline
+  format_firstline /^\s{0,2}\#\s{0,2}User@Host/
+  format1 /^\s{0,2}\#\s{0,2}User@Host: +(?<UserHost>.+\])\s*(Id\:\s*(?<Id>\d+))?\n/
+  format2 /^\#\s{0,4}Query_time\:\s{0,4}(?<QueryTime>[\-\+]?[\.\d]*)\s{0,4}Lock_time\:\s{0,4}(?<LockTime>[\-\+]?[\.\d]*)\s{0,4}Rows_sent\:\s{0,4}(?<RowsSent>\d*)\s{0,4}Rows_examined\:\s{0,4}(?<RowsExamined>\d*)[^;]*(\;)?\n/
+  format3 /^\s{0,4}SET\s{0,4}timestamp\=(?<Timestamp>\d*)\;\s{0,4}\n/
+  format4 /^(?<Query>[^;]*;)/
+  multiline_flush_interval 4s
+  path /var/log/mysql/mysql-slow.log
+  pos_file /var/opt/microsoft/omsagent/state/var_log_mysql_slow_log.pos
+  types QueryTime:float,LockTime:float,RowsSent:integer,RowsExamined:integer
+</source>
+
+# Filter Plugins
+
+# All MySQL Logs
+<filter oms.api.MySQL.**>
+  type record_transformer
+  enable_ruby
+  <record>
+    ResourceName MySQL
+    ResourceType ${tag.split('.')[3]}
+    Computer ${OMS::Common.get_hostname}
+    ResourceId ${OMS::Common.get_hostname}
+  </record>
+</filter>
+
+# General Logs
+<filter oms.api.MySQL.General.logs>
+  type record_transformer
+  enable_ruby
+  <record>
+    Timestamp ${DateTime.parse(record["Timestamp"]).strftime("%FT%H:%M:%S.%3NZ") if record["Timestamp"]}
+  </record>
+</filter>
+
+# Slow Query Logs
+<filter oms.api.MySQL.SlowQuery.logs>
+  type record_transformer
+  enable_ruby
+  <record>
+    Timestamp ${OMS::Common.format_time(record["Timestamp"].to_i)}
+  </record>
+</filter>
+
+#Error Logs
+<filter oms.api.MySQL.Error.logs>
+  type record_transformer
+  enable_ruby
+  <record>
+    Timestamp ${DateTime.parse(record["Timestamp"]).strftime("%FT%H:%M:%S.%3NZ")}
+  </record>
+</filter>
+
+# Output Plugin
+
+<match oms.api.MySQL.**>
+  type out_oms_api
+  log_level info
+  buffer_chunk_limit 5m
+  buffer_type file
+  buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_mysql_logs*.buffer
+  buffer_queue_limit 10
+  flush_interval 20s
+  retry_limit 10
+  retry_wait 5s
+  max_retry_wait 5m
+</match>

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -36,6 +36,7 @@ MAINTAINER:              'Microsoft Corporation'
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/statsd.conf;             installer/conf/omsagent.d/statsd.conf;                 644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/auditlog.conf;           installer/conf/omsagent.d/auditlog.conf;               644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/mysql.conf;              installer/conf/omsagent.d/mysql.conf;                  644; root; root
+/etc/opt/microsoft/omsagent/sysconf/omsagent.d/mysql_logs.conf;         installer/conf/omsagent.d/mysql_logs.conf;             644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/apache_logs.conf;        installer/conf/omsagent.d/apache_logs.conf;            644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/mongo.conf;              installer/conf/omsagent.d/mongo.conf;                  644; root; root
 /etc/opt/microsoft/omsagent/sysconf/omsagent.d/vmware_esxi.conf;        installer/conf/omsagent.d/vmware_esxi.conf;            644; root; root


### PR DESCRIPTION
This PR splits MySQL log related conf and documentation from MySQL plugin, based on ICM for the customer who used an incorrect article about MySQL logs to setup MySQL workload for OMS instead of MySQL topics documented on the main page..
@keikhara 
@Microsoft/omsagent-devs 