### PR TITLE
Move AGENT_GUID to non-workspace-specific location to allow for single-machine agent ID

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -26,6 +26,7 @@ FILE_ONBOARD=/etc/omsagent-onboard.conf
 
 # Generated conf file containing information for this script
 CONF_OMSADMIN=$CONF_DIR/omsadmin.conf
+AGENTGUID_FILE=$ETC_DIR/agentid
 
 # Omsagent daemon configuration
 CONF_OMSAGENT=$CONF_DIR/omsagent.conf
@@ -170,7 +171,6 @@ save_config()
 {
     #Save configuration
     echo WORKSPACE_ID=$WORKSPACE_ID > $CONF_OMSADMIN
-    echo AGENT_GUID=$AGENT_GUID >> $CONF_OMSADMIN
     echo LOG_FACILITY=$LOG_FACILITY >> $CONF_OMSADMIN
     echo CERTIFICATE_UPDATE_ENDPOINT=$CERTIFICATE_UPDATE_ENDPOINT >> $CONF_OMSADMIN
     echo URL_TLD=$URL_TLD >> $CONF_OMSADMIN
@@ -180,6 +180,16 @@ save_config()
     echo OMSCLOUD_ID=$OMSCLOUD_ID | tr -d ' ' >> $CONF_OMSADMIN
     echo UUID=$UUID | tr -d ' ' >> $CONF_OMSADMIN
     chown_omsagent "$CONF_OMSADMIN"
+
+    save_agent_guid
+}
+
+save_agent_guid()
+{
+    if [ -n "$AGENT_GUID" ]; then
+        echo $AGENT_GUID > $AGENTGUID_FILE
+        chown_omsagent "$AGENTGUID_FILE"
+    fi
 }
 
 cleanup()
@@ -263,6 +273,7 @@ parse_args()
             REMOVE_ALL=1
             ;;
         M)
+            MIGRADE_AGENT_ID=1
             MIGRATE_OLD_WS=1
             MIGRATE_OLD_PROXY_CONF=1
             ;;
@@ -464,16 +475,44 @@ onboard()
     create_workspace_directories $WORKSPACE_ID
 
     if [ -f $FILE_KEY -a -f $FILE_CRT -a -f $CONF_OMSADMIN ]; then
-        # Keep the same agent GUID by loading it from the previous conf
-        AGENT_GUID=`grep AGENT_GUID $CONF_OMSADMIN | cut -d= -f2`
-        log_info "Reusing previous agent GUID $AGENT_GUID"
-    else
-        AGENT_GUID=`$RUBY -e "require 'securerandom'; print SecureRandom.uuid"`
-        if [ $? -ne 0 -o -z "$AGENT_GUID" ]; then
-            log_error "Error generating agent GUID"
-            clean_exit $RUBY_ERROR_GENERATING_GUID
+        # Certs have been generated from a GUID
+        CONF_OMSADMIN_AGENT_GUID=`grep AGENT_GUID $CONF_OMSADMIN | cut -d= -f2` # this may result in an empty string
+        if [ -f $AGENTGUID_FILE ]; then
+            AGENT_GUID=`cat $AGENTGUID_FILE`
+            if [ -z "$CONF_OMSADMIN_AGENT_GUID" ]; then
+                # There is no GUID stored in omsadmin.conf. The certs must have been generated with the machine GUID.
+                log_info "Reusing machine's agent GUID $AGENT_GUID"
+            elif [ "$CONF_OMSADMIN_AGENT_GUID" == "$AGENT_GUID" ]; then
+                # The GUID stored in omsadmin.conf matches the machine GUID. It will be removed from omsadmin.conf at the end of onboarding.
+                log_info "Reusing previous agent GUID $AGENT_GUID"
+            else
+                # The GUID stored in omsadmin.conf does NOT match the machine GUID. The certs will be re-generated with the machine GUID.
+                log_info "Workspace is using an old agent GUID: Using machine's agent GUID $AGENT_GUID"
+                GENERATE_CERTS="true"
+            fi
+        else
+            # The agent GUID hasn't been moved to the non-workspace-specific location yet. It will be saved there at the end of onboarding.
+            AGENT_GUID=$CONF_OMSADMIN_AGENT_GUID
+            log_info "Reusing previous agent GUID $AGENT_GUID"
         fi
