### PR TITLE
Revert "Move AGENT_GUID to non-workspace-specific location to allow for single-machine agent ID"

### DIFF
--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -37,14 +37,13 @@ module MaintenanceModule
     attr_accessor :suppress_stdout
   
     def initialize(omsadmin_conf_path, cert_path, key_path, pid_path, proxy_path,
-                   os_info, install_info, agentid_path, log = nil, verbose = false)
+                   os_info, install_info, log = nil, verbose = false)
       @suppress_logging = true  # suppress_logging suppresses all output, including both print and logger
       @suppress_stdout = false  # suppress_stdout suppresses only print
 
       @AGENT_USER = "omsagent"
       @AGENT_GROUP = "omiusers"
       @omsadmin_conf_path = omsadmin_conf_path
-      @agentid_path = !agentid_path.nil? ? agentid_path : "/etc/opt/microsoft/omsagent/agentid"
       @cert_path = cert_path
       @key_path = key_path
       @pid_path = pid_path
@@ -160,10 +159,6 @@ module MaintenanceModule
 
     # Load necessary configuration values from omsadmin.conf
     def load_config
-      if File.exist?(@agentid_path)
-        @AGENT_GUID = File.read(@agentid_path).strip
-      end
-
       if !File.exist?(@omsadmin_conf_path)
         log_error("Missing configuration file: #{@omsadmin_conf_path}")
         return MISSING_CONFIG_FILE
@@ -172,8 +167,7 @@ module MaintenanceModule
       File.open(@omsadmin_conf_path, "r").each_line do |line|
         if line =~ /^WORKSPACE_ID/
           @WORKSPACE_ID = line.sub("WORKSPACE_ID=","").strip
-        # Do not allow contents of omsadmin.conf to overwrite machine agent GUID
-        elsif line =~ /^AGENT_GUID/ and @AGENT_GUID.nil?
+        elsif line =~ /^AGENT_GUID/
           @AGENT_GUID = line.sub("AGENT_GUID=","").strip
         elsif line =~ /^URL_TLD/
           @URL_TLD = line.sub("URL_TLD=","").strip
@@ -646,8 +640,7 @@ if __FILE__ == $0
   install_info = ARGV[6]
 
   maintenance = MaintenanceModule::Maintenance.new(omsadmin_conf_path, cert_path, key_path,
-                    pid_path, proxy_path, os_info, install_info, agentid_path = nil,
-                    log = nil, options[:verbose])
+                    pid_path, proxy_path, os_info, install_info, log = nil, options[:verbose])
   ret_code = 0
 
   if !maintenance.check_user

--- a/source/code/plugins/in_heartbeat_request.rb
+++ b/source/code/plugins/in_heartbeat_request.rb
@@ -19,7 +19,6 @@ module Fluent
     config_param :proxy_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf' #optional
     config_param :os_info, :string, :default => '/etc/opt/microsoft/scx/conf/scx-release' #optional
     config_param :install_info, :string, :default => '/etc/opt/microsoft/omsagent/sysconf/installinfo.txt' #optional
-    config_param :agentid_path, :string, :default => '/etc/opt/microsoft/omsagent/agentid' #optional
 
     def configure (conf)
       super
@@ -39,8 +38,7 @@ module Fluent
 
     def start
       @maintenance_script = MaintenanceModule::Maintenance.new(@omsadmin_conf_path, @cert_path,
-                              @key_path, @pid_path, @proxy_path, @os_info, @install_info,
-                              @agentid_path, @log)
+                              @key_path, @pid_path, @proxy_path, @os_info, @install_info, @log)
 
       if @run_interval
         @finished = false

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -75,8 +75,8 @@ module OMS
           Hash[ matches.names.map{ |name| name.to_sym}.zip( matches.captures ) ]
       end
 
-      # load the configuration from the configuration files, cert, and key path
-      def load_configuration(conf_path, cert_path, key_path, agentid_path = "/etc/opt/microsoft/omsagent/agentid")
+      # load the configuration from the configuration file, cert, and key path
+      def load_configuration(conf_path, cert_path, key_path)
         return true if @@ConfigurationLoaded
         return false if !test_onboard_file(conf_path) or !test_onboard_file(cert_path) or !test_onboard_file(key_path)
 
@@ -118,23 +118,19 @@ module OMS
           return false
         end
 
