### PR TITLE
Xcshowplim

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -162,7 +162,7 @@ usage()
     echo "Detect if omiserver is listening to SCOM port:"
     echo "$basename -o"
     echo
-    echo "Show the configured process limit in /etc/limits.conf for user $AGENT_USER."
+    echo "Show the configured process limit in $PROC_LIMIT_CONF for user $AGENT_USER."
     echo "$basename -c"
 }
 
@@ -242,7 +242,7 @@ parse_args()
 {
     local OPTIND opt
 
-    while getopts "h?s:w:d:vp:u:a:lx:XUm:Nrn:oRc" opt; do
+    while getopts "h?s:w:d:vp:u:a:lx:XUm:cNrn:oR" opt; do
         case "$opt" in
         h|\?)
             usage
@@ -422,7 +422,7 @@ unset_omsagent_proc_limit()
 find_current_omsagent_proc_limit()
 {
     #cat $PROC_LIMIT_CONF | grep -E "$LIMIT_LINE_REGEX" > /dev/null 2>&1
-    get_current_omsagent_proc_limit >/dev/null 2>/dev/null
+    get_current_omsagent_proc_limit > /dev/null 2>&1
     return $?
 }
 
@@ -841,7 +841,8 @@ show_omsagent_proc_limit()
         result_limit=`get_current_omsagent_proc_limit | tail -1 | awk '{print $4}'`
         if [ "$result_limit" -eq "-1" ]; then
             result_limit="No Limit"
-            log_info "There is NO present limit to number of processes for $AGENT_USER."
+            #log_info "There is NO present limit to number of processes for $AGENT_USER."
+            log_info "The number of processes for $AGENT_USER is unlimited."
         elif [ "$result_limit" -lt "$MIN_OMSAGENT_PROC_LIMIT" ]; then
             log_warning "$AGENT_USER process limit setting of '$result_limit' is less than minimum of $MIN_OMSAGENT_PROC_LIMIT."
         fi

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -150,6 +150,9 @@ usage()
     echo "Azure resource ID:"
     echo "$basename -a <Azure resource ID>"
     echo
+    echo "Show the configured process limit in $PROC_LIMIT_CONF for user $AGENT_USER."
+    echo "$basename -c"
+    echo
     echo "Set process limit for OMSAgent:"
     echo "$basename -n <specific number limit>"
     echo
@@ -161,9 +164,6 @@ usage()
     echo
     echo "Detect if omiserver is listening to SCOM port:"
     echo "$basename -o"
-    echo
-    echo "Show the configured process limit in $PROC_LIMIT_CONF for user $AGENT_USER."
-    echo "$basename -c"
 }
 
 set_user_agent()

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -242,7 +242,7 @@ parse_args()
 {
     local OPTIND opt
 
-    while getopts "h?s:w:d:vp:u:a:lx:XUm:cNrn:oR" opt; do
+    while getopts "h?s:w:d:vp:u:a:lx:XUm:Nrcn:oR" opt; do
         case "$opt" in
         h|\?)
             usage
@@ -398,7 +398,7 @@ set_omsagent_proc_limit()
 
     log_info "Setting process limit for the $AGENT_USER user in $PROC_LIMIT_CONF to $NEW_OMSAGENT_PROC_LIMIT..."
     local new_omsagent_line="$AGENT_USER  hard  nproc  $NEW_OMSAGENT_PROC_LIMIT"
-    get_current_omsagent_proc_limit >/dev/null 2>/dev/null
+    get_current_omsagent_proc_limit > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         old_omsagent_line=`cat $PROC_LIMIT_CONF | grep -E "$LIMIT_LINE_REGEX" | tail -1`
         sed -i s,"$old_omsagent_line","$new_omsagent_line",1 $PROC_LIMIT_CONF
