### PR TITLE
Match patch man page for apply_patch dry-run and execution

### DIFF
--- a/build/configure
+++ b/build/configure
@@ -209,11 +209,13 @@ fi
 # Parameter: patch file path (like /etc/clear_options.patch)
 # Parameter: file to patch (like /etc/file_to_be_changed)
 apply_patch() {
-    patch -p0 -N --dry-run --silent < $1 2>/dev/null 1>&2
+    local patch_file=$1
+    local file_to_patch=$2
+    patch -p0 -N --dry-run --silent $file_to_patch $patch_file 2>/dev/null 1>&2
     if [ $? -eq 0 ]; then
-        patch -p0 -N $2 < $1
+        patch -p0 -N $file_to_patch $patch_file
     else
-        echo "Patch $1 already applied"
+        echo "Patch $patch_file already applied"
     fi
 }
 


### PR DESCRIPTION
apply_patch check is failing in some build environments because the target is not specified in dry-run check
I have verified that this parameter addition (to mimic the actual patch application line) succeeds on both the affected environment and our regular CentOS 5 build environments.

@Microsoft/omsagent-devs 
@amal-khalaf 