### PR TITLE
Update mof to refer to correct module instead of PSDesiredStateConfiguration

### DIFF
--- a/installer/conf/omsagent.d/change_tracking_inventory.mof
+++ b/installer/conf/omsagent.d/change_tracking_inventory.mof
@@ -6,7 +6,7 @@ instance of MSFT_nxPackageResource
 {
                 Name = "*";
                 ResourceId = "[MSFT_nxPackageResource]Inventory";
-                ModuleName = "PSDesiredStateConfiguration";
+                ModuleName = "nx";
                 ModuleVersion = "1.0";
 
 

--- a/installer/conf/omsagent.d/patch_management_inventory.mof
+++ b/installer/conf/omsagent.d/patch_management_inventory.mof
@@ -6,7 +6,7 @@ instance of MSFT_nxAvailableUpdatesResource
 {
     Name = "*";
     ResourceId = "[MSFT_nxAvailableUpdates]Inventory";
-    ModuleName = "PSDesiredStateConfiguration";
+    ModuleName = "nx";
     ModuleVersion = "1.0";
 };
 

--- a/installer/conf/omsagent.d/service_change_tracking_inventory.mof
+++ b/installer/conf/omsagent.d/service_change_tracking_inventory.mof
@@ -7,7 +7,7 @@ instance of MSFT_nxServiceResource
                 Name = "*";
                 Controller = "*";
                 ResourceId = "[MSFT_nxServiceResource]Inventory";
-                ModuleName = "PSDesiredStateConfiguration";
+                ModuleName = "nx";
                 ModuleVersion = "1.0";
 
 

--- a/test/doc/change-tracking.md
+++ b/test/doc/change-tracking.md
@@ -27,7 +27,7 @@ instance of MSFT_nxPackageResource
 {
  Name = "*";
  ResourceId = "[MSFT_nxPackageResource]Inventory";
- ModuleName = "PSDesiredStateConfiguration";
+ ModuleName = "nx";
  ModuleVersion = "1.0";
 };
 
@@ -36,7 +36,7 @@ instance of MSFT_nxServiceResource
  Name = "*";
  Controller = "init";
  ResourceId = "[MSFT_nxFileResource]Inventory";
- ModuleName = "PSDesiredStateConfiguration";
+ ModuleName = "nx";
  ModuleVersion = "1.0";
 };
 

--- a/test/doc/patch-management.md
+++ b/test/doc/patch-management.md
@@ -30,7 +30,7 @@ instance of MSFT_nxPackageResource
 {
     Name = "*";
     ResourceId = "[MSFT_nxPackageResource]Inventory";
-    ModuleName = "PSDesiredStateConfiguration";
+    ModuleName = "nx";
     ModuleVersion = "1.0";
 };
 
@@ -38,7 +38,7 @@ instance of MSFT_nxAvailableUpdatesResource
 {
     Name = "*";
     ResourceId = "[MSFT_nxAvailableUpdates]Inventory";
-    ModuleName = "PSDesiredStateConfiguration";
+    ModuleName = "nx";
     ModuleVersion = "1.0";
 };
 


### PR DESCRIPTION
This PR fixes the typo in the mof files that reference to DSC module PSDesiredStateConfiguration instead of nx and nxFileInventory. Apparently, the module name is not used at the moment and by accident these mofs are parsed successfully, but eventually it will. Similar PR is created on Powershell-DSC-for_Linux repo.
@gauravga , @Atchub