-        if File.exist?(agentid_path)
-          @@AgentId = File.read(agentid_path).strip
-        else
-          agentid_lines = IO.readlines(conf_path).select{ |line| line.start_with?("AGENT_GUID")}
-          if agentid_lines.size == 0
-            Log.error_once("Could not find AGENT_GUID setting in #{conf_path}")
-            return false
-          elsif agentid_lines.size > 1
-            Log.warn_once("Found more than one AGENT_GUID setting in #{conf_path}, will use the first one.")
-          end
-  
-          begin
-            @@AgentId = agentid_lines[0].split("=")[1].strip
-          rescue => e
-            OMS::Log.error_once("Error parsing agent id. #{e}")
-            return false
-          end
+        agentid_lines = IO.readlines(conf_path).select{ |line| line.start_with?("AGENT_GUID")}
+        if agentid_lines.size == 0
+          OMS::Log.error_once("Could not find AGENT_GUID setting in #{conf_path}")
+          return false
+        elsif agentid_lines.size > 1
+          OMS::Log.warn_once("Found more than one AGENT_GUID setting in #{conf_path}, will use the first one.")
+        end
+
+        begin
+          @@AgentId = agentid_lines[0].split("=")[1].strip
+        rescue => e
+          OMS::Log.error_once("Error parsing agent id. #{e}")
+          return false
         end
 
         File.open(conf_path).each_line do |line|

--- a/test/code/plugins/agent_maintenance_script_plugintest.rb
+++ b/test/code/plugins/agent_maintenance_script_plugintest.rb
@@ -14,6 +14,7 @@ class MaintenanceUnitTest < Test::Unit::TestCase
                                       "int.com/ConfigurationService.Svc/RenewCertificate"
 
   VALID_OMSADMIN_CONF = "WORKSPACE_ID=#{VALID_WORKSPACE_ID}\n"\
+                        "AGENT_GUID=#{VALID_AGENT_GUID}\n"\
                         "LOG_FACILITY=local0\n"\
                         "CERTIFICATE_UPDATE_ENDPOINT=#{VALID_CERTIFICATE_UPDATE_ENDPOINT}\n"\
                         "URL_TLD=int2.microsoftatlanta-int.com\n"\
@@ -40,7 +41,6 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   def setup
     @omsadmin_conf_file = Tempfile.new("omsadmin_conf")
-    @agentid_file = Tempfile.new("agentid")
     @cert_file = Tempfile.new("oms_crt")
     @key_file = Tempfile.new("oms_key")
     @pid_file = Tempfile.new("omsagent_pid")  # doesn't need to have meaningful data for testing
@@ -52,7 +52,6 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   def teardown
     @omsadmin_conf_file.unlink
-    @agentid_file.unlink
     @cert_file.unlink
     @key_file.unlink
     @pid_file.unlink
@@ -63,18 +62,12 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   # Helper to create a new Maintenance class object to test
   def get_new_maintenance_obj(omsadmin_path = @omsadmin_conf_file.path,
-                              cert_path = @cert_file.path,
-                              key_path = @key_file.path,
-                              pid_path = @pid_file.path,
-                              proxy_path = @proxy_file.path,
-                              os_info_path = @os_info_file.path,
-                              install_info_path = @install_info_file.path,
-                              agentid_path = @agentid_file.path,
-                              log = @log,
-                              verbose = false)
+       cert_path = @cert_file.path, key_path = @key_file.path, pid_path = @pid_file.path,
+       proxy_path = @proxy_file.path, os_info_path = @os_info_file.path,
+       install_info_path = @install_info_file.path, log = @log, verbose = false)
 
     m = MaintenanceModule::Maintenance.new(omsadmin_path, cert_path, key_path, pid_path,
-         proxy_path, os_info_path, install_info_path, agentid_path, log, verbose)
+         proxy_path, os_info_path, install_info_path, log, verbose)
     m.suppress_stdout = true
     return m
   end
@@ -92,7 +85,6 @@ class MaintenanceUnitTest < Test::Unit::TestCase
 
   def test_load_config_return_code
     File.write(@omsadmin_conf_file.path, VALID_OMSADMIN_CONF)
-    File.write(@agentid_file.path, "#{VALID_AGENT_GUID}\n")
     m = get_new_maintenance_obj
     assert_equal(m.load_config_return_code, 0, "load_config failed with valid config")
   end

