### PR TITLE
Update proxy documentation for http and https

### DIFF
--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -146,7 +146,7 @@ http://user01:password@proxy01.contoso.com:8080
 *Note: Although you do not have any user/password set for the proxy, you will still need to add a psuedo user/password. This can be any username or password.    
 (This will be enhanced in future so that these psuedo user/password will not be necessary)*
 
-The proxy server can be specified during installation or directly in a file (at any point). 
+OMS agent only creates secure connection over http. Even if you specify the protocol as http, please note that http requests are created using SSL/TLS secure connection so the proxy must support SSL/TLS. The proxy server can be specified during installation or directly in a file (at any point). 
 
 **Specify proxy configuration during installation:**
 The `-p` or `--proxy` argument to the omsagent installation bundle specifies the proxy configuration to use. 


### PR DESCRIPTION
Update proxy documentation for http and https to make it clear only secure http is used. OMS agent only creates secure HTTP connection over SSL/TLS even if http URL is specified in the
proxy configuration. So proxy server has to support SSL/TLS.

@keikhara