### PR TITLE
Update omsagent bundle version

### DIFF
--- a/installer/scripts/onboard_agent.sh
+++ b/installer/scripts/onboard_agent.sh
@@ -6,9 +6,9 @@
 
 
 # Values to be updated upon each new release
-GITHUB_RELEASE="https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_GA_v1.4.1-123/"
-BUNDLE_X64="omsagent-1.4.1-123.universal.x64.sh"
-BUNDLE_X86="omsagent-1.4.1-123.universal.x86.sh"
+GITHUB_RELEASE="https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_GA_v1.4.2-124/"
+BUNDLE_X64="omsagent-1.4.2-124.universal.x64.sh"
+BUNDLE_X86="omsagent-1.4.2-124.universal.x86.sh"
 
 usage()
 {

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -148,7 +148,6 @@ should_check_omsadmin_conf()
 
 setup_variables()
 {
-
     local initial_conf_dir=
     if [ -z "$1" ]; then
         initial_conf_dir="$ETC_DIR/conf/omsadmin.conf"
@@ -156,16 +155,9 @@ setup_variables()
         initial_conf_dir="$ETC_DIR/$1/conf/omsadmin.conf"
     fi
 
-    WS_STATUS=0
-    should_check_omsadmin_conf $1    
-    if [ $? -eq 0 ]; then
-        check_omsadmin_conf $initial_conf_dir
-        WS_STATUS=$?
-    fi
-    if [ "$WS_STATUS" -eq "0" ]; then
-        . $initial_conf_dir
-        WS_STATUS=$?
-    fi
+    WS_STATUS=0    
+    . $initial_conf_dir
+    WS_STATUS=$?
 
     if [ "$WS_STATUS" -eq "0" ]; then
 


### PR DESCRIPTION
Update omsagent bundle version to be 1.4.2.124 and match last patch
release (remove omsadmin validation to unblock LAd and Disney). There is already existing validation done by shell itself when running service_control to import omsadmin.conf on all required fields presence. At this point there is no need to refactor the code to perform additional validations on top of default since  that new logic break existing customers. 