--- a/test/code/plugins/oms_configuration_test.rb
+++ b/test/code/plugins/oms_configuration_test.rb
@@ -30,30 +30,25 @@ module OMS
       Configuration.configurationLoaded = false
       Common.OSFullName = nil
       @tmp_conf_file = Tempfile.new('oms_conf_file')
-      @tmp_agentid_file = Tempfile.new('agentid')
       @tmp_cert_file = Tempfile.new('temp_cert_file')
       @tmp_key_file = Tempfile.new('temp_key_file')
     end
 
     def teardown
-      [@tmp_conf_file,
-       @tmp_agentid_file,
-       @tmp_cert_file,
-       @tmp_key_file].each { |tmpfile|
+      [@tmp_conf_file, @tmp_cert_file, @tmp_key_file].each { |tmpfile|
         tmpfile.unlink
       }
     end
 
     def prepare_files
       conf = "WORKSPACE_ID=#{TEST_WORKSPACE_ID}\n" \
+      "AGENT_GUID=#{TEST_AGENT_GUID}\n" \
       "LOG_FACILITY=local0\n" \
       "CERTIFICATE_UPDATE_ENDPOINT=#{TEST_CERT_UPDATE_ENDPOINT}\n" \
       "DSC_ENDPOINT=#{TEST_DSC_ENDPOINT}\n" \
       "OMS_ENDPOINT=#{TEST_ODS_ENDPOINT}\n"
 
       File.write(@tmp_conf_file.path, conf)
-
-      File.write(@tmp_agentid_file.path, "#{TEST_AGENT_GUID}\n")
 
       # this is a fake certificate
       cert = "-----BEGIN CERTIFICATE-----\n" \
@@ -119,7 +114,7 @@ module OMS
     def test_load_configuration()
       prepare_files
       $log = MockLog.new
-      success = Configuration.load_configuration(@tmp_conf_file.path, @tmp_cert_file.path, @tmp_key_file.path, @tmp_agentid_file.path)
+      success = Configuration.load_configuration(@tmp_conf_file.path, @tmp_cert_file.path, @tmp_key_file.path)
       puts $log.logs
       assert_equal(true, success, 'Configuration should be loaded')
       assert_equal(TEST_AGENT_GUID, Configuration.agent_id, "Agent ID should be loaded")
@@ -131,45 +126,26 @@ module OMS
       assert_equal([], $log.logs, "There was an error loading the configuration")
     end
 
-    def test_load_configuration_no_agentid_file()
-      prepare_files
-      conf_content = File.read(@tmp_conf_file.path)
-      conf_content += "AGENT_GUID=#{TEST_AGENT_GUID}\n"
-      File.write(@tmp_conf_file.path, conf_content)
-      $log = MockLog.new
-      fake_agentid_path = @tmp_agentid_file.path + '.fake'
-      assert_equal(false, File.file?(fake_agentid_path))
-      success = Configuration.load_configuration(@tmp_conf_file.path, @tmp_cert_file.path, @tmp_key_file.path, fake_agentid_path)
-      assert_equal(true, success, 'Configuration should be loaded')
-      assert_equal(TEST_AGENT_GUID, Configuration.agent_id, "Agent ID should be loaded")
-      assert_equal([], $log.logs, "There was an error loading the configuration")
-    end
-
     def test_load_configuration_wrong_path()
       prepare_files
       fake_conf_path = @tmp_conf_file.path + '.fake'
       assert_equal(false, File.file?(fake_conf_path))
-      success = Configuration.load_configuration(fake_conf_path, @tmp_cert_file.path, @tmp_key_file.path, @tmp_agentid_file.path)
+      success = Configuration.load_configuration(fake_conf_path, @tmp_cert_file.path, @tmp_key_file.path)
       assert_equal(false, success, "Should not find configuration in a non existing file")
       
       fake_cert_path = @tmp_cert_file.path + '.fake'
       assert_equal(false, File.file?(fake_cert_path))
-      success = Configuration.load_configuration(@tmp_conf_file.path, fake_cert_path, @tmp_key_file.path, @tmp_agentid_file.path)
+      success = Configuration.load_configuration(@tmp_conf_file.path, fake_cert_path, @tmp_key_file.path)
       assert_equal(false, success, "Should not find configuration in a non existing file")
 
       fake_key_path = @tmp_key_file.path + '.fake'
       assert_equal(false, File.file?(fake_key_path))
-      success = Configuration.load_configuration(@tmp_key_file.path, @tmp_cert_file.path, fake_key_path, @tmp_agentid_file.path)
-      assert_equal(false, success, "Should not find configuration in a non existing file")
-
-      fake_agentid_path = @tmp_agentid_file.path + '.fake'
-      assert_equal(false, File.file?(fake_agentid_path))
-      success = Configuration.load_configuration(@tmp_key_file.path, @tmp_cert_file.path, @tmp_key_file.path, fake_agentid_path)
+      success = Configuration.load_configuration(@tmp_key_file.path, @tmp_cert_file.path, fake_key_path)
       assert_equal(false, success, "Should not find configuration in a non existing file")
 
       $log = MockLog.new
       # Should retry the second time since it did not find anything before
-      success = Configuration.load_configuration(@tmp_conf_file.path, @tmp_cert_file.path, @tmp_key_file.path, @tmp_agentid_file.path)
+      success = Configuration.load_configuration(@tmp_conf_file.path, @tmp_cert_file.path, @tmp_key_file.path)
       assert_equal(true, success, 'Configuration should be loaded')
       assert_equal([], $log.logs, "There was an error loading the configuration")
     end

--- a/test/code/plugins/out_oms_systestbase.rb
+++ b/test/code/plugins/out_oms_systestbase.rb
@@ -28,10 +28,10 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
 
   def prep_onboard
     # Make sure that we read test onboarding information from the environment varibles
-    assert(TEST_WORKSPACE_ID != nil, "TEST_WORKSPACE_ID should be set by the environment for this test to run.")
+    assert(TEST_WORKSPACE_ID != nil, "TEST_WORKSPACE_ID should be set by the environment for this test to run.") 
     assert(TEST_SHARED_KEY != nil, "TEST_SHARED_KEY should be set by the environment for this test to run.")
 
-    assert(TEST_WORKSPACE_ID.empty? == false, "TEST_WORKSPACE_ID should not be empty.")
+    assert(TEST_WORKSPACE_ID.empty? == false, "TEST_WORKSPACE_ID should not be empty.") 
     assert(TEST_SHARED_KEY.empty? == false, "TEST_SHARED_KEY should not be empty.")
 
     # Setup test onboarding script and folder
@@ -51,7 +51,6 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
     conf_path = "#{@omsadmin_test_dir_ws}/conf/omsadmin.conf"
     cert_path = "#{@omsadmin_test_dir_ws}/certs/oms.crt"
     key_path = "#{@omsadmin_test_dir_ws}/certs/oms.key"
-    agentid_path = @omsadmin_test_dir_ws.gsub(/\/[^\/]*$/, '') + '/agentid'
 
     conf = %[
       omsadmin_conf_path #{conf_path}
@@ -59,7 +58,7 @@ class OutOMSSystemTestBase < Test::Unit::TestCase
       key_path #{key_path}
     ]
 
-    success = OMS::Configuration.load_configuration(conf_path, cert_path, key_path, agentid_path)
+    success = OMS::Configuration.load_configuration(conf_path, cert_path, key_path)
     assert_equal(true, success, "Configuration should be loaded")
 
     return conf

--- a/test/installer/scripts/agent_maintenance_script_systest.rb
+++ b/test/installer/scripts/agent_maintenance_script_systest.rb
@@ -68,7 +68,6 @@ class AgentMaintenanceSystemTest < MaintenanceSystemTestBase
     @pid_path = Tempfile.new("omsagent_pid")  # this does not need to be meaningful during testing
     @os_info_path = "#{@omsadmin_test_dir}/scx-release"
     @install_info_path = "#{@base_dir}/installer/conf/installinfo.txt"
-    @agentid_path = get_agentid_path(@omsadmin_test_dir_ws1)
     @log = OMS::MockLog.new
 
     @test_omsadmin_conf = Tempfile.new("omsadmin_conf")
@@ -89,10 +88,11 @@ class AgentMaintenanceSystemTest < MaintenanceSystemTestBase
   # Helper to create a new Maintenance class object to test; uses valid files by default
   def get_new_maintenance_obj(omsadmin_path = @omsadmin_conf_path, cert_path = @cert_path,
        key_path = @key_path, pid_path = @pid_path.path, proxy_path = @proxy_conf,
-       os_info_path = @os_info_path, install_info_path = @install_info_path,
-       agentid_path = @agentid_path, log = @log, verbose = false)
+       os_info_path = @os_info_path, install_info_path = @install_info_path, log = @log,
+       verbose = false)
+
     m = MaintenanceModule::Maintenance.new(omsadmin_path, cert_path, key_path, pid_path,
-         proxy_path, os_info_path, install_info_path, agentid_path, log, verbose)
+         proxy_path, os_info_path, install_info_path, log, verbose)
     m.suppress_stdout = true
     return m
   end

