### PR TITLE
Mask sensitive shared key output in verbose omsadmin.sh logging

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -496,8 +496,12 @@ onboard_lad()
 onboard()
 {
     if [ $VERBOSE -eq 1 ]; then
+        # Mask the shared key
+        local shared_key_trunc=`echo "$SHARED_KEY" | cut -c 1-4 2> /dev/null`
+        local shared_key_covered=`echo "$SHARED_KEY" | tr "$SHARED_KEY" "*" | cut -c 5- 2> /dev/null`
+
         echo "Workspace ID:      $WORKSPACE_ID"
-        echo "Shared key:        $SHARED_KEY"
+        echo "Shared key:        $shared_key_trunc$shared_key_covered"
         echo "Top Level Domain:  $URL_TLD"
     fi
 
@@ -592,9 +596,13 @@ onboard()
     AUTHORIZATION_KEY=`echo $AUTHS | cut -d" " -f2`
 
     if [ $VERBOSE -ne 0 ]; then
+        # Mask the certificate in the request
+        local body_no_newlines="`cat $BODY_ONBOARD | tr -d '\n' 2> /dev/null`"
+        local cert_tag="AuthenticationCertificate"
+        local hidden_cert="********"
         echo
         echo "Generated request:"
-        cat $BODY_ONBOARD
+        echo "$body_no_newlines" | sed "s/<$cert_tag>[^<]*<\/$cert_tag>/<$cert_tag>$hidden_cert<\/$cert_tag>/g"
         echo
     fi
 

--- a/test/installer/scripts/omsadmin_systest.rb
+++ b/test/installer/scripts/omsadmin_systest.rb
@@ -77,6 +77,28 @@ class OmsadminTest < MaintenanceSystemTestBase
     assert_match(/Error resolving host during the onboarding request/, output)
   end
 
+  def test_onboard_verbose_valid_shared_key
+    output = do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY, should_succeed = true, verbose = true)
+    original_key = TEST_SHARED_KEY.dup
+    assert_match(/Shared key:\s+#{original_key.slice!(0..3)}\*{#{TEST_SHARED_KEY.length - 4}}/,
+                 output, "Did not find correct shared key printout")
+    assert_match(/<AuthenticationCertificate>\*+<\/AuthenticationCertificate>/, output,
+                 "Did not find masked cert")
+    post_onboard_validation
+  end
+
+  def test_onboard_verbose_short_shared_key
+    output = do_onboard(TEST_WORKSPACE_ID, "xx", should_succeed = false, verbose = true)
+    assert_match(/Shared key:\s+xx\n/, output,
+                 "Did not find correct shared key printout")
+  end
+
+  def test_onboard_verbose_no_shared_key
+    output = do_onboard(TEST_WORKSPACE_ID, nil, should_succeed = false, verbose = true)
+    assert_match(/Shared key:\s+\n/, output,
+                 "Did not find correct shared key printout")
+  end
+
   def test_reonboard
     do_onboard(TEST_WORKSPACE_ID, TEST_SHARED_KEY)
 


### PR DESCRIPTION
Add system tests for shared key logging
Mask certificate in generated request logging