+    else
+        GENERATE_CERTS="true"
+        if [ -f $AGENTGUID_FILE ]; then
+            AGENT_GUID=`cat $AGENTGUID_FILE`
+            log_info "Using machine's agent GUID $AGENT_GUID"
+        else
+            AGENT_GUID=`$RUBY -e "require 'securerandom'; print SecureRandom.uuid"`
+        fi
+    fi
 
+    if [ -z "$AGENT_GUID" ]; then
+        log_error "AGENT_GUID should not be empty"
+        return $INTERNAL_ERROR
+    else
+        log_info "Agent GUID is $AGENT_GUID"
+    fi
+
+    if [ -n "$GENERATE_CERTS" ]; then
         $RUBY $MAINTENANCE_TASKS_SCRIPT -c "$CONF_OMSADMIN" "$FILE_CRT" "$FILE_KEY" "$RUN_DIR/omsagent.pid" "$CONF_PROXY" "$OS_INFO" "$INSTALL_INFO" -w "$WORKSPACE_ID" -a "$AGENT_GUID" $CURL_VERBOSE
         generate_certs_ret=$?
         if [ $generate_certs_ret -eq $AGENT_MAINTENANCE_MISSING_CONFIG ]; then
@@ -483,13 +522,6 @@ onboard()
             log_error "Error generating certs"
             clean_exit $ERROR_GENERATING_CERTS
         fi
-    fi
-
-    if [ -z "$AGENT_GUID" ]; then
-        log_error "AGENT_GUID should not be empty"
-        return $INTERNAL_ERROR
-    else
-        log_info "Agent GUID is $AGENT_GUID"
     fi
 
     if [ "$VERBOSE" = "1" ]; then
@@ -808,6 +840,15 @@ list_workspaces()
     return 0
 }
 
+migrate_to_single_agent_id()
+{
+    # If there are any workspaces configured, move the agent GUID to the central location
+    if [ -f $CONF_OMSADMIN -a ! -f $AGENTGUID_FILE ]; then
+        AGENT_GUID=`grep AGENT_GUID $CONF_OMSADMIN | cut -d= -f2`
+        save_agent_guid
+    fi
+}
+
 migrate_old_workspace()
 {
     if [ -d $DF_CONF_DIR -a ! -h $DF_CONF_DIR -a -f $DF_CONF_DIR/omsadmin.conf ]; then
@@ -1067,6 +1108,10 @@ main()
 
     if [ "$LIST_WORKSPACES" = "1" ]; then
         list_workspaces || clean_exit 1
+    fi
+
+    if [ "$MIGRADE_AGENT_ID" = "1" ]; then
+        migrate_to_single_agent_id || clean_exit 1
     fi
 
     if [ "$MIGRATE_OLD_WS" = "1" ]; then

--- a/source/code/plugins/in_heartbeat_request.rb
+++ b/source/code/plugins/in_heartbeat_request.rb
@@ -19,6 +19,7 @@ module Fluent
     config_param :proxy_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf' #optional
     config_param :os_info, :string, :default => '/etc/opt/microsoft/scx/conf/scx-release' #optional
     config_param :install_info, :string, :default => '/etc/opt/microsoft/omsagent/sysconf/installinfo.txt' #optional
+    config_param :agentid_path, :string, :default => '/etc/opt/microsoft/omsagent/agentid' #optional
 
     def configure (conf)
       super
@@ -38,7 +39,8 @@ module Fluent
 
     def start
       @maintenance_script = MaintenanceModule::Maintenance.new(@omsadmin_conf_path, @cert_path,
-                              @key_path, @pid_path, @proxy_path, @os_info, @install_info, @log)
+                              @key_path, @pid_path, @proxy_path, @os_info, @install_info,
+                              @agentid_path, @log)
 
       if @run_interval
         @finished = false

--- a/source/code/plugins/oms_diag_lib.rb
+++ b/source/code/plugins/oms_diag_lib.rb
@@ -163,7 +163,7 @@ module OMS
       # Parameters:
       # @dataitems[mandatory]: Array of dataitems sent via LogDiag from
       # Input and Filter plugins