--- a/test/installer/scripts/maintenance_systestbase.rb
+++ b/test/installer/scripts/maintenance_systestbase.rb
@@ -84,15 +84,9 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
     return onboard_out
   end
 
-  def get_agentid_path(ws_dir)
-    omsagent_path = ws_dir.gsub(/\/[^\/]*$/, '')
-    agentid_path = omsagent_path + '/agentid'
-    return agentid_path
-  end
-
   def get_GUID(ws_dir = @omsadmin_test_dir_ws1)
-    agentid_path = get_agentid_path(ws_dir)
-    guid = File.read(agentid_path).strip
+    conf = File.read("#{ws_dir}/conf/omsadmin.conf")
+    guid = conf[/AGENT_GUID=(.*)/, 1]
     return guid
   end
 

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -15,15 +15,11 @@ class OmsadminTest < MaintenanceSystemTestBase
   def post_onboard_validation(ws_dir = @omsadmin_test_dir_ws1)
     crt_path = "#{ws_dir}/certs/oms.crt"
     key_path = "#{ws_dir}/certs/oms.key"
-    agentid_path = get_agentid_path(ws_dir)
 
     # Make sure certs and config was generated
     assert(File.file?(crt_path), "'#{crt_path}' does not exist!")
     assert(File.file?(key_path), "'#{key_path}' does not exist!")
     assert(File.file?("#{ws_dir}/conf/omsadmin.conf"), "omsadmin.conf does not exist!")
