### PR TITLE
Expose 1.4.1-45 through onboard_agent.sh

### DIFF
--- a/installer/scripts/onboard_agent.sh
+++ b/installer/scripts/onboard_agent.sh
@@ -6,9 +6,9 @@
 
 
 # Values to be updated upon each new release
-GITHUB_RELEASE="https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_GA_v1.4.0-45/"
-BUNDLE_X64="omsagent-1.4.0-45.universal.x64.sh"
-BUNDLE_X86="omsagent-1.4.0-45.universal.x86.sh"
+GITHUB_RELEASE="https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_GA_v1.4.1-45/"
+BUNDLE_X64="omsagent-1.4.1-45.universal.x64.sh"
+BUNDLE_X86="omsagent-1.4.1-45.universal.x86.sh"
 
 usage()
 {


### PR DESCRIPTION
@Microsoft/omsagent-devs @keikhara 

Will merge this to master (thereby exposing it to Quick Install customers) once the Azure VM extension with this bundle version has been published to all public regions.