### PR TITLE
Remove duplicate proxy conf workaround from doc

### DIFF
--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -81,8 +81,6 @@ sudo sh ./omsagent-*.universal.x64.sh --upgrade -w <workspace id> -s <shared key
 **To install and onboard directly using an HTTP proxy:**
 ```
 sudo sh ./omsagent-*.universal.x64.sh --upgrade -p http://<proxy user>:<proxy password>@<proxy address>:<proxy port> -w <workspace id> -s <shared key>
-sudo cp /etc/opt/microsoft/omsagent/proxy.conf /etc/opt/microsoft/omsagent/conf/proxy.conf
-sudo /opt/microsoft/omsagent/bin/service_control restart
 ```
 
 **To install and onboard to a workspace in FairFax:**
@@ -155,25 +153,22 @@ The `-p` or `--proxy` argument to the omsagent installation bundle specifies the
 
 ```
 sudo sh ./omsagent-*.universal.x64.sh --upgrade -p http://<proxy user>:<proxy password>@<proxy address>:<proxy port> -w <workspace id> -s <shared key>
-sudo cp /etc/opt/microsoft/omsagent/proxy.conf /etc/opt/microsoft/omsagent/conf/proxy.conf
-sudo /opt/microsoft/omsagent/bin/service_control restart
 ```
 
 **Define the proxy configuration in a file**
-The proxy configuration is set in these files: `/etc/opt/microsoft/omsagent/proxy.conf` and `/etc/opt/microsoft/omsagent/conf/proxy.conf` These files can be directly created or edited, but must be readable by the omsagent user. Both files must be updated should the proxy configuration change. For example:
+The proxy configuration is set in this file: `/etc/opt/microsoft/omsagent/proxy.conf` This file can be directly created or edited, but must be readable by the omsagent user. This file must be updated, and the omsagent daemon restarted, should the proxy configuration change. For example:
 ```
 proxyconf="https://proxyuser:proxypassword@proxyserver01:8080"
 sudo echo $proxyconf >>/etc/opt/microsoft/omsagent/proxy.conf
-sudo cp /etc/opt/microsoft/omsagent/proxy.conf /etc/opt/microsoft/omsagent/conf/proxy.conf
-sudo chown omsagent:omiusers /etc/opt/microsoft/omsagent/proxy.conf /etc/opt/microsoft/omsagent/conf/proxy.conf
-sudo chmod 600 /etc/opt/microsoft/omsagent/proxy.conf /etc/opt/microsoft/omsagent/conf/proxy.conf
+sudo chown omsagent:omiusers /etc/opt/microsoft/omsagent/proxy.conf
+sudo chmod 600 /etc/opt/microsoft/omsagent/proxy.conf
 sudo /opt/microsoft/omsagent/bin/service_control restart
 ```
 
 **Removing the proxy configuration**
 To remove a previously defined proxy configuration and revert to direct connectivity, remove the proxy.conf file:
 ```
-sudo rm /etc/opt/microsoft/omsagent/proxy.conf /etc/opt/microsoft/omsagent/conf/proxy.conf
+sudo rm /etc/opt/microsoft/omsagent/proxy.conf
 sudo /opt/microsoft/omsagent/bin/service_control restart
 ```
 


### PR DESCRIPTION
This workaround was rendered unnecessary by nxOMSPlugin version 3.0 with updated oms_configuration.rb: https://github.com/Microsoft/PowerShell-DSC-for-Linux/commit/3360ce8a2015075c8a03fae3b691bc600cb2b91a

This commit will function as a revert of the commit which added the temporary workaround to the doc: https://github.com/Microsoft/OMS-Agent-for-Linux/commit/30c33fdce13cd128928049fdfff80642572efef0