### PR TITLE
Make OMS::Log usage consistent across plugins

### DIFF
--- a/source/code/plugins/flattenjson_lib.rb
+++ b/source/code/plugins/flattenjson_lib.rb
@@ -9,7 +9,7 @@ module OMS
       begin
         data = eval(select)
       rescue => e
-        Log.error_once("Invalid select: #{select} #{e}");
+        OMS::Log.error_once("Invalid select: #{select} #{e}");
       end
 
       if data.instance_of?(Array)

--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -527,7 +527,7 @@ module OMS
             end
           }
         rescue => error
-          Log.error_once("Unable to get the current time zone: #{error}")
+          OMS::Log.error_once("Unable to get the current time zone: #{error}")
         end
 
         # assign the tzID if the corresponding Windows Time Zone is not found
@@ -593,13 +593,13 @@ module OMS
             return @@Hostname
           end
         rescue => error
-          Log.warn_once("Unable to read the hostname from #{@@HostnameFilePath}: #{error}")
+          OMS::Log.warn_once("Unable to read the hostname from #{@@HostnameFilePath}: #{error}")
         end
 
         begin
           hostname = Socket.gethostname.split(".")[0]
         rescue => error
-          Log.error_once("Unable to get the Host Name: #{error}")
+          OMS::Log.error_once("Unable to get the Host Name: #{error}")
         else
           @@Hostname = hostname
         end
@@ -612,7 +612,7 @@ module OMS
         begin
           fqdn = Socket.gethostbyname(Socket.gethostname)[0]
         rescue => error
-          Log.error_once("Unable to get the FQDN: #{error}")
+          OMS::Log.error_once("Unable to get the FQDN: #{error}")
         else
           @@FQDN = fqdn
         end
@@ -629,7 +629,7 @@ module OMS
             begin
               Time.parse(installed_date)
             rescue ArgumentError
-              Log.error_once("Invalid install date: #{installed_date}")
+              OMS::Log.error_once("Invalid install date: #{installed_date}")
             else
               @@InstalledDate = installed_date
             end
@@ -756,7 +756,7 @@ module OMS
             # at this point we've given up up, we don't recognize
             # the encode, so return nil and log_warning for the 
             # record
-            Log.warn_once("Skipping due to failed encoding for #{record}: #{error}")
+            OMS::Log.warn_once("Skipping due to failed encoding for #{record}: #{error}")
           end
         end
         return msg
@@ -773,7 +773,7 @@ module OMS
         begin
           msg = JSON.dump(records)
         rescue JSON::GeneratorError => error
-          Log.warn_once("Unable to dump to JSON string. #{error}")
+          OMS::Log.warn_once("Unable to dump to JSON string. #{error}")
           begin
             # failed to dump, encode to utf-8, iso-8859-1 and try again
             # records is an array of hash
@@ -792,12 +792,12 @@ module OMS
           rescue => error
             # at this point we've given up, we don't recognize the encode,
             # so return nil and log_warning for the record
-            Log.warn_once("Skipping due to failed encoding for #{records}: #{error}")
+            OMS::Log.warn_once("Skipping due to failed encoding for #{records}: #{error}")
           end
         rescue => error
           # unexpected error when dumpping the records into JSON string
           # skip here and return nil
-          Log.warn_once("Skipping due to unexpected error for #{records}: #{error}")
+          OMS::Log.warn_once("Skipping due to unexpected error for #{records}: #{error}")
         end
 
         return msg
@@ -841,7 +841,7 @@ module OMS
           if res.code != "200"
             # Retry all failure error codes...
             res_summary = "(request-id=#{req["X-Request-ID"]}; class=#{res.class.name}; code=#{res.code}; message=#{res.message}; body=#{res.body};)"
-            Log.error_once("HTTP Error: #{res_summary}")
+            OMS::Log.error_once("HTTP Error: #{res_summary}")
             raise RetryRequestException, "HTTP error: #{res_summary}"
           end
 
@@ -879,7 +879,7 @@ module OMS
       begin
         addrinfos = Socket::getaddrinfo(hostname, "echo", Socket::AF_UNSPEC)
       rescue => error
-        Log.error_once("Unable to resolve the IP of '#{hostname}': #{error}")
+        OMS::Log.error_once("Unable to resolve the IP of '#{hostname}': #{error}")
         return nil
       end
 

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -25,12 +25,12 @@ module OMS
       # test the onboard file existence
       def test_onboard_file(file_name)
         if !File.file?(file_name)
-          Log.error_once("Could not find #{file_name} Make sure to onboard.")
+          OMS::Log.error_once("Could not find #{file_name} Make sure to onboard.")
           return false
         end
       
         if !File.readable?(file_name)
-          Log.error_once("Could not read #{file_name} Check that the read permissions are set for the omsagent user")
+          OMS::Log.error_once("Could not read #{file_name} Check that the read permissions are set for the omsagent user")
           return false
         end
 
@@ -50,7 +50,7 @@ module OMS
         end
 
         if proxy_config.nil?
-          Log.error_once("Failed to parse the proxy configuration in '#{proxy_conf_path}'")
+          OMS::Log.error_once("Failed to parse the proxy configuration in '#{proxy_conf_path}'")
           return {}
         end
 
