### PR TITLE
Heartbeat: let response be analyzed before returning the error code

### DIFF
--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -382,7 +382,6 @@ module MaintenanceModule
         res = http.start { |http_each| http.request(req) }
       rescue => e
         log_error("Error sending the heartbeat: #{e.message}")
-        return ERROR_SENDING_HTTP
       end
 
       if !res.nil?


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Commit 7096a0cc08e5f372477b16c525e8b9b40a48b161  added "return ERROR_SENDING_HTTP" which returns prematurely; the response from the failed HTTP transaction is checked and a return code is appropriately handled there.