-      # @agentId[mandatory]: The omsagent guid parsed from omsadmin.conf
+      # @agentId[mandatory]: The omsagent guid parsed from OMS configuration
       def ProcessDataItemsPostAggregation(dataitems, agentId)
         # Remove all invalid dataitems
         dataitems.delete_if{|x| !IsValidDataItem?(x)}

--- a/test/code/plugins/agent_maintenance_script_plugintest.rb
+++ b/test/code/plugins/agent_maintenance_script_plugintest.rb
@@ -14,7 +14,6 @@ class MaintenanceUnitTest < Test::Unit::TestCase
                                       "int.com/ConfigurationService.Svc/RenewCertificate"
 
   VALID_OMSADMIN_CONF = "WORKSPACE_ID=#{VALID_WORKSPACE_ID}\n"\
-                        "AGENT_GUID=#{VALID_AGENT_GUID}\n"\
                         "LOG_FACILITY=local0\n"\
                         "CERTIFICATE_UPDATE_ENDPOINT=#{VALID_CERTIFICATE_UPDATE_ENDPOINT}\n"\
                         "URL_TLD=int2.microsoftatlanta-int.com\n"\
@@ -41,6 +40,7 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   def setup
     @omsadmin_conf_file = Tempfile.new("omsadmin_conf")
+    @agentid_file = Tempfile.new("agentid")
     @cert_file = Tempfile.new("oms_crt")
     @key_file = Tempfile.new("oms_key")
     @pid_file = Tempfile.new("omsagent_pid")  # doesn't need to have meaningful data for testing
@@ -52,6 +52,7 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   def teardown
     @omsadmin_conf_file.unlink
+    @agentid_file.unlink
     @cert_file.unlink
     @key_file.unlink
     @pid_file.unlink
@@ -62,12 +63,18 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   # Helper to create a new Maintenance class object to test
   def get_new_maintenance_obj(omsadmin_path = @omsadmin_conf_file.path,
-       cert_path = @cert_file.path, key_path = @key_file.path, pid_path = @pid_file.path,
-       proxy_path = @proxy_file.path, os_info_path = @os_info_file.path,
-       install_info_path = @install_info_file.path, log = @log, verbose = false)
+                              cert_path = @cert_file.path,
+                              key_path = @key_file.path,
+                              pid_path = @pid_file.path,
+                              proxy_path = @proxy_file.path,
+                              os_info_path = @os_info_file.path,
+                              install_info_path = @install_info_file.path,
+                              agentid_path = @agentid_file.path,
+                              log = @log,
+                              verbose = false)
 
     m = MaintenanceModule::Maintenance.new(omsadmin_path, cert_path, key_path, pid_path,
-         proxy_path, os_info_path, install_info_path, log, verbose)
+         proxy_path, os_info_path, install_info_path, agentid_path, log, verbose)
     m.suppress_stdout = true
     return m
   end
@@ -85,6 +92,7 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   def test_load_config_return_code
     File.write(@omsadmin_conf_file.path, VALID_OMSADMIN_CONF)
+    File.write(@agentid_file.path, "#{VALID_AGENT_GUID}\n")
     m = get_new_maintenance_obj
     assert_equal(m.load_config_return_code, 0, "load_config failed with valid config")
   end

--- a/test/code/plugins/out_oms_systestbase.rb
+++ b/test/code/plugins/out_oms_systestbase.rb
@@ -28,10 +28,10 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
 
   def prep_onboard
     # Make sure that we read test onboarding information from the environment varibles
-    assert(TEST_WORKSPACE_ID != nil, "TEST_WORKSPACE_ID should be set by the environment for this test to run.") 
+    assert(TEST_WORKSPACE_ID != nil, "TEST_WORKSPACE_ID should be set by the environment for this test to run.")
     assert(TEST_SHARED_KEY != nil, "TEST_SHARED_KEY should be set by the environment for this test to run.")
 
-    assert(TEST_WORKSPACE_ID.empty? == false, "TEST_WORKSPACE_ID should not be empty.") 
+    assert(TEST_WORKSPACE_ID.empty? == false, "TEST_WORKSPACE_ID should not be empty.")
     assert(TEST_SHARED_KEY.empty? == false, "TEST_SHARED_KEY should not be empty.")
 
     # Setup test onboarding script and folder
