### PR TITLE
Improve system tests and remove_all logic

### DIFF
--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -187,25 +187,23 @@ module OMS
       assert(hostname.size > 0, "Hostname returned is empty")
     end
 
-    def test_get_hostname_in_containerzed_agent
+    def test_get_hostname_in_containerized_agent
       $log = MockLog.new
-      file_hostname = '/tmp/containerhostname'
+
+      # create container hostname file
+      # get_hostname should read hostname from this file when exist
+      container_hostname_tempfile = Tempfile.new('containerhostname')
       test_hostname = 'test_hostname'
       Common.Hostname = nil
-      Common.HostnameFilePath = file_hostname
-
-      # create container hostname file 
-      # get_hostname should read hostname from this file when exist
-      out_file = File.new(file_hostname, "w+")
-      out_file.puts(test_hostname)
-      out_file.close
+      Common.HostnameFilePath = container_hostname_tempfile.path
+      File.write(container_hostname_tempfile.path, test_hostname)
       hostname = Common.get_hostname
-      assert_equal(test_hostname, hostname, 'get_hostname should read from /tmp/containerhostname file')
+      assert_equal(test_hostname, hostname, 'get_hostname should read from containerhostname file')
 
       # Remove container host name file
       # get_hostname should get hostname from Socket.gethostname when this file when doesn't exist
       Common.Hostname = nil
-      File.delete(file_hostname)
+      container_hostname_tempfile.unlink
       hostname = Common.get_hostname
       test_hostname = Socket.gethostname.split(".")[0]
       assert_equal(test_hostname, hostname, 'get_hostname should read from Socket.gethostname')

--- a/test/installer/scripts/maintenance_systestbase.rb
+++ b/test/installer/scripts/maintenance_systestbase.rb
@@ -40,16 +40,16 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
   end
 
   def check_proxy_server_working
-    output = `curl --proxy #{TEST_PROXY_SETTING} example.com 2>/dev/null`
-    return_code = $?.to_i
-    assert_equal(0, return_code)
+    return_code, output = run_command("curl --proxy #{TEST_PROXY_SETTING} example.com")
+    assert_equal(0, return_code.to_i)
     assert_match(/Example Domain/, output)
   end
 
   def prep_omsadmin
     # Setup test onboarding script and folder
-    @omsadmin_test_dir = `#{@prep_omsadmin} #{@base_dir} #{@ruby_test_dir}`.strip()
-    assert_equal(0, $?.to_i, "Unexpected failure setting up the test")
+    result, output = run_command("#{@prep_omsadmin} #{@base_dir} #{@ruby_test_dir}")
+    @omsadmin_test_dir = output.strip()
+    assert_equal(0, result.to_i, "Unexpected failure setting up the test")
     assert_equal(true, File.directory?(@omsadmin_test_dir), "'#{@omsadmin_test_dir}' does not exist!")
 
     @omsadmin_test_dir_ws1 = "#{@omsadmin_test_dir}/#{TEST_WORKSPACE_ID}"
@@ -72,16 +72,22 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
     check_proxy_server_working
   end
 
-  def do_onboard(workspace_id, shared_key, should_succeed = true)
+  def do_onboard(workspace_id, shared_key, should_succeed = true, verbose = false)
     check_test_keys()
-    onboard_out = `#{@omsadmin_script} -w #{workspace_id} -s #{shared_key}`
-    result = $?
+    onboard_cmd = "#{@omsadmin_script}"
+    onboard_cmd = "#{onboard_cmd} -w #{workspace_id}" unless workspace_id.nil?
+    onboard_cmd = "#{onboard_cmd} -s #{shared_key}" unless shared_key.nil?
+    if verbose
+      onboard_cmd = "#{onboard_cmd} -v"
+    end
+
+    result, onboard_out = run_command(onboard_cmd, should_succeed)
     if should_succeed
       assert_equal(0, result.to_i, "Unexpected failure onboarding : '#{onboard_out}'")
       assert_match(/Onboarding success/, onboard_out, "Did not find onboarding success message")
     else
       assert_not_equal(0, result.to_i, "Onboarding was expected to fail but exited with a return code of 0")
-      assert_match(/Error/, onboard_out, "Did not find onboarding error message")
+      assert_match(/error/, onboard_out.downcase, "Did not find onboarding error message")
     end
     return onboard_out
   end
@@ -93,8 +99,7 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
   end
 
   def remove_workspace(workspace_id, should_succeed = true)
-    remove_out = `#{@omsadmin_script} -x #{workspace_id}`
-    result = $?
+    result, remove_out = run_command("#{@omsadmin_script} -x #{workspace_id}", assert_no_error = should_succeed)
     if should_succeed
       assert_equal(0, result.to_i, "Unexpected failure removing workspace: '#{remove_out}'")
     else
@@ -102,5 +107,16 @@ class MaintenanceSystemTestBase < Test::Unit::TestCase
       assert_match(/Workspace #{workspace_id} doesn't exist/, remove_out, "Removing workspace message is not expected  #{remove_out}")
     end
     return remove_out
+  end
+
+  # Helper method to redirect stderr away from the screen when system tests are running
+  # Unless assert_no_error is specified as false, this method will assert that no error message is found
+  def run_command(cmd, assert_no_error = true)
+    output = `#{cmd} 2>&1`
+    result = $?
+    if assert_no_error
+      assert_not_match(/error/, output.downcase, "Found unexpected error message")
+    end
+    return result, output
   end
 end


### PR DESCRIPTION
No extraneous messages are printed out during system testing
Improvement of remove_all workspaces logic for non-OMS workspace cases
Localized unit test for containerized agent hostname

@Microsoft/omsagent-devs 