@@ -409,7 +409,7 @@ set_omsagent_proc_limit()
 
 unset_omsagent_proc_limit()
 {
-    get_current_omsagent_proc_limit >/dev/null 2>/dev/null
+    get_current_omsagent_proc_limit > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         # Remove all lines for the omsagent from the limit file
         log_info "Removing process limit for the $AGENT_USER user in $PROC_LIMIT_CONF..."
@@ -417,13 +417,6 @@ unset_omsagent_proc_limit()
         # sed does not handle the complex/extended regex in older versions, but grep does
         cat $PROC_LIMIT_CONF.bak | grep -Ev "$LIMIT_LINE_REGEX"  > $PROC_LIMIT_CONF
     fi
-}
-
-find_current_omsagent_proc_limit()
-{
-    #cat $PROC_LIMIT_CONF | grep -E "$LIMIT_LINE_REGEX" > /dev/null 2>&1
-    get_current_omsagent_proc_limit > /dev/null 2>&1
-    return $?
 }
 
 get_current_omsagent_proc_limit()
@@ -841,7 +834,6 @@ show_omsagent_proc_limit()
         result_limit=`get_current_omsagent_proc_limit | tail -1 | awk '{print $4}'`
         if [ "$result_limit" -eq "-1" ]; then
             result_limit="No Limit"
-            #log_info "There is NO present limit to number of processes for $AGENT_USER."
             log_info "The number of processes for $AGENT_USER is unlimited."
         elif [ "$result_limit" -lt "$MIN_OMSAGENT_PROC_LIMIT" ]; then
             log_warning "$AGENT_USER process limit setting of '$result_limit' is less than minimum of $MIN_OMSAGENT_PROC_LIMIT."

--- a/test/installer/scripts/maintenance_systestbase.rb
+++ b/test/installer/scripts/maintenance_systestbase.rb
@@ -2,6 +2,8 @@ require 'fluent/test'
 
 class MaintenanceSystemTestBase < Test::Unit::TestCase
 
+  TEST_USER=`id -un`.chomp  # NOTE OF CAUTION:  These two lines must be defined
+  TEST_GROUP=`id -gn`.chomp # in parallel to those by same name in prep_omsadmin.sh
   TEST_WORKSPACE_ID = ENV["TEST_WORKSPACE_ID"]
   TEST_SHARED_KEY = ENV["TEST_SHARED_KEY"]
   TEST_WORKSPACE_ID_2 = ENV["TEST_WORKSPACE_ID_2"]

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -332,8 +332,8 @@ class OmsadminTest < MaintenanceSystemTestBase
     v = linearray[l-1].chomp
     assert_equal(6, l, "This example should have six output lines from stdout.")
     expectedline0 = "2 #{TEST_USER} entries found in #{@proc_limits_conf}."
