### PR TITLE
Fix omsadmind.sh if it is used in system tests

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -452,11 +452,14 @@ onboard()
         log_error "The Workspace ID is not valid"
         clean_exit $INVALID_CONFIG_PROVIDED
     fi
-
-    $SERVICE_CONTROL is-running $WORKSPACE_ID
-    if [ $? -eq 1 ]; then
-        echo "Workspace $WORKSPACE_ID already onboarded and agent is running."
-        return 0
+    
+    # If a test is not in progress then call service_control to check on the workspace status 
+    if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then
+        $SERVICE_CONTROL is-running $WORKSPACE_ID
+        if [ $? -eq 1 ]; then
+            echo "Workspace $WORKSPACE_ID already onboarded and agent is running."
+            return 0
+        fi
     fi
     create_workspace_directories $WORKSPACE_ID
 


### PR DESCRIPTION
Fix the regression in omsadmind.sh which causes system tests that mock
onboarding now fail due to service_control script not being present on the
machine during the system test run. Fixed same way as it is done in line #617.