### PR TITLE
omsagent.ulinux now uses this_omsagent_running.

### DIFF
--- a/installer/scripts/omsagent.ulinux
+++ b/installer/scripts/omsagent.ulinux
@@ -53,21 +53,21 @@ RETVAL=0
 USER_REQ=""
 case "$1" in
      start)
-        AGENT_RUNNING=is_omsagent_running
+        AGENT_RUNNING=this_omsagent_running # Returns 0 for true, 1 for false.
         START_QUALS="-d $PIDFILE --no-supervisor -o $LOGFILE -c $CONFFILE"
 
         case $INIT_STYLE in
             D)
                 log_begin_msg "Starting $OMS_NAME: "
                 [ "`id -u`" -eq 0 ] && USER_REQ="--chuid omsagent"
-                $AGENT_RUNNING && /sbin/start-stop-daemon --start $USER_REQ --quiet --pidfile $PIDFILE --exec $OMS_BIN -- $START_QUALS
+                $AGENT_RUNNING || /sbin/start-stop-daemon --start $USER_REQ --quiet --pidfile $PIDFILE --exec $OMS_BIN -- $START_QUALS
                 RETVAL=$?
                 log_end_msg $RETVAL
                 ;;               
             R)
                 echo -n "Starting $OMS_NAME: "
                 [ "`id -u`" -eq 0 ] && USER_REQ="--user=omsagent"
-                $AGENT_RUNNING && daemon $USER_REQ $OMS_BIN $START_QUALS
+                $AGENT_RUNNING || daemon $USER_REQ $OMS_BIN $START_QUALS
                 RETVAL=$?
                 echo
                 ;;
@@ -77,7 +77,7 @@ case "$1" in
                 LC_CTYPE="$RC_LANG"; export LC_CTYPE
                 echo -n "Starting $OMS_NAME "
                 [ "`id -u`" -eq 0 ] && USER_REQ="-u omsagent"
-                $AGENT_RUNNING && startproc $USER_REQ -p $PIDFILE $OMS_BIN $START_QUALS
+                $AGENT_RUNNING || startproc $USER_REQ -p $PIDFILE $OMS_BIN $START_QUALS
                 rc_status -v
                 ;;
             *)  exit 1   ;;


### PR DESCRIPTION
This fix is a mere five lines of changes to use a new this_omsagent_running routine we build for this problem a month ago.  The new routine is used in place of the still existing "is_omsagent_running" and the logic of three of the lines in the start section are reversed.  The old diagnostic build messages appeared as follows:
[FAIL] Starting Operations Management Suite agent (08d4b0c0-7fac-4159-987c-000271282eff):  failed!
invoke-rc.d: initscript omsagent-08d4b0c0-7fac-4159-987c-000271282eff, action "start" failed.
ERROR:  start_omsagent failed with result '1' on workspace 08d4b0c0-7fac-4159-987c-000271282eff.
---snip---
with this fix the new response is now normal:
[ ok ] Starting Operations Management Suite agent (08d4b0c0-7fac-4159-987c-000271282eff): .
---snip---
Also  regression testing was done across many platforms with automation test scripts which will be checked in separately.