@@ -51,6 +51,7 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
     conf_path = "#{@omsadmin_test_dir_ws}/conf/omsadmin.conf"
     cert_path = "#{@omsadmin_test_dir_ws}/certs/oms.crt"
     key_path = "#{@omsadmin_test_dir_ws}/certs/oms.key"
+    agentid_path = @omsadmin_test_dir_ws.gsub(/\/[^\/]*$/, '') + '/agentid'
 
     conf = %[
       omsadmin_conf_path #{conf_path}
@@ -58,7 +59,7 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
       key_path #{key_path}
     ]
 
-    success = OMS::Configuration.load_configuration(conf_path, cert_path, key_path)
+    success = OMS::Configuration.load_configuration(conf_path, cert_path, key_path, agentid_path)
     assert_equal(true, success, "Configuration should be loaded")
 
     return conf

--- a/test/installer/scripts/agent_maintenance_script_systest.rb
+++ b/test/installer/scripts/agent_maintenance_script_systest.rb
@@ -68,6 +68,7 @@ class AgentMaintenanceSystemTest < MaintenanceSystemTestBase
     @pid_path = Tempfile.new("omsagent_pid")  # this does not need to be meaningful during testing
     @os_info_path = "#{@omsadmin_test_dir}/scx-release"
     @install_info_path = "#{@base_dir}/installer/conf/installinfo.txt"
+    @agentid_path = get_agentid_path(@omsadmin_test_dir_ws1)
     @log = OMS::MockLog.new
 
     @test_omsadmin_conf = Tempfile.new("omsadmin_conf")
@@ -88,11 +89,10 @@ class AgentMaintenanceSystemTest < MaintenanceSystemTestBase
   # Helper to create a new Maintenance class object to test; uses valid files by default
   def get_new_maintenance_obj(omsadmin_path = @omsadmin_conf_path, cert_path = @cert_path,
        key_path = @key_path, pid_path = @pid_path.path, proxy_path = @proxy_conf,
-       os_info_path = @os_info_path, install_info_path = @install_info_path, log = @log,
-       verbose = false)
-
+       os_info_path = @os_info_path, install_info_path = @install_info_path,
+       agentid_path = @agentid_path, log = @log, verbose = false)
     m = MaintenanceModule::Maintenance.new(omsadmin_path, cert_path, key_path, pid_path,
-         proxy_path, os_info_path, install_info_path, log, verbose)
+         proxy_path, os_info_path, install_info_path, agentid_path, log, verbose)
     m.suppress_stdout = true
     return m
   end

--- a/test/installer/scripts/maintenance_systestbase.rb
+++ b/test/installer/scripts/maintenance_systestbase.rb
@@ -82,9 +82,15 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
     return onboard_out
   end
 
+  def get_agentid_path(ws_dir)
+    omsagent_path = ws_dir.gsub(/\/[^\/]*$/, '')
+    agentid_path = omsagent_path + '/agentid'
+    return agentid_path
+  end
+
   def get_GUID(ws_dir = @omsadmin_test_dir_ws1)
-    conf = File.read("#{ws_dir}/conf/omsadmin.conf")
-    guid = conf[/AGENT_GUID=(.*)/, 1]
+    agentid_path = get_agentid_path(ws_dir)
+    guid = File.read(agentid_path).strip
     return guid
   end
 


### PR DESCRIPTION
npmd: check if agentid file exists to get omsagent guid (PR https://github.com/Microsoft/OMS-Agent-for-Linux/pull/508)
If agentid file exists then utilize that for NPM computer id.
To identify an instance of omsagent we utilize agent id and
workspace id.
Ensure agent ID is moved in upgrade from versions > 1.3

Unit and system tests passed
pBuild passed
Verified that agentid file was created under /etc/opt/microsoft/omsagent/ upon clean install
Verified that agentid file was created under /etc/opt/microsoft/omsagent/ using /etc/opt/microsoft/omsagent/conf/omsadmin.conf in --upgrade from version 1.4.0-12
Verified that agentid file was used to set the agent ID for additional multi-homed workspaces
Verified that agentid file remained after --remove

@Microsoft/omsagent-devs 