Before this change, verbose output looked like this:
```
Workspace ID:      08d4b0c0-7fac-4159-987c-000271282eff
Shared key:        dummysharedkey
Top Level Domain:  int2.microsoftatlanta-int.com
info    Generating certificate ...
-e info Agent GUID is a7ed1a96-c323-4440-8f72-59c71cc2f3b7
-e info Private Key stored in:   /etc/opt/microsoft/omsagent/08d4b0c0-7fac-4159-987c-000271282eff/certs/oms.key
-e info Public Key stored in:    /etc/opt/microsoft/omsagent/08d4b0c0-7fac-4159-987c-000271282eff/certs/oms.crt

Generated request:
<?xml version="1.0"?>
<AgentTopologyRequest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/WorkloadMonitoring/HealthServiceProtocol/2014/09/"><FullyQualfiedDomainName>lagalbraUb12SyslogNG
.s3awofdf0nqe3ksstzhcju325c.bx.internal.cloudapp.net
</FullyQualfiedDomainName><EntityTypeId>a7ed1a96-c323-4440-8f72-59c71cc2f3b7</EntityTypeId><AuthenticationCertificate>MIID9TCCAt2gAwIBAgIDANQxMA0GCSqGSIb3DQEBCwUAMIGTMS0wKwYDVQQDDCQw
OGQ0YjBjMC03ZmFjLTQxNTktOTg3Yy0wMDAyNzEyODJlZmYxLTArBgNVBAMMJGE3
ZWQxYTk2LWMzMjMtNDQ0MC04ZjcyLTU5YzcxY2MyZjNiNzEfMB0GA1UECwwWTGlu
dXggTW9uaXRvcmluZyBBZ2VudDESMBAGA1UECgwJTWljcm9zb2Z0MB4XDTE3MDky
MjE4NTE0N1oXDTE4MDkyMjE4NTE0N1owgZMxLTArBgNVBAMMJDA4ZDRiMGMwLTdm
YWMtNDE1OS05ODdjLTAwMDI3MTI4MmVmZjEtMCsGA1UEAwwkYTdlZDFhOTYtYzMy
My00NDQwLThmNzItNTljNzFjYzJmM2I3MR8wHQYDVQQLDBZMaW51eCBNb25pdG9y
aW5nIEFnZW50MRIwEAYDVQQKDAlNaWNyb3NvZnQwggEiMA0GCSqGSIb3DQEBAQUA
A4IBDwAwggEKAoIBAQDeDd2tsxcTIVrFbi01RacWxli98ViKdL0dulZRoHLbue31
HTa7CFeGOenF4uxpyDsrvbNO6kBpsFqIjoPcJa3KrWxXQLI7r7Acie9GQa1rXAr4
he7UPMHFJPz0vum1oFIn2bTU6OTKDRbPFFNz8f9Rh0bO93TJeWKwXKD+GorKtMnI
SGuipv+mUJi+l5d3t6T3Ov8EA9oXOhNyk/KAZPdqRukEijWZBlCz3RSJWxLH0/PN
w2CxA/3TxmXsup3/mJpwyP0ibrOfyglEAroV/cjWbK8LsyteqyG4lyqg+slIUgSF
Vb70BjspDEAIKvH2jWcr7H2dlFBP9EgjFvksDH9pAgMBAAGjUDBOMB0GA1UdDgQW
BBTEU8NjANKL6d5BkD6BA/WV88GoHzAfBgNVHSMEGDAWgBTEU8NjANKL6d5BkD6B
A/WV88GoHzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQC0e2cbekB1
7LFRLgLSUprEtkuWUUDmaJWZjOfSOSYrRghoqo+Uq/Nvm6eHgvkqibGidB8i1qcL
0LPiQDyoDO/x7NrvEOrOWT/Og8rs+IXilISvLxbS7Jvy8e/NR5S2sbIW4S7bpbLx
amlll/K4XgyZ5gQZ3sUAvzSUwn8lD7gf85j6ZOSGoXrOrH0BQ18JEEnOWcX6uMM5
SYdyrTIRpGHiL5/2oX0t+8z/Ok89kcF5sfHTv3VPtTx5hxUCrBQKCFiRPvsALPsf
KE18WweJNbzkR8KRKvU6LePweVnpqvVSOCrBKhOTJly2q5Gqym4nAOzJp1VxRiJU
J3Vn/b2tqul6</AuthenticationCertificate><OperatingSystem><InContainer>False</InContainer><Name>Ubuntu</Name><Version>12.04</Version><Manufacturer>Canonical Group Limited</Manufacturer><Telemetry></Telemetry><ProcessorArchitecture>x64</ProcessorArchitecture></OperatingSystem></AgentTopologyRequest>

...
```

After this change, verbose output looks like this:
```
Workspace ID:      08d4b0c0-7fac-4159-987c-000271282eff
Shared key:        dumm**********
Top Level Domain:  int2.microsoftatlanta-int.com
info    Generating certificate ...
-e info Agent GUID is 0dc3e8b2-d82a-4a28-a9cf-872686288c65
-e info Private Key stored in:   /etc/opt/microsoft/omsagent/08d4b0c0-7fac-4159-987c-000271282eff/certs/oms.key
-e info Public Key stored in:    /etc/opt/microsoft/omsagent/08d4b0c0-7fac-4159-987c-000271282eff/certs/oms.crt

Generated request:
<?xml version="1.0"?><AgentTopologyRequest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/WorkloadMonitoring/HealthServiceProtocol/2014/09/"><FullyQualfiedDomainName>lagalbraUb12SyslogNG.s3awofdf0nqe3ksstzhcju325c.bx.internal.cloudapp.net</FullyQualfiedDomainName><EntityTypeId>0dc3e8b2-d82a-4a28-a9cf-872686288c65</EntityTypeId><AuthenticationCertificate>********</AuthenticationCertificate><OperatingSystem><InContainer>False</InContainer><Name>Ubuntu</Name><Version>12.04</Version><Manufacturer>Canonical Group Limited</Manufacturer><Telemetry></Telemetry><ProcessorArchitecture>x64</ProcessorArchitecture></OperatingSystem></AgentTopologyRequest>

...
```

@Microsoft/omsagent-devs 