-    assert_not_match(/error/i,m,"Should not be an error")
-    assert_match(/#{expectedline0}/,m,"Expected first line message does not match that output.")
+    assert_not_match(/error/i, m, "Should not be an error")
+    assert_match(/#{expectedline0}/, m, "Expected first line message does not match that output.")
     assert_equal("100", v, "Multiple entries should still report last entry, in compliance with specification.")
   end
 
@@ -346,8 +346,8 @@ class OmsadminTest < MaintenanceSystemTestBase
     v = linearray[l-1].chomp
     assert_equal(2, l, "This example should have six output lines from stdout.")
     expectedline0 = "There is NO present limit to number of processes for #{TEST_USER}."
-    assert_not_match(/error/i,m,"Should not be an error")
-    assert_match(/#{expectedline0}/,m,"Expected first line message does not match that output.")
+    assert_not_match(/error/i, m, "Should not be an error")
+    assert_match(/#{expectedline0}/, m, "Expected first line message does not match that output.")
     assert_equal("No Limit", v, "Unexpected return value for -c.")
   end
 

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -328,15 +328,27 @@ class OmsadminTest < MaintenanceSystemTestBase
     lso = show_omsagent_proc_limit()
     linearray = lso.split("\n")
     l = linearray.length
+    m = linearray[0].chomp
     v = linearray[l-1].chomp
     assert_equal(6, l, "This example should have six output lines from stdout.")
+    expectedline0 = "2 #{TEST_USER} entries found in #{@proc_limits_conf}."
+    assert_not_match(/error/i,m,"Should not be an error")
+    assert_match(/#{expectedline0}/,m,"Expected first line message does not match that output.")
     assert_equal("100", v, "Multiple entries should still report last entry, in compliance with specification.")
   end
 
   def test_show_omsagent_proc_limit_no_entry
     FileUtils.cp("#{@omsadmin_test_dir}/limits-no-settings.conf", @proc_limits_conf)
     lso = show_omsagent_proc_limit()
-    assert_match(/info/, lso, "The integer associated with unlimited is -1, but we return only logging.")
+    linearray = lso.split("\n")
+    l = linearray.length
+    m = linearray[0].chomp
+    v = linearray[l-1].chomp
+    assert_equal(2, l, "This example should have six output lines from stdout.")
+    expectedline0 = "There is NO present limit to number of processes for #{TEST_USER}."
+    assert_not_match(/error/i,m,"Should not be an error")
+    assert_match(/#{expectedline0}/,m,"Expected first line message does not match that output.")
+    assert_equal("No Limit", v, "Unexpected return value for -c.")
   end
 
 end

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -319,19 +319,24 @@ class OmsadminTest < MaintenanceSystemTestBase
   def test_show_omsagent_proc_limit_5000
     set_omsagent_proc_limit(5000)
     lso = show_omsagent_proc_limit()
-    assert_match(/^5000$/, lso, "Should have been 5000 process limit.")
+    nostr = lso.chomp
+    assert_equal("5000", nostr, "Should have been 5000 process limit.")
   end
 
   def test_show_omsagent_proc_limit_two_entries
     FileUtils.cp("#{@omsadmin_test_dir}/limits-two-settings.conf", @proc_limits_conf)
     lso = show_omsagent_proc_limit()
-    assert_match(/^100$/, lso, "Multiple entries should still report last entry, in compliance with specification.")
+    linearray = lso.split("\n")
+    l = linearray.length
+    v = linearray[l-1].chomp
+    assert_equal(6, l, "This example should have six output lines from stdout.")
+    assert_equal("100", v, "Multiple entries should still report last entry, in compliance with specification.")
   end
 
   def test_show_omsagent_proc_limit_no_entry
     FileUtils.cp("#{@omsadmin_test_dir}/limits-no-settings.conf", @proc_limits_conf)
     lso = show_omsagent_proc_limit()
-    assert_equal("", lso, "The integer associated with unlimited is -1, but we return blank for reporting.")
+    assert_match(/info/, lso, "The integer associated with unlimited is -1, but we return only logging.")
   end
 
 end

--- a/test/installer/scripts/prep_omsadmin.sh
+++ b/test/installer/scripts/prep_omsadmin.sh
@@ -87,3 +87,25 @@ omiagent    soft    nproc 75
 #        hard    nproc           75
 #    $TEST_USER hard nproc 20000
 EOF
+
+# The following two represent the actual kind of file ending found on systems:
+cat <<EOF > $TESTDIR/limits-no-settings-endlabel.conf
+@$TEST_GROUP          hard           nproc                20
+*       hard    nproc   10
+omiagent    soft    nproc 75
+#        hard    nproc           75
+#    $TEST_USER hard nproc 20000
+
+# End of file
+EOF
+
+cat <<EOF > $TESTDIR/limits-new-settings-endlabel.conf
+@$TEST_GROUP          hard           nproc                20
+*       hard    nproc   10
+omiagent    soft    nproc 75
+#        hard    nproc           75
+#    $TEST_USER hard nproc 20000
+$TEST_USER  hard  nproc  20000
+
+# End of file
+EOF


### PR DESCRIPTION
Two items:
1.  Adds -c switch to display limit value, and in cases of missing entry or multiple entries provide logging too.
2.  Adds feature to insert new $AGENT_USER entry 2 lines before the end of the file to avoid making the typical two line sequence indicating the end of this configuration file end up out of place.
