### PR TITLE
Truncate UUID= validation line.

### DIFF
--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -206,7 +206,7 @@ check_omsadmin_conf()
         if ! check_file_has_line_pattern $_fs "OMS_ENDPOINT=.*";                then ec=$(expr $ec + 1); fi
         if ! check_file_has_line_pattern $_fs "AZURE_RESOURCE_ID=.*";           then ec=$(expr $ec + 1); fi
         if ! check_file_has_line_pattern $_fs "OMSCLOUD_ID=.*";                 then ec=$(expr $ec + 1); fi
-        if ! check_file_has_line_pattern $_fs "UUID=$REGEX_UUID";               then ec=$(expr $ec + 1); fi
+        if ! check_file_has_line_pattern $_fs "UUID=.*";                        then ec=$(expr $ec + 1); fi
         return $ec
     else
         echo "ERROR:  OMS Admin configuration file $_fs NOT Found!" >&2


### PR DESCRIPTION
Fix by loosening validation.

This is simply a matter of over-validation from the service_control refactoring project 6 weeks ago.  We established that the UUID= line in omsadmin.conf does NOT need to have a valid UUID for the omagent install to work.   It apparently never did in the past in certain cases.  Thus we are simply backing out of an addition that was not mandatory anyway.