### PR TITLE
Guard against blank omsadmin.conf file during onboarding

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -509,7 +509,9 @@ onboard()
     fi
     create_workspace_directories $WORKSPACE_ID
 
-    if [ -f $FILE_KEY -a -f $FILE_CRT -a -f $CONF_OMSADMIN ]; then
+    # Guard against blank omsadmin.conf
+    local omsadmin_contents="`cat $CONF_OMSADMIN 2> /dev/null`"
+    if [ -f $FILE_KEY -a -f $FILE_CRT -a -f $CONF_OMSADMIN -a -n "$omsadmin_contents" ]; then
         # Keep the same agent GUID by loading it from the previous conf
         AGENT_GUID=`grep AGENT_GUID $CONF_OMSADMIN | cut -d= -f2`
         log_info "Reusing previous agent GUID $AGENT_GUID"


### PR DESCRIPTION
@Microsoft/omsagent-devs 

Some issues have surfaced where a workspace cannot be re-onboarded to a machine because an omsadmin.conf file exists but is empty. This causes onboarding to fail with INTERNAL_ERROR. This fix will regenerate the agent GUID and the certs to re-onboard.

pBuild, unit tests, and system tests have passed.