-    assert(File.file?(agentid_path), "The agentid file does not exist!")
-    omsadmin_conf_contents = File.read("#{ws_dir}/conf/omsadmin.conf")
-    assert_not_match(/AGENT_GUID=/, omsadmin_conf_contents, "Agent GUID should not be stored in omsadmin.conf")
 
     # Check permissions
     crt_uid = File.stat(crt_path).uid
@@ -84,7 +80,7 @@ class OmsadminTest < MaintenanceSystemTestBase
     
     # Reonboarding should not modify the agent GUID or the certs 
     output = do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)
-    assert_match(/Reusing machine's agent GUID/, output, "Did not find GUID reuse message")
+    assert_match(/Reusing previous agent GUID/, output, "Did not find GUID reuse message")
     assert_equal(old_guid, get_GUID(), "Agent GUID should not change on reonboarding")
     assert(crt_hash == Digest::SHA256.file(crt_path), "The cert should not change on reonboarding")
     assert(key_hash == Digest::SHA256.file(key_path), "The key should not change on reonboarding")
@@ -97,9 +93,8 @@ class OmsadminTest < MaintenanceSystemTestBase
     output = do_onboard(TEST_WORKSPACE_ID_2, TEST_SHARED_KEY_2)
     new_guid = get_GUID(@omsadmin_test_dir_ws2)
 
-    assert_equal(old_guid, new_guid, "The GUID should not change when reonboarding with a different workspace ID")
-    assert_not_match(/Reusing/, output, "Should not print reusing message")
-    assert_match(/Using machine's agent GUID/, output, "Should be using GUID from machine")
+    assert_not_equal(old_guid, new_guid, "The GUID should change when reonboarding with a different workspace ID")
+    assert_not_match(/Reusing/, output, "Should not be reusing GUID")
   end
 
   def test_onboard_two_workspaces


### PR DESCRIPTION
This reverts commit 1e5a6b78f35ecf6cc4369c7d0027a5cb7f9cc506.
Do not revert changes from diagnostic and NPM plugins - these changes were backwards-compatible.
This change will not be released because it violates the OMS security model.

@Microsoft/omsagent-devs @chparimi