### PR TITLE
Enable multi-homing for in_dsc_monitor.rb

### DIFF
--- a/installer/conf/omsagent.d/operation.conf
+++ b/installer/conf/omsagent.d/operation.conf
@@ -1,6 +1,7 @@
 <source>
   type dsc_monitor 
   tag oms.operation.dsc
+  dsc_cache_file %STATE_DIR_WS%/dsc_cache.yml
 </source>
 
 <source>

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -1033,6 +1033,7 @@ copy_no_port_omsagent_d_conf()
     cp -p $SYSCONF_DIR/omsagent.d/container.conf $1 2>/dev/null
 
     update_path $1/heartbeat.conf
+    update_path $1/operation.conf
     if [ -f $1/container.conf ] ; then
         update_path $1/container.conf
     fi


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Have tested this by onboarding multiple workspaces; they get separate DSC cache files placed and proper string replacement in each copy of operation.conf.