### PR TITLE
Enable all workspace processes restarting upon --upgrade after --remove

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -208,39 +208,52 @@ fi
 #
 # Thus, if we're an upgrade, skip all of this cleanup
 ETC_DIR=/etc/opt/microsoft/omsagent
+VAR_DIR=/var/opt/microsoft/omsagent
 WORKSPACE_REGEX='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
 if ${{PERFORMING_UPGRADE_NOT}}; then
-   # Clean up /var directory tree
-   rm -rf /var/opt/microsoft/omsagent 2> /dev/null
-   
-   # Clean up /etc/opt directory tree (created via PostInstall) if dirs are empty
+   # Clean up directory trees: /etc/opt, /var/opt, /opt
    # If multi-workspace scenario
    for ws_id in `ls -1 $ETC_DIR | grep -E $WORKSPACE_REGEX`
     do
         echo "Deleting certs and conf directories for workspace $ws_id if empty..."
-        rmdir /etc/opt/microsoft/omsagent/$ws_id/certs/ 2> /dev/null
-        rmdir /etc/opt/microsoft/omsagent/$ws_id/conf/ 2> /dev/null
-        rm /opt/microsoft/omsagent/bin/omsagent-$ws_id 2> /dev/null		
-        rm /var/opt/microsoft/omsagent/$ws_id/tmp/Changetrackinginventory.xml* 2> /dev/null
-        rm /var/opt/microsoft/omsagent/$ws_id/tmp/LinuxFileChangeTracking.xml* 2> /dev/null
-        rm /var/opt/microsoft/omsagent/$ws_id/tmp/ServiceChangeTrackingInventory.xml* 2> /dev/null
+        rmdir $ETC_DIR/$ws_id/certs/ 2> /dev/null
+        rmdir $ETC_DIR/$ws_id/conf/ 2> /dev/null
+
+        rm /opt/microsoft/omsagent/bin/omsagent-$ws_id 2> /dev/null
+
+        rm -rf $VAR_DIR/$ws_id/tmp/ 2> /dev/null
+        rmdir $VAR_DIR/$ws_id/state/ 2> /dev/null
+        # /var/opt/microsoft/omsagent/<wkspc>/run/ and log/ should be left for later service start
     done
    
    # Clean up installinfo.txt file (registered as "conf" file to pass rpmcheck)
-   rm -f /etc/opt/microsoft/omsagent/sysconf/installinfo.txt*
-   rmdir /etc/opt/microsoft/omsagent/sysconf 2> /dev/null
+   rm -f $ETC_DIR/sysconf/installinfo.txt*
+   rmdir $ETC_DIR/sysconf 2> /dev/null
+
    # Clean up symbolic links if multi-workspace scenario
-   rm /etc/opt/microsoft/omsagent/certs 2> /dev/null
-   rm /etc/opt/microsoft/omsagent/conf 2> /dev/null
+   rm $ETC_DIR/certs 2> /dev/null
+   rm $ETC_DIR/conf 2> /dev/null
+   rm $VAR_DIR/tmp 2> /dev/null
+   rm $VAR_DIR/state 2> /dev/null
+   rm $VAR_DIR/run 2> /dev/null
+   rm $VAR_DIR/log 2> /dev/null
+
    # Clean up directory tree if agent installed or upgraded without onboarding. No symbolic links.
-   rmdir /etc/opt/microsoft/omsagent/certs/ 2> /dev/null
-   rmdir /etc/opt/microsoft/omsagent/conf/ 2> /dev/null
-   # Remove parent folders
-   rmdir /etc/opt/microsoft/omsagent 2> /dev/null
+   rmdir $ETC_DIR/certs/ 2> /dev/null
+   rmdir $ETC_DIR/conf/ 2> /dev/null
+   rmdir $VAR_DIR/tmp/ 2> /dev/null
+   rmdir $VAR_DIR/state/ 2> /dev/null
+   rmdir $VAR_DIR/run/ 2> /dev/null
+   rmdir $VAR_DIR/log/ 2> /dev/null
+
+   # Remove parent folders if they are empty
+   rmdir $ETC_DIR 2> /dev/null
    rmdir /etc/opt/microsoft 2> /dev/null
    rmdir /etc/opt 2> /dev/null
+   rmdir $VAR_DIR 2> /dev/null
    rmdir /opt/microsoft/omsagent/bin/ 2> /dev/null
    rmdir /opt/microsoft/omsagent/ 2> /dev/null
+
    # Clean up logrotate
    rm -f /etc/logrotate.d/omsagent*
    rm -f /etc/cron.d/omsagent

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -887,7 +887,7 @@ list_workspaces()
 
 migrate_to_single_agent_id()
 {
-    # If there are any workspaces configured, move the agent GUID to the central location
+    # If there is a symlinked workspace configured, move the agent GUID to the central location
     if [ -f $CONF_OMSADMIN -a ! -f $AGENTGUID_FILE ]; then
         echo "Migrating agent ID to multi-homing folder structure..."
         AGENT_GUID=`grep AGENT_GUID $CONF_OMSADMIN | cut -d= -f2`
@@ -925,6 +925,11 @@ migrate_pre_mh_workspace()
         sed -i s,%MONITOR_AGENT_PORT%,$DEFAULT_MONITOR_AGENT_PORT,1 $CONF_DIR/omsagent.d/monitor.conf
 
         update_symlinks
+    elif [ -d $DF_CONF_DIR -a ! -h $DF_CONF_DIR ]; then
+        # In some upgrade cases, conf and conf/omsagent.d directories are created and are empty
+        # Remove these directories if they are empty
+        rmdir $DF_CONF_DIR/omsagent.d 2> /dev/null
+        rmdir $DF_CONF_DIR 2> /dev/null
     fi
 }
 


### PR DESCRIPTION
Keep /var/opt/microsoft/omsagent/<workspace id>/log/ and run/ with --remove
-> Without these directories to store files in, the service is unable to start by itself

Ensure that any auto-created non-workspace-specific conf/ and omsagent.d/ directories are removed
-> If no onboarding explicitly happens, directories /etc/opt/microsoft/omsagent/conf/ and /etc/opt/microsoft/omsagent/conf/omsagent.d/ get created by package install.

Full Jenkins build (build, unit tests, system tests) passes. pBuild running now as a precaution.
Verified locally for upgrade and remove scenarios from previous versions and from this version with multiple workspaces.

@Microsoft/omsagent-devs 