### PR TITLE
Skip time skew test if ntpdate command is not found

### DIFF
--- a/test/installer/scripts/time_systest.rb
+++ b/test/installer/scripts/time_systest.rb
@@ -5,7 +5,13 @@ require 'open-uri'
 class Time_Test < Test::Unit::TestCase
 
   def test_time_skew()
-    output = `ntpdate -q pool.ntp.org`
+    begin
+      output = `ntpdate -q pool.ntp.org`
+    rescue Errno::ENOENT
+      print "Warning: ntpdate command not found; cannot run time skew test"
+      return
+    end
+
     assert_equal(0, $?, "ntpdate command failed with error code : #{$?}")
     offset_line = output[/offset (.*) sec/]
     assert(offset_line != nil, "Could not find the offset line in '#{output}'")


### PR DESCRIPTION
@Microsoft/omsagent-devs 

If the ntpdate command is not found on the machine, then this test will return immediately.

On pBuild-based CentOS 5 machines, the ntpdate command is not installed (and I have not yet discovered how to install it). Because of this, system tests always fail and stop before running [systemtestsh](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/build/Makefile#L575) tests.