@@ -82,10 +82,10 @@ module OMS
 
         endpoint_lines = IO.readlines(conf_path).select{ |line| line.start_with?("OMS_ENDPOINT")}
         if endpoint_lines.size == 0
-          Log.error_once("Could not find OMS_ENDPOINT setting in #{conf_path}")
+          OMS::Log.error_once("Could not find OMS_ENDPOINT setting in #{conf_path}")
           return false
         elsif endpoint_lines.size > 1
-          Log.warn_once("Found more than one OMS_ENDPOINT setting in #{conf_path}, will use the first one.")
+          OMS::Log.warn_once("Found more than one OMS_ENDPOINT setting in #{conf_path}, will use the first one.")
         end
 
         begin
@@ -96,7 +96,7 @@ module OMS
           @@NotifyBlobODSEndpoint = @@ODSEndpoint.clone
           @@NotifyBlobODSEndpoint.path = '/ContainerService.svc/PostBlobUploadNotification'
         rescue => e
-          Log.error_once("Error parsing endpoint url. #{e}")
+          OMS::Log.error_once("Error parsing endpoint url. #{e}")
           return false
         end
 
@@ -108,28 +108,28 @@ module OMS
             @@DiagnosticEndpoint.path = '/DiagnosticsDataService.svc/PostJsonDataItems'
           else
             if diagnostic_endpoint_lines.size > 1
-              Log.warn_once("Found more than one DIAGNOSTIC_ENDPOINT setting in #{conf_path}, will use the first one.")
+              OMS::Log.warn_once("Found more than one DIAGNOSTIC_ENDPOINT setting in #{conf_path}, will use the first one.")
             end
             diagnostic_endpoint_url = diagnostic_endpoint_lines[0].split("=")[1].strip
             @@DiagnosticEndpoint = URI.parse( diagnostic_endpoint_url )
           end
         rescue => e
-          Log.error_once("Error obtaining diagnostic endpoint url. #{e}")
+          OMS::Log.error_once("Error obtaining diagnostic endpoint url. #{e}")
           return false
         end
 
         agentid_lines = IO.readlines(conf_path).select{ |line| line.start_with?("AGENT_GUID")}
         if agentid_lines.size == 0
-          Log.error_once("Could not find AGENT_GUID setting in #{conf_path}")
+          OMS::Log.error_once("Could not find AGENT_GUID setting in #{conf_path}")
           return false
         elsif agentid_lines.size > 1
-          Log.warn_once("Found more than one AGENT_GUID setting in #{conf_path}, will use the first one.")
+          OMS::Log.warn_once("Found more than one AGENT_GUID setting in #{conf_path}, will use the first one.")
         end
 
         begin
           @@AgentId = agentid_lines[0].split("=")[1].strip
         rescue => e
-          Log.error_once("Error parsing agent id. #{e}")
+          OMS::Log.error_once("Error parsing agent id. #{e}")
           return false
         end
 
@@ -151,7 +151,7 @@ module OMS
           raw = File.read key_path
           @@Key  = OpenSSL::PKey::RSA.new raw
         rescue => e
-          Log.error_once("Error loading certs: #{e}")
+          OMS::Log.error_once("Error loading certs: #{e}")
           return false
         end
 

--- a/source/code/plugins/out_oms_api.rb
+++ b/source/code/plugins/out_oms_api.rb
@@ -134,7 +134,7 @@ module Fluent
       end
     rescue OMS::RetryRequestException => e
       @log.info "Encountered retryable exception. Will retry sending data later."
-      Log.error_once("Error for Request-ID: #{request_id} Error: #{e}")
+      OMS::Log.error_once("Error for Request-ID: #{request_id} Error: #{e}")
       @log.debug "Error:'#{e}'"
       # Re-raise the exception to inform the fluentd engine we want to retry sending this chunk of data later.
       raise e.message, "Request-ID: #{request_id}"

--- a/source/code/plugins/out_oms_blob.rb
+++ b/source/code/plugins/out_oms_blob.rb
@@ -92,7 +92,7 @@ module Fluent
       req.body = msg
       return req
     rescue OMS::RetryRequestException => e
-        Log.error_once("HTTP error for Request-ID: #{request_id} Error: #{e}")
+        OMS::Log.error_once("HTTP error for Request-ID: #{request_id} Error: #{e}")
         raise e.message, "Request-ID: #{request_id}"
     end # create_blob_put_request
 

--- a/source/code/plugins/out_oms_changetracking_file.rb
+++ b/source/code/plugins/out_oms_changetracking_file.rb
@@ -166,7 +166,7 @@ module Fluent
       req.body = msg
       return req
     rescue OMS::RetryRequestException => e
-        Log.error_once("HTTP error for Request-ID: #{request_id} Error: #{e}")
+        OMS::Log.error_once("HTTP error for Request-ID: #{request_id} Error: #{e}")
         raise e.message, "Request-ID: #{request_id}"
     end # create_blob_put_request
 


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Currently, Log.error_once (and warn_once, etc.) statements assume the Fluent::Log is being referred to, and this error shows in omsagent.log:
`.... error_class="NoMethodError" error="undefined method `error_once' for Fluent::Log:Class" ....`

This change explicitly scopes all uses of the OMS::Log class.