### PR TITLE
Stop is-running check from printing out "does not exist" messages

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -455,7 +455,7 @@ onboard()
     
     # If a test is not in progress then call service_control to check on the workspace status 
     if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then
-        $SERVICE_CONTROL is-running $WORKSPACE_ID
+        $SERVICE_CONTROL is-running $WORKSPACE_ID > /dev/null 2>&1
         if [ $? -eq 1 ]; then
             echo "Workspace $WORKSPACE_ID already onboarded and agent is running."
             return 0


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Without this change, every time a new workspace is onboarded, "Warning: Specified workspace xxxxxx does not exist on the machine. Check the correctness of the workspace ID and that onboarding succeeded." is printed to the console. This may be confusing to customers.

I have verified with this change that newly added workspaces still get onboarded, and already-added workspaces print "Workspace xxxxx already onboarded and agent is running." and exit cleanly.