### PR TITLE
Remove omsagent process limit when omsagent is uninstalled

### DIFF
--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -1,8 +1,9 @@
 %Variables
-PF:           'Linux'
-OMI_SERVICE:  '/opt/omi/bin/service_control'
-OMS_SERVICE:  '/opt/microsoft/omsagent/bin/service_control'
-CONF_SYSLOG:  '/opt/microsoft/omsagent/bin/configure_syslog.sh'
+PF:               'Linux'
+OMI_SERVICE:      '/opt/omi/bin/service_control'
+OMS_SERVICE:      '/opt/microsoft/omsagent/bin/service_control'
+CONF_SYSLOG:      '/opt/microsoft/omsagent/bin/configure_syslog.sh'
+OMSADMIN_SCRIPT:  '/opt/microsoft/omsagent/bin/omsadmin.sh'
 
 %Directories
 /etc;                                                   755; root; root; sysdir
@@ -136,6 +137,8 @@ ${{OMS_SERVICE}} start
 if ${{PERFORMING_UPGRADE_NOT}}; then
     ${{OMS_SERVICE}} disable
     ${{CONF_SYSLOG}} purge
+    # Remove the omsagent user process limit from limits.conf - should not be done during upgrade
+    ${{OMSADMIN_SCRIPT}} -r
 fi
 
 

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -160,6 +160,24 @@ class OmsadminTest < MaintenanceSystemTestBase
     assert_match(/New process limit must be at least/, output, "Did not find correct error message")
   end
 
+  def test_unset_proc_limit_when_set
+    FileUtils.cp("#{@omsadmin_test_dir}/limits-two-settings.conf", @proc_limits_conf)
+    output = unset_proc_limit
+    assert_match(/Removing process limit/, output, "Did not find expected removal message")
+    assert(FileUtils.compare_file(@proc_limits_conf,
+                                  "#{@omsadmin_test_dir}/limits-no-settings.conf"),
+           "Process limit conf file was not cleared out correctly")
+  end
+
+  def test_unset_proc_limit_when_not_set
+    FileUtils.cp("#{@omsadmin_test_dir}/limits-no-settings.conf", @proc_limits_conf)
+    output = unset_proc_limit
+    assert_not_match(/Removing process limit/, output, "Should not have found a limit")
+    assert(FileUtils.compare_file(@proc_limits_conf,
+                                  "#{@omsadmin_test_dir}/limits-no-settings.conf"),
+           "Process limit conf file was wrongly changed")
+  end
+
   def set_omsagent_proc_limit(val = nil, should_succeed = true)
     if val.nil?
       val = 75
@@ -178,6 +196,13 @@ class OmsadminTest < MaintenanceSystemTestBase
       assert_not_equal(0, ret_code.to_i, "The command to set the user process limit was " \
                                          "unexpectedly successful")
     end
+    return output
+  end
+
+  def unset_proc_limit
+    output = `#{@omsadmin_script} -r`
+    ret_code = $?
+    assert_equal(0, ret_code.to_i, "The command to unset the proc limit failed")
     return output
   end
 

--- a/test/installer/scripts/prep_omsadmin.sh
+++ b/test/installer/scripts/prep_omsadmin.sh
@@ -69,3 +69,21 @@ omiagent    soft    nproc 75
 $TEST_USER  hard  nproc  5000
 #    $TEST_USER hard nproc 20000
 EOF
+
+cat <<EOF > $TESTDIR/limits-two-settings.conf
+@$TEST_GROUP          hard           nproc                20
+*       hard    nproc   10
+omiagent    soft    nproc 75
+#        hard    nproc           75
+$TEST_USER  hard  nproc  200
+$TEST_USER  hard  nproc  100
+#    $TEST_USER hard nproc 20000
+EOF
+
+cat <<EOF > $TESTDIR/limits-no-settings.conf
+@$TEST_GROUP          hard           nproc                20
+*       hard    nproc   10
+omiagent    soft    nproc 75
+#        hard    nproc           75
+#    $TEST_USER hard nproc 20000
+EOF


### PR DESCRIPTION
Without this change, /etc/security/limits.conf never gets cleaned up after the OMSAgent is uninstalled. Additionally, a customer can set a limit low enough which restricts proper cleanup.

Build, unit, and system tests pass.
Verified that limit is removed after installing and removing.

@Microsoft/omsagent-devs 