### PR TITLE
Use omiconfigeditor to determine state of port 1270

### DIFF
--- a/installer/datafiles/linux_dpkg.data
+++ b/installer/datafiles/linux_dpkg.data
@@ -6,5 +6,5 @@ PACKAGE_TYPE: 'DPKG'
 %% In omsadmin.sh: 'curl' requires 'curl'
 curl
 
-omi (>= 1.0.8.6)
-scx (>= 1.6.2.129)
+omi (>= 1.3.0.2)
+scx (>= 1.6.3.212)

--- a/installer/datafiles/linux_rpm.data
+++ b/installer/datafiles/linux_rpm.data
@@ -7,8 +7,8 @@ SEPKG_DIR_OMSAGENT: '/usr/share/selinux/packages/omsagent-logrotate'
 %% In omsadmin.sh: 'curl' requires 'curl',
 curl
 
-omi >= 1.0.8-6
-scx >= 1.6.2-129
+omi >= 1.3.0-2
+scx >= 1.6.3-212
 
 %Files
 ${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.fc;                       installer/selinux/omsagent-logrotate.fc;                                 644; root; root


### PR DESCRIPTION
@Microsoft/omsagent-devs 
@jeffaco 

omiconfigeditor now supports query option. Existing
logic, to determine if port 1270 is open or not, is
updated to use omiconfigeditor.

PBUILD has passed for the changes.