### PR TITLE
WLM discovery and monitors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -255,6 +255,28 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 +++++++++++++++++++++++++++++++++++++++
 
+Copyright © Ruby on Rails project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
++++++++++++++++++++++++++++++++++++++++
+
 %%MessagePack Implementation for C and C++ (msgpack-c)
 
 For information purposes only.

--- a/installer/conf/omsagent.d/wlm_baseOS.conf
+++ b/installer/conf/omsagent.d/wlm_baseOS.conf
@@ -1,0 +1,61 @@
+<source>
+  type wlm_discovery
+  discovery_time_file %CONF_DIR_WS%/.discovery_time
+  omi_mapping_path %CONF_DIR_WS%/wlm_discovery_mapping.json
+  wlm_class_file %CONF_DIR_WS%/universal.linux.json
+</source>
+
+<source>
+  type oms_omi
+  object_name "Universal Linux Operating System"
+  instance_regex ".*"
+  counter_name_regex ".*"
+  interval 30s
+  omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
+  wlm_enabled true
+  tag oms.wlm.monitor
+</source>
+
+<source>
+  type oms_omi
+  object_name "Logical Disk"
+  instance_regex ".*"
+  counter_name_regex ".*"
+  interval 30s
+  omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
+  wlm_enabled true
+  tag oms.wlm.monitor
+</source>
+
+<source>
+  type oms_omi
+  object_name "Physical Disk"
+  instance_regex ".*"
+  counter_name_regex ".*"
+  interval 30s
+  omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
+  wlm_enabled true
+  tag oms.wlm.monitor
+</source>
+
+<source>
+  type oms_omi
+  object_name "Network Adapter"
+  instance_regex ".*"
+  counter_name_regex ".*"
+  interval 30s
+  omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
+  wlm_enabled true
+  tag oms.wlm.monitor
+</source>
+
+<source>
+  type oms_omi
+  object_name "Processor"
+  instance_regex ".*"
+  counter_name_regex ".*"
+  interval 30s
+  omi_mapping_path %CONF_DIR_WS%/wlm_monitor_mapping.json
+  wlm_enabled true
+  tag oms.wlm.monitor
+</source>

--- a/installer/conf/universal.linux.json
+++ b/installer/conf/universal.linux.json
@@ -1,0 +1,114 @@
+[
+  {
+    "Name":"Disk Partition",
+    "Id":"26e4e0bb-806a-765b-2271-753373764e32",
+    "properties": [
+      {"Id":"883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc","Name":"DisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"d3e652a3-299c-6205-ab69-671206afdd6c","Name":"ObjectStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"6c51988d-69fe-7f3c-d56f-70b761ed1a3b","Name":"AssetStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8838bd0e-e9ca-ae96-0d1e-7da1291a772f","Name":"Notes","Type":8,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"47ea2d8d-a28f-161b-14e1-5cc98b736208","Name":"DeviceID","Type":3,"IsKey":true,"IsCaseSensitive":false},
+      {"Id":"03414ef5-5e89-39cc-c858-7a6751b10fdc","Name":"DeviceName","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"0d87b39a-3d89-42df-cf60-d7c47a78675f","Name":"DiskIndex","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"fe7e26e7-a252-5668-4cc4-6df1450ec836","Name":"BlockSize","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"2801abff-093a-dda9-d568-b9379f28fe3e",    "Name":"PrimaryPartition","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"582cded2-9e3f-3103-bf64-ecb214c603b1","Name":"Bootable","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"1f1be831-240c-5daf-acb8-f1e17df1c51b","Name":"Size","Type":3,"IsKey":false,"IsCaseSensitive":false}
+    ]
+  },
+  {
+    "Name":"Universal Linux Computer",
+    "Id":"30bc9ca4-f724-93f4-2208-58e872489b95",
+    "properties": [
+      {"Id":"883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc","Name":"DisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"CSName"},
+      {"Id":"d3e652a3-299c-6205-ab69-671206afdd6c","Name":"ObjectStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"6c51988d-69fe-7f3c-d56f-70b761ed1a3b","Name":"AssetStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8838bd0e-e9ca-ae96-0d1e-7da1291a772f","Name":"Notes","Type":8,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"5442c0f1-3251-3bf6-6f1b-d8c6f333afc3","Name":"PrincipalName","Type":3,"IsKey":true,"IsCaseSensitive":false,"CimName":"CSName"},
+      {"Id":"a670add7-280a-8f11-96e5-45ff00baba46","Name":"DNSName","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"aea59933-e0b2-6e7c-8999-798836b5730e","Name":"IPAddress","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"63e3c71e-f002-f8c4-f071-abee558cb077","Name":"NetworkName","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"144b1601-1bd9-77c2-f085-f1d09c88218b","Name":"SSHPort","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"dbdd2341-592f-0de4-7d7f-bf3007c9bf89","Name":"AgentVersion","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"51f3b833-ae5f-a4d0-fdd6-deb1c1263d35","Name":"Architecture","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"904bd983-8e8a-1ae4-5a2c-94b34fda675c","Name":"TimeZoneOffset","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"CurrentTimeZone"},
+      {"Id":"491fcb88-dfa2-08af-a147-cab2d5f74e52","Name":"IsVirtualMachine","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"ac616fe1-d25e-2575-54b4-577bf6589d67","Name":"LogicalProcessors","Type":0,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"1c2fc5ed-90b5-1656-58b8-eb7082ce13e1","Name":"PhysicalProcessors","Type":0,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"9fb792d3-6f0f-bc95-751b-ae2b2e8c6b1a","Name":"HostServerName","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"b807c42b-c750-4e45-4c85-41fddd461948","Name":"VirtualMachineName","Type":3,"IsKey":false,"IsCaseSensitive":false}
+    ]
+  },
+  {
+    "Name":"Universal Linux Operating System",
+    "Id":"5cac2bf9-b7a0-5e30-8122-70c09c077516",
+    "properties": [
+      {"Id":"883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc","Name":"DisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Caption"},
+      {"Id":"d3e652a3-299c-6205-ab69-671206afdd6c","Name":"ObjectStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"6c51988d-69fe-7f3c-d56f-70b761ed1a3b","Name":"AssetStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8838bd0e-e9ca-ae96-0d1e-7da1291a772f","Name":"Notes","Type":8,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"e218457a-4fbf-34e5-c5b4-f134e4f476df","Name":"OSVersion","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Version"},
+      {"Id":"76ee6891-3a76-37d0-082e-64f272545242","Name":"OSVersionDisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Caption"}
+    ]
+  },
+  {
+    "Name":"Logical Disk",
+    "Id":"74735bff-9225-c45f-1edf-fa2edb1f7884",
+    "properties": [
+      {"Id":"883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc","Name":"DisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"d3e652a3-299c-6205-ab69-671206afdd6c","Name":"ObjectStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"6c51988d-69fe-7f3c-d56f-70b761ed1a3b","Name":"AssetStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8838bd0e-e9ca-ae96-0d1e-7da1291a772f","Name":"Notes","Type":8,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"47ea2d8d-a28f-161b-14e1-5cc98b736208","Name":"DeviceID","Type":3,"IsKey":true,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"03414ef5-5e89-39cc-c858-7a6751b10fdc","Name":"DeviceName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"8714ce8a-1d61-b2b4-ffb6-1ffb73cc4fbc","Name":"FileSystem","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"FileSystemType"},
+      {"Id":"3111f912-5791-3853-1464-d3f4a0b0243e","Name":"Compressed","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"CompressionMethod"},
+      {"Id":"da334500-da1c-476a-69d6-732001aade17","Name":"Size","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"FileSystemSize"}
+    ]
+  },
+  {
+    "Name":"Physical Disk",
+    "Id":"a9eef4f2-c51c-ee4c-39d9-fa838bd52f20",
+    "properties": [
+      {"Id":"883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc","Name":"DisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"d3e652a3-299c-6205-ab69-671206afdd6c","Name":"ObjectStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"6c51988d-69fe-7f3c-d56f-70b761ed1a3b","Name":"AssetStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8838bd0e-e9ca-ae96-0d1e-7da1291a772f","Name":"Notes","Type":8,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"47ea2d8d-a28f-161b-14e1-5cc98b736208","Name":"DeviceID","Type":3,"IsKey":true,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"03414ef5-5e89-39cc-c858-7a6751b10fdc","Name":"DeviceName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"0b7121e8-767b-1848-978b-2a9459a83bc9","Name":"InterfaceType","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"InterfaceType"},
+      {"Id":"91180091-159e-ce3b-18d1-0f783e981e67","Name":"Model","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8e9d27b7-bb1b-be03-4ae3-17160ad8f06e","Name":"Size","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"MaxMediaSize"},
+      {"Id":"db155b3a-02a1-d540-88b1-6539c904c68f","Name":"TotalCylinders","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"TotalCylinders"},
+      {"Id":"6e954922-a6a3-1423-310d-dc8140504b59","Name":"TotalHeads","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"TotalHeads"},
+      {"Id":"d0156721-6f31-43b9-89bd-89c8e6264db0","Name":"TotalSectors","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"TotalSectors"}
+    ]
+  },
+  {
+    "Name":"Network Adapter",
+    "Id":"c4700c4e-8a81-1f93-bfc2-eb738f70d561",
+    "properties": [
+      {"Id":"883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc","Name":"DisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"d3e652a3-299c-6205-ab69-671206afdd6c","Name":"ObjectStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"6c51988d-69fe-7f3c-d56f-70b761ed1a3b","Name":"AssetStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8838bd0e-e9ca-ae96-0d1e-7da1291a772f","Name":"Notes","Type":8,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"47ea2d8d-a28f-161b-14e1-5cc98b736208","Name":"DeviceID","Type":3,"IsKey":true,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"03414ef5-5e89-39cc-c858-7a6751b10fdc","Name":"DeviceName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"ElementName"},
+      {"Id":"2460e156-cb84-3f7b-eac3-1349cde7c5db","Name":"IPAddress","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"IPv4Address"},
+      {"Id":"d26d0fc5-5e4e-7c26-34ec-6f8da5e01bcb","Name":"IPSubnet","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"SubnetMask"}
+    ]
+  },
+  {
+    "Name":"Processor",
+    "Id":"e00521c1-e161-bbe5-fb70-af43ed73ea9f",
+    "properties": [
+      {"Id":"883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc","Name":"DisplayName","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"d3e652a3-299c-6205-ab69-671206afdd6c","Name":"ObjectStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"6c51988d-69fe-7f3c-d56f-70b761ed1a3b","Name":"AssetStatus","Type":7,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"8838bd0e-e9ca-ae96-0d1e-7da1291a772f","Name":"Notes","Type":8,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"47ea2d8d-a28f-161b-14e1-5cc98b736208","Name":"DeviceID","Type":3,"IsKey":true,"IsCaseSensitive":false,"CimName":"Name"},
+      {"Id":"03414ef5-5e89-39cc-c858-7a6751b10fdc","Name":"DeviceName","Type":3,"IsKey":false,"IsCaseSensitive":false},
+      {"Id":"648dd78a-1018-2201-dae8-68edaa186d83","Name":"PerfmonInstance","Type":3,"IsKey":false,"IsCaseSensitive":false,"CimName":"Name"}
+    ]
+  }
+]

--- a/installer/conf/wlm_discovery_mapping.json
+++ b/installer/conf/wlm_discovery_mapping.json
@@ -1,0 +1,61 @@
+[
+    {
+        "CimClassName": "SCX_OperatingSystem",
+        "InstanceProperty": "Caption",
+        "InstanceRegex": ".*",
+        "Namespace": "root/scx",
+        "DiscoveryID": "SystemDiscoveryID",
+        "ClassName": "Universal Linux Computer",
+        "CimProperties": ["CSName","CurrentTimeZone"]
+    },
+    {
+        "CimClassName": "SCX_RTProcessorStatisticalInformation",
+        "InstanceProperty": "Name",
+        "InstanceRegex": "^(?!_Total).*$",
+        "Namespace": "root/scx",
+        "DiscoveryID": "ProcessorDiscoveryID",
+        "ClassName": "Processor",
+        "Parent": "Universal Linux Computer",
+        "CimProperties": ["Name"]
+    },
+    {
+        "CimClassName": "SCX_FileSystem",
+        "InstanceProperty": "Name",
+        "InstanceRegex": "^(?!_Total).*$",
+        "Namespace": "root/scx",
+        "DiscoveryID": "LogicalDiskDiscoveryID",
+        "ClassName": "Logical Disk",
+        "Parent": "Universal Linux Computer",
+        "CimProperties": ["Name","FileSystemType","CompressionMethod","FileSystemSize"]
+    },
+    {
+        "CimClassName": "SCX_IPProtocolEndpoint",
+        "InstanceProperty": "Name",
+        "InstanceRegex": "^(?!sit).*$",
+        "Namespace": "root/scx",
+        "DiscoveryID": "NetworkAdapterDiscoveryID",
+        "ClassName": "Network Adapter",
+        "Parent": "Universal Linux Computer",
+        "CimProperties": ["Name","ElementName","IPv4Address","SubnetMask"]
+    },
+    {
+        "CimClassName": "SCX_OperatingSystem",
+        "InstanceProperty": "Caption",
+        "InstanceRegex": ".*",
+        "Namespace": "root/scx",
+        "DiscoveryID": "OperatingSystemDiscoveryID",
+        "ClassName": "Universal Linux Operating System",
+        "Parent": "Universal Linux Computer",
+        "CimProperties": ["Version","Caption"]
+    },
+    {
+        "CimClassName": "SCX_DiskDrive",
+        "InstanceProperty": "Name",
+        "InstanceRegex": "^(?!_Total).*$",
+        "Namespace": "root/scx",
+        "DiscoveryID": "PhysicalDiskDiscoveryID",
+        "ClassName": "Physical Disk",
+        "Parent": "Universal Linux Computer",
+        "CimProperties": ["Name","InterfaceType","MaxMediaSize","TotalCylinders","TotalHeads","TotalSectors"]
+    }
+]

--- a/installer/conf/wlm_monitor_mapping.json
+++ b/installer/conf/wlm_monitor_mapping.json
@@ -1,0 +1,190 @@
+[
+    {
+        "CimClassName": "SCX_RTProcessorStatisticalInformation",
+        "ObjectName": "Processor",
+        "InstanceProperty": "Name",
+        "Namespace": "root/scx",
+        "CimProperties": [
+            {
+                "CimPropertyName": "PercentProcessorTime",
+                "CounterName": "% Processor Time"
+            },
+            {
+                "CimPropertyName": "PercentDPCTime",
+                "CounterName": "% DPC Time"
+            },
+            {
+                "CimPropertyName": "PercentInterruptTime",
+                "CounterName": "% Interrupt Time"
+            }
+        ]
+    },
+    {
+        "CimClassName": "SCX_FileSystemStatisticalInformation",
+        "ObjectName": "Logical Disk",
+        "InstanceProperty": "Name",
+        "Namespace": "root/scx",
+        "CimProperties": [
+            {
+                "CimPropertyName": "PercentFreeInodes",
+                "CounterName": "% Free Inodes"
+            },
+            {
+                "CimPropertyName": "FreeMegabytes",
+                "CounterName": "Free Megabytes"
+            },
+            {
+                "CimPropertyName": "PercentFreeSpace",
+                "CounterName": "% Free Space"
+            },
+            {   "CimPropertyName": "IsOnline",
+                "CounterName": "Logical Disk Online"
+            }
+        ]
+    },
+    {
+        "CimClassName": "SCX_MemoryStatisticalInformation",
+        "ObjectName": "Universal Linux Operating System",
+        "InstanceProperty": "Name",
+        "Namespace": "root/scx",
+        "CimProperties": [
+            {
+                "CimPropertyName": "AvailableMemory",
+                "CounterName": "Available MBytes Memory"
+            },
+            {
+                "CimPropertyName": "AvailableSwap",
+                "CounterName": "Available MBytes Swap"
+            }
+        ]
+    },
+    {
+        "CimClassName": "SCX_DiskDriveStatisticalInformation",
+        "ObjectName": "Physical Disk",
+        "InstanceProperty": "Name",
+        "Namespace": "root/scx",
+        "CimProperties": [
+            {
+                "CimPropertyName": "AverageTransferTime",
+                "CounterName": "Avg. Disk sec/Transfer"
+            },
+            {
+                "CimPropertyName": "AverageReadTime",
+                "CounterName": "Avg. Disk sec/Read"
+            },
+            {
+                "CimPropertyName": "AverageWriteTime",
+                "CounterName": "Avg. Disk sec/Write"
+            },
+            {   "CimPropertyName": "IsOnline",
+                "CounterName": "Physical Disk Online"
+            }
+        ]
+    },
+    {
+        "CimClassName": "SCX_IPProtocolEndpoint",
+        "ObjectName": "Network Adapter",
+        "InstanceProperty": "Name",
+        "Namespace": "root/scx",
+        "CimProperties": [
+            {
+                "CimPropertyName": "EnabledState",
+                "CounterName": "Enabled state"
+            }
+        ]
+    },
+    {
+        "CimClassName": "SCX_UnixProcessStatisticalInformation",
+        "ObjectName": "Process",
+        "InstanceProperty": "Name",
+        "Namespace": "root/scx",
+        "CimProperties": [
+            {
+                "CimPropertyName": "PercentUserTime",
+                "CounterName": "Pct User Time"
+            },
+            {
+                "CimPropertyName": "PercentPrivilegedTime",
+                "CounterName": "Pct Privileged Time"
+            },
+            {
+                "CimPropertyName": "UsedMemory",
+                "CounterName": "Used Memory",
+                "DisplayName": "Used Memory kBytes"
+            },
+            {
+                "CimPropertyName": "VirtualSharedMemory",
+                "CounterName": "Virtual Shared Memory"
+            }
+        ]
+    },
+    {
+        "CimClassName": "Apache_HTTPDServerStatistics",
+        "ObjectName": "Apache HTTP Server Statistics",
+        "InstanceProperty": "InstanceID",
+        "Namespace": "root/apache",
+        "CimProperties": [
+            {
+                "CimPropertyName": "TotalPctCPU",
+                "CounterName": "Total Pct CPU"
+            },
+            {
+                "CimPropertyName": "IdleWorkers",
+                "CounterName": "Idle Workers"
+            },
+            {
+                "CimPropertyName": "BusyWorkers",
+                "CounterName": "Busy Workers"
+            },
+            {
+                "CimPropertyName": "PctBusyWorkers",
+                "CounterName": "Pct Busy Workers"
+            }
+        ]
+    },
+    {
+        "CimClassName": "Apache_HTTPDServer",
+        "ObjectName": "Apache HTTP Server",
+        "InstanceProperty": "InstanceID",
+        "Namespace": "root/apache",
+        "CimProperties": [
+            {
+              "CimPropertyName": "OperatingStatus",
+              "CounterName": "Operating Status"
+            }
+        ]
+    },
+    {
+        "CimClassName": "Apache_HTTPDVirtualHostStatistics",
+        "ObjectName": "Apache Virtual Host",
+        "InstanceProperty": "InstanceID",
+        "Namespace": "root/apache",
+        "CimProperties": [
+            {
+                "CimPropertyName": "RequestsPerSecond",
+                "CounterName": "Requests per Second"
+            },
+            {
+                "CimPropertyName": "ErrorsPerMinute400",
+                "CounterName": "Errors per Minute - Client"
+            },
+            {
+                "CimPropertyName": "ErrorsPerMinute500",
+                "CounterName": "Errors per Minute - Server"
+            }   
+        ]
+    },
+   {
+        "CimClassName": "Apache_HTTPDVirtualHostCertificate",
+        "ObjectName": "Apache Virtual Host Certificate",
+        "InstanceProperty": "Name",
+        "Namespace": "root/apache",
+        "CimProperties": [
+            {
+                "CimPropertyName": "DaysUntilExpiration",
+                "CounterName": "Days Until Expiration"
+            }
+        ]
+    }
+]
+

--- a/source/code/plugins/in_oms_omi.rb
+++ b/source/code/plugins/in_oms_omi.rb
@@ -16,6 +16,7 @@ module Fluent
     config_param :interval, :time, :default => nil
     config_param :tag, :string, :default => "oms.omi"  
     config_param :omi_mapping_path, :string, :default => "/etc/opt/microsoft/omsagent/conf/omsagent.d/omi_mapping.json"
+    config_param :wlm_enabled, :bool, :default => false
 
     def configure (conf)
       super
@@ -46,8 +47,13 @@ module Fluent
     end
 
     def enumerate
+      wrapper = nil
       time = Time.now.to_f
-      wrapper = @omi_lib.enumerate(time)
+      if(!@wlm_enabled)
+        wrapper = @omi_lib.enumerate(time)
+      else
+        wrapper = @omi_lib.enumerate(time, "WLM_LINUX_PERF_DATA_BLOB", "WorkloadBaseOS", @wlm_enabled)
+      end
       router.emit(@tag, time, wrapper) if wrapper
     end
 

--- a/source/code/plugins/in_wlm_discovery.rb
+++ b/source/code/plugins/in_wlm_discovery.rb
@@ -1,0 +1,120 @@
+module Fluent
+
+  class WLMOMIDiscovery < Input
+    Plugin.register_input('wlm_discovery', self)
+
+    def initialize
+      super
+      require 'base64'
+      require_relative 'oms_omi_lib'
+      require_relative 'wlm_omi_discovery_lib'
+      require_relative 'wlm_formatter'
+      require_relative 'oms_common'
+    end
+
+    config_param :wlm_class_file, :string
+    config_param :discovery_time_file, :string
+    config_param :omi_mapping_path, :string
+
+    def configure (conf)
+      super
+      @default_timeout = 14400
+    end
+
+    def start
+      @finished = false
+      @condition = ConditionVariable.new
+      @mutex = Mutex.new
+      @thread = Thread.new(&method(:run_periodic))
+    end
+
+    def shutdown
+      if @interval
+        @mutex.synchronize {
+          @finished = true
+          @condition.signal
+        }
+        @thread.join
+      end
+    end
+
+    def discover
+      omi_lib = WLM::WLMOMIDiscoveryCollector.new(@omi_mapping_path)
+      discovery_data = omi_lib.get_discovery_data()
+      wlm_formatter = WLM::WLMDataFormatter.new(@wlm_class_file)
+      discovery_data.each do |wclass|
+        discovery_xml = wlm_formatter.get_discovery_xml(wclass)
+        instance = {}
+        instance["Host"] = OMS::Common.get_fully_qualified_domain_name
+        instance["OSType"] = "Linux"
+        instance["ObjectName"] = wclass["class_name"]
+        instance["EncodedDataItem"] = Base64.strict_encode64(discovery_xml)
+        wrapper = {
+          "DataType"=>"WLM_LINUX_INSTANCE_DATA_BLOB",
+          "IPName"=>"WorkloadBaseOS",
+          "DataItems"=>[instance]
+        }
+        router.emit("oms.wlm.discovery", Time.now.to_f, wrapper)
+      end # each
+      update_discovery_time(Time.now.to_i)
+      $log.debug "Discovery data for #{@omi_mapping_path} generated successfully"
+    end # method discover
+
+    def run_periodic
+      begin
+        timeout_value = @default_timeout
+        last_discovery_time = Time.at(get_last_discovery_time.to_i)
+        if(last_discovery_time.to_i > 0)
+          next_discovery_time = last_discovery_time + @default_timeout
+          current_time = Time.now
+          if(current_time >= next_discovery_time)
+            discover
+          else
+            timeout_value = next_discovery_time - current_time
+          end # if
+        else
+          discover
+        end # if
+        @mutex.lock
+        done = @finished
+        until done
+          $log.debug "#{timeout_value} seconds befor next discovery"
+          @condition.wait(@mutex, timeout_value)
+          timeout_value = @default_timeout
+          done = @finished
+          @mutex.unlock
+          if !done
+            discover
+          end
+          @mutex.lock
+        end # until
+        @mutex.unlock
+        rescue => e
+          $log.error "Error generating discovery data #{e}"
+        end # begin
+    end # method run_periodic
+    
+    def update_discovery_time(time)
+      begin
+        time_file = File.open(@discovery_time_file, "w")
+        time_file.write(time.to_s)
+      rescue => e
+        $log.debug "Error updating last discovery time #{e}"
+      ensure
+        time_file.close unless time_file.nil?
+      end # begin
+    end # method update_discovery_time
+    
+    def get_last_discovery_time()
+      begin
+        last_discovery_time = File.open(@discovery_time_file, &:readline)
+        return last_discovery_time.strip()
+      rescue => e
+        $log.debug "Error reading last discovery time #{e}"
+        return ""
+      end # begin
+    end # method get_last_discovery_time
+
+  end # class WLMOMIDiscovery
+
+end # module Fluent

--- a/source/code/plugins/wlm_formatter.rb
+++ b/source/code/plugins/wlm_formatter.rb
@@ -1,0 +1,223 @@
+require "securerandom"
+require 'json'
+require 'stringio'
+require_relative 'omslog'
+require_relative 'oms_common'
+
+module Digest
+    # Took sample from https://github.com/rails/rails/blob/a9dc45459abcd9437085f4dd0aa3c9d0e64e062f/activesupport/lib/active_support/core_ext/digest/uuid.rb#L16
+    # Generates a v5 non-random UUID (Universally Unique IDentifier).
+    #
+    # Using Digest::MD5 generates version 3 UUIDs; Digest::SHA1 generates version 5 UUIDs.
+    # uuid_from_hash always generates the same UUID for a given name and namespace combination.
+    #
+    # See RFC 4122 for details of UUID at: http://www.ietf.org/rfc/rfc4122.txt
+
+  def self.uuid_from_hash(name)
+    hash = Digest::SHA1.new
+    version = 5
+
+    hash.update("WLM_Linux_MP")
+    hash.update(name)
+
+    ary = hash.digest.unpack("NnnnnN")
+    ary[2] = (ary[2] & 0x0FFF) | (version << 12)
+    ary[3] = (ary[3] & 0x3FFF) | 0x8000
+
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+  end
+end
+
+module WLM
+
+  class MPStore 
+    class << self
+      def Initialize()
+        @@class_name_guids = Hash.new
+        @@key_properties = Hash.new
+        @@properties = Hash.new
+        @@cim_properties = Hash.new    
+      end
+
+      def get_class_name_guid(className)
+        return @@class_name_guids[className]
+      end
+
+      def is_key_property(className, propertyName)
+        return @@key_properties.has_key?(className + "_" + propertyName)
+      end
+
+      def get_property_guid(className,propertyName)
+        return @@properties[className + "_" + propertyName]
+      end
+        
+      def get_cim_property(className,propertyName)
+        return @@cim_properties[className+"_"+propertyName]
+      end
+
+      def load(file_name)
+        classes = []
+       
+        begin
+          file = File.read(file_name)
+        rescue => e
+          $log.error "Unable to read file #{file_name}"
+        end # begin
+       
+        begin
+          classes = JSON.parse(file)
+        rescue => e
+          $log.error "Error parsing file #{file_name} : #{e}"
+        end # begin
+
+        classes.each do |workload_class|
+          @@class_name_guids[workload_class["Name"]] =  workload_class["Id"]
+          workload_class["properties"].each do |prop|
+            if !(prop.has_key? "CimName")
+              next
+            end # if
+                            
+            if prop["IsKey"]
+              @@key_properties[workload_class["Name"]+"_"+prop["Name"]] = prop["Id"]
+            end # if
+            @@properties[workload_class["Name"]+"_"+prop["Name"]] = prop["Id"]
+                            
+            if @@cim_properties.has_key? (workload_class["Name"]+"_"+prop["CimName"])
+              @@cim_properties[workload_class["Name"]+"_"+prop["CimName"]].push(prop["Name"])
+            else
+              @@cim_properties[workload_class["Name"]+"_"+prop["CimName"]] = [prop["Name"]]
+            end # if
+          end # do |prop|               
+        end # do |workload_class|
+      end # method load
+      
+    end # class self
+  end # class MPStore
+
+  class WLMClassInstance
+   
+    def initialize(class_name)
+      @class_name = class_name      
+      @class_id = MPStore.get_class_name_guid(class_name)
+      @properties = Hash.new
+      @key_properties = Hash.new
+    end
+
+    def add_property(property_name, property_value)       
+        
+      if MPStore.is_key_property(@class_name,property_name)
+        @key_properties[MPStore.get_property_guid(@class_name, property_name)] = property_value.to_sym
+      end
+
+      @properties[MPStore.get_property_guid(@class_name, property_name)] = property_value.to_sym  
+    end # method add_property
+    
+    def add_cim_property(property_name, property_value)
+      MPStore.get_cim_property(@class_name, property_name).each do |prop|
+        add_property(prop, property_value)
+      end # do
+    end # method add_cim_property
+
+    def add_key_property(property_guid, property_value)         
+      @key_properties[property_guid] = property_value.to_sym
+      @properties[property_guid] = property_value.to_sym
+    end # method add_key_property
+
+    def get_class_id
+      return @class_id
+    end
+
+    def get_key_properties()
+      return @key_properties
+    end
+
+    def get_all_properties
+      return @properties
+    end
+
+    def create_sub_class_instance(class_name)
+      sub_instance = WLMClassInstance.new(class_name)
+      @key_properties.each {|key,value| sub_instance.add_key_property(key,value)}
+      return sub_instance
+    end # method create_sub_class_instance
+    
+  end # class WLMClassInstance
+
+  class WLMDiscoveryData
+    
+    def initialize(rule_name, computer_name)
+      @rule_id = Digest.uuid_from_hash(rule_name)
+      @root_managed_entity_id = Digest.uuid_from_hash(computer_name)
+      @source_health_service_id = Digest.uuid_from_hash(computer_name+"HealthService")
+      @instance_array = Array.new
+    end
+
+    def create_root_instance(class_name)
+      return WLMClassInstance.new(class_name)
+    end
+
+    def add_instance(new_instance)
+      @instance_array.push(new_instance)
+    end 
+
+    def generate_xml(class_name)
+      xml_buffer = StringIO.new
+      xml_buffer << "<DataItem type=System.DiscoveryData time=#{Time.now.strftime("%Y-%m-%dT%H:%M:%S.%7N%:z")} sourceHealthServiceId="+@source_health_service_id+">"
+      xml_buffer << "<DiscoveryType>0</DiscoveryType>"
+      xml_buffer << "<DiscoverySourceType>0</DiscoverySourceType>"
+      xml_buffer << "<DiscoverySourceObjectId>{"+@rule_id+"}</DiscoverySourceObjectId>"
+      xml_buffer << "<DiscoverySourceManagedEntity>{"+@root_managed_entity_id+"}</DiscoverySourceManagedEntity>" 
+      xml_buffer << "<ClassInstances>"
+      @instance_array.each do  |instance|
+        xml_buffer << "<ClassInstance TypeId={"+instance.get_class_id()+"}>"
+        xml_buffer << "<Settings>"
+        property_map = instance.get_all_properties()            
+        property_map.keys.each do |instance_property_key|
+          xml_buffer << "<Setting>"
+          xml_buffer << "<Name>{"+instance_property_key+"}</Name>"
+          xml_buffer << "<Value>"+String(property_map[instance_property_key])+"</Value>"
+          xml_buffer << "</Setting>"
+        end # do |instance_property_key|
+        xml_buffer << "</Settings>"
+        xml_buffer << "</ClassInstance>"
+      end # do |instance|
+      xml_buffer << "</ClassInstances>"
+      xml_buffer << "</DataItem>"
+      return xml_buffer.string  
+    end # method generate_xml
+    
+  end # class WLMDiscoveryData
+
+  class WLMDataFormatter
+
+    def initialize(wlm_class_file)
+      MPStore.Initialize
+      MPStore.load(wlm_class_file)
+      @parent_key_properties = {}
+    end
+
+    def get_discovery_xml(wclass)
+      discovery  = WLMDiscoveryData.new(wclass["discovery_id"],OMS::Common.get_fully_qualified_domain_name)
+      wclass["discovery_data"].each do |instance|
+        wlm_instance = discovery.create_root_instance(wclass["class_name"])
+        if wclass.has_key? "parent"
+          @parent_key_properties[wclass["parent"]].each do |key, value|
+            wlm_instance.add_key_property(key,value)
+          end # do |key, value|
+        end # if
+        instance.each do |properties|
+          properties.each do |key,value|
+            wlm_instance.add_cim_property(key,value)
+          end # do |key,value|
+        end # do |properties|
+        discovery.add_instance(wlm_instance)
+        if wclass["class_name"] == "Universal Linux Computer"
+          @parent_key_properties["Universal Linux Computer"] = wlm_instance.get_key_properties
+        end # if
+      end # do |instance| 
+      $log.debug "Discovery xml generated for #{wclass["class_name"]}"
+      return discovery.generate_xml(wclass["class_name"])  
+    end # method get_discovery_xml
+    
+  end# class WLMDataFormatter
+end # module WLM

--- a/source/code/plugins/wlm_omi_discovery_lib.rb
+++ b/source/code/plugins/wlm_omi_discovery_lib.rb
@@ -1,0 +1,94 @@
+module WLM
+  class WLMOMIDiscoveryCollector
+    require 'json'
+    require_relative 'oms_common'
+    require_relative 'omslog'
+    
+    def initialize(omi_mapping_path, omi_interface=nil)
+      begin
+        file = File.read(omi_mapping_path)
+      rescue => e
+        @conf_error = true
+        $log.error "Unable to read file #{omi_mapping_path}"
+      end
+
+      begin
+        @omi_mapping = JSON.parse(file)
+      rescue => e
+        @conf_error = true
+        $log.error "Error parsing file #{omi_mapping_path} : #{e}"
+      end
+
+      if omi_interface
+        @omi_interface = omi_interface
+      else
+        require_relative 'Libomi'
+        @omi_interface = Libomi::OMIInterface.new
+      end
+      @omi_interface.connect
+      @conf_error = false
+    end
+    
+    def enumerate(specific_mapping)
+      return nil if @conf_error
+
+      namespace = specific_mapping["Namespace"]
+      cim_class_name = specific_mapping["CimClassName"]
+      items = [[namespace, cim_class_name]]
+      record_txt = @omi_interface.enumerate(items)
+      instances = JSON.parse record_txt
+
+      # Filter based on instance names
+      begin
+        instances.select!{ |instance| 
+          /#{specific_mapping["InstanceRegex"]}/.match(instance[specific_mapping["InstanceProperty"]])
+        }
+      rescue => e
+        $log.error "Regex error on instance_regex : #{e}"
+        return nil
+      end # begin
+      return instances
+    end # method enumerate
+    
+    def get_cim_data(instances,specific_mapping)
+      cim_data = []
+      instances.each do |instance|
+        cim_data.push(get_cim_values(instance,specific_mapping))
+      end # each
+      return cim_data
+    end # method get_cim_data
+    
+    def get_cim_values(instance,specific_mapping)
+      cim_values = []
+      cim_properties = specific_mapping["CimProperties"]
+      instance.each do |property,value|
+       if cim_properties.include? property
+         property_pair = {}
+         property_pair[property] = value
+         cim_values.push(property_pair)
+       end # if
+      end # each
+      return cim_values
+    end # method get_cim_values
+    
+    def get_specific_discovery(specific_mapping)
+      discovery_data = {}
+      discovery_data["discovery_id"] = specific_mapping["DiscoveryID"]
+      discovery_data["class_name"] = specific_mapping["ClassName"]
+      discovery_data["parent"] = specific_mapping["Parent"] if specific_mapping.has_key? "Parent"
+      instances = enumerate(specific_mapping)
+      discovery_data["discovery_data"] = get_cim_data(instances,specific_mapping)
+      return discovery_data
+    end # method get_discovery_data
+
+    def get_discovery_data
+      discovery_collection = []
+      @omi_mapping.each do |specific_mapping|
+        discovery_collection.push(get_specific_discovery(specific_mapping))
+      end # each
+      @omi_interface.disconnect
+      return discovery_collection
+    end # method get_discovery data
+
+  end # class WLMOMIDiscoveryCollector
+end # module WLM

--- a/test/code/plugins/oms_omi_lib_test.rb
+++ b/test/code/plugins/oms_omi_lib_test.rb
@@ -41,6 +41,7 @@ class In_OMS_OMI_Test < Test::Unit::TestCase
     @mock = MockOmiInterface.new
     @common = MockCommon
     @mapping_path = "#{ENV['BASE_DIR']}/installer/conf/omi_mapping.json"
+    @wlm_mapping_path = "#{ENV['BASE_DIR']}/installer/conf/wlm_monitor_mapping.json"
   end
 
   def teardown
@@ -53,8 +54,14 @@ class In_OMS_OMI_Test < Test::Unit::TestCase
     oms_object_names.each { |name| validate_specific_mapping(name) }
   end
   
-  def validate_specific_mapping(object_name)
-    omilib = OmiOms.new(object_name, 'inst_regex', 'counter_regex', @mapping_path, @mock)
+  def test_get_specific_mapping_wlm
+    wlm_object_names = ['Processor', 'Logical Disk', 'Universal Linux Operating System', 'Physical Disk', 'Network Adapter', 'Apache HTTP Server Statistics',
+                        'Apache HTTP Server', 'Apache Virtual Host', 'Apache Virtual Host Certificate']
+    wlm_object_names.each { |name| validate_specific_mapping(name, @wlm_mapping_path) }
+  end
+  
+  def validate_specific_mapping(object_name, mapping=@mapping_path)
+    omilib = OmiOms.new(object_name, 'inst_regex', 'counter_regex', mapping, @mock)
 
     assert_equal([], $log.logs, "There was an error creating omilib")
     assert_not_equal(nil, omilib.specific_mapping, "Specific mapping should not be null for '#{object_name}'")
@@ -116,6 +123,27 @@ class In_OMS_OMI_Test < Test::Unit::TestCase
     cim_to_oms = omilib.get_cim_to_oms_mappings(cim_properties)
     expected = {"TotalPctCPU"=>"Total Pct CPU", "IdleWorkers"=>"Idle Workers", "BusyWorkers"=>"Busy Workers", "PctBusyWorkers"=>"Pct Busy Workers"}
     assert_equal(expected, cim_to_oms, "Did not generate the correct mapping of CIM to OMS properties")
+  end
+  
+  def test_get_cim_to_wlm_mappings
+    omilib = OmiOms.new('Processor', 'inst_regex', 'counter_regex', @wlm_mapping_path, @mock)
+    
+    cim_properties = [{
+                        "CimPropertyName"=> "PercentProcessorTime",
+                        "CounterName"=> "% Processor Time"
+                      },
+                      {
+                        "CimPropertyName"=> "PercentDPCTime",
+                        "CounterName"=> "% DPC Time"
+                      },
+                      {
+                        "CimPropertyName"=> "PercentInterruptTime",
+                        "CounterName"=> "% Interrupt Time"
+                      }]
+
+    cim_to_wlm = omilib.get_cim_to_oms_mappings(cim_properties)
+    expected = {"PercentProcessorTime"=>"% Processor Time", "PercentDPCTime"=>"% DPC Time", "PercentInterruptTime"=>"% Interrupt Time"}
+    assert_equal(expected, cim_to_wlm, "Did not generate the correct mapping of CIM to WLM properties")  
   end
   
   def test_enumerate_filtering

--- a/test/code/plugins/wlm_formatter_test.rb
+++ b/test/code/plugins/wlm_formatter_test.rb
@@ -1,0 +1,61 @@
+require 'test/unit'
+require_relative '../../../source/code/plugins/wlm_formatter'
+require_relative 'omstestlib'
+
+class In_WLM_Formatter_test < Test::Unit::TestCase
+
+  def setup
+    $log = OMS::MockLog.new
+    wlm_class_file = "#{ENV['BASE_DIR']}/installer/conf/universal.linux.json"
+    WLM::MPStore.Initialize
+    WLM::MPStore.load(wlm_class_file)
+  end # method setup
+
+  def teardown
+  end
+
+  def test_wlm_system_class_instance
+    class_inst = WLM::WLMClassInstance.new("Universal Linux Computer")
+    class_inst.add_cim_property("CSName", "TestCSName")
+    class_inst.add_cim_property("CurrentTimeZone", "1234")
+
+    assert_equal(class_inst.get_class_id, "30bc9ca4-f724-93f4-2208-58e872489b95", "Unexpected class ID")
+
+    expected_key_props = {"5442c0f1-3251-3bf6-6f1b-d8c6f333afc3" => "TestCSName".to_sym}
+    assert_equal(class_inst.get_key_properties, expected_key_props, "Unexpected key properties")
+
+    expected_props = {
+                       "5442c0f1-3251-3bf6-6f1b-d8c6f333afc3" => "TestCSName".to_sym, 
+                       "883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc" => "TestCSName".to_sym, 
+                       "904bd983-8e8a-1ae4-5a2c-94b34fda675c" => "1234".to_sym
+                     }
+    assert_equal(class_inst.get_all_properties, expected_props, "Unexpected properties")
+  end # method test_wlm_class_instance
+  
+  def test_wlm_logical_disk_class_instance
+    class_inst = WLM::WLMClassInstance.new("Logical Disk")
+    class_inst.add_key_property("5442c0f1-3251-3bf6-6f1b-d8c6f333afc3","TestCSName")
+    class_inst.add_cim_property("Name","LDisk")
+    class_inst.add_cim_property("FileSystemType","FSType")
+    class_inst.add_cim_property("CompressionMethod","CMethod")
+    class_inst.add_cim_property("FileSystemSize","FSSize")
+    
+    expected_key_props = {
+                           "5442c0f1-3251-3bf6-6f1b-d8c6f333afc3" => "TestCSName".to_sym,
+                           "47ea2d8d-a28f-161b-14e1-5cc98b736208" => "LDisk".to_sym
+                         }
+    assert_equal(class_inst.get_key_properties, expected_key_props, "Unexpected key properties")
+    
+    expected_props = {
+                       "5442c0f1-3251-3bf6-6f1b-d8c6f333afc3" => "TestCSName".to_sym, 
+                       "47ea2d8d-a28f-161b-14e1-5cc98b736208" => "LDisk".to_sym, 
+                       "883cd2bb-eb57-b4ff-bbf2-69b7cf4570dc" => "LDisk".to_sym,
+                       "03414ef5-5e89-39cc-c858-7a6751b10fdc" => "LDisk".to_sym,
+                       "8714ce8a-1d61-b2b4-ffb6-1ffb73cc4fbc" => "FSType".to_sym,
+                       "3111f912-5791-3853-1464-d3f4a0b0243e" => "CMethod".to_sym,
+                       "da334500-da1c-476a-69d6-732001aade17" => "FSSize".to_sym
+                     }
+    assert_equal(class_inst.get_all_properties, expected_props, "Unexpected properties")
+  end # method test_wlm_logical_disk_class_instance
+
+end # In_WLM_Formatter_test

--- a/test/code/plugins/wlm_omi_discovery_lib_test.rb
+++ b/test/code/plugins/wlm_omi_discovery_lib_test.rb
@@ -1,0 +1,63 @@
+require 'test/unit'
+require_relative '../../../source/code/plugins/wlm_omi_discovery_lib'
+require_relative 'omstestlib'
+
+class In_OMS_WLM_Test < Test::Unit::TestCase
+  
+  class MockOmiWlmInterface
+    attr_accessor :omi_result
+    attr_reader :called_connect
+    attr_reader :called_disconnect
+
+    def initialize
+      @called_connect = false
+      @called_disconnect = false
+    end
+    
+    def enumerate(items)
+      return @omi_result[items[0][1]]
+    end
+
+    def connect
+      @called_connect = true
+    end
+
+    def disconnect
+      @called_disconnect = true
+    end
+    
+  end # class MockOmiWlmInterface
+  
+  def setup
+    $log = OMS::MockLog.new
+    @mock = MockOmiWlmInterface.new
+    set_static_mock_data
+    @mapping_path = "#{ENV['BASE_DIR']}/installer/conf/wlm_discovery_mapping.json"
+  end
+
+  def teardown
+  end
+
+  def test_wlm_omi_data
+    omilib = WLM::WLMOMIDiscoveryCollector.new(@mapping_path, @mock)
+    discovery_data = omilib.get_discovery_data()
+    assert_equal(discovery_data, @expected_result, "Discovery data not as expected")
+  end  
+
+  def set_static_mock_data
+    @mock.omi_result = {}
+    @mock.omi_result['SCX_OperatingSystem'] = '[{"ClassName":"SCX_OperatingSystem","Caption":"Ubuntu 16.04 (x86_64)","Description":"Ubuntu 16.04 (x86_64)","Name":"Linux Distribution","EnabledState":"5","RequestedState":"12","EnabledDefault":"2","CSCreationClassName":"SCX_ComputerSystem","CSName":"vimish-ubu-01.scx.com","CreationClassName":"SCX_OperatingSystem","OSType":"36","OtherTypeDescription":"4.4.0-96-generic #119-Ubuntu SMP Tue Sep 12 14:59:54 UTC 2017 x86_64   ","Version":"16.04","LastBootUpTime":{"MI_Type":"MI_Timestamp","year":"2017","month":"10","day":"14","hour":"8","minute":"21","second":"26","microseconds":"0","utc":"0"},"LocalDateTime":{"MI_Type":"MI_Timestamp","year":"2017","month":"10","day":"17","hour":"3","minute":"58","second":"26","microseconds":"25506","utc":"0"},"CurrentTimeZone":"-420","NumberOfLicensedUsers":"0","NumberOfUsers":"1","NumberOfProcesses":"118","MaxNumberOfProcesses":"3520","TotalSwapSpaceSize":"1044476","TotalVirtualMemorySize":"1535404","FreeVirtualMemory":"1219404","FreePhysicalMemory":"198736","TotalVisibleMemorySize":"490928","SizeStoredInPagingFiles":"1044476","FreeSpaceInPagingFiles":"1020668","MaxProcessMemorySize":"0","MaxProcessesPerUser":"1760","OperatingSystemCapability":"64 bit","SystemUpTime":"243034"}]'
+    
+    @mock.omi_result['SCX_RTProcessorStatisticalInformation'] = '[{"ClassName":"SCX_RTProcessorStatisticalInformation","Caption":"Processor information","Description":"CPU usage statistics","Name":"0","IsAggregate":"false","PercentIdleTime":"99","PercentUserTime":"0","PercentNiceTime":"0","PercentPrivilegedTime":"0","PercentInterruptTime":"0","PercentDPCTime":"0","PercentProcessorTime":"1","PercentIOWaitTime":"0"},{"ClassName":"SCX_RTProcessorStatisticalInformation","Caption":"Processor information","Description":"CPU usage statistics","Name":"_Total","IsAggregate":"true","PercentIdleTime":"99","PercentUserTime":"0","PercentNiceTime":"0","PercentPrivilegedTime":"0","PercentInterruptTime":"0","PercentDPCTime":"0","PercentProcessorTime":"1","PercentIOWaitTime":"0"}]'
+
+    @mock.omi_result['SCX_FileSystem'] = ' [{"ClassName":"SCX_FileSystem","Caption":"File system information","Description":"Information about a logical unit of secondary storage","Name":"\/","CSCreationClassName":"SCX_ComputerSystem","CSName":"vimish-ubu-01.scx.com","CreationClassName":"SCX_FileSystem","Root":"\/","BlockSize":"4096","FileSystemSize":"132476702720","AvailableSpace":"124229484544","ReadOnly":"false","EncryptionMethod":"Not Encrypted","CompressionMethod":"Not Compressed","CaseSensitive":"true","CasePreserved":"true","MaxFileNameLength":"255","FileSystemType":"ext4","PersistenceType":"2","NumberOfFiles":"420291","IsOnline":"true","TotalInodes":"8224768","FreeInodes":"7804477"},{"ClassName":"SCX_FileSystem","Caption":"File system information","Description":"Information about a logical unit of secondary storage","Name":"\/boot","CSCreationClassName":"SCX_ComputerSystem","CSName":"vimish-ubu-01.scx.com","CreationClassName":"SCX_FileSystem","Root":"\/boot","BlockSize":"1024","FileSystemSize":"494512128","AvailableSpace":"18881536","ReadOnly":"false","EncryptionMethod":"Not Encrypted","CompressionMethod":"Not Compressed","CaseSensitive":"true","CasePreserved":"true","MaxFileNameLength":"255","FileSystemType":"ext2","PersistenceType":"2","NumberOfFiles":"347","IsOnline":"true","TotalInodes":"124928","FreeInodes":"124581"}]'
+  
+    @mock.omi_result['SCX_IPProtocolEndpoint'] = '[{"ClassName":"SCX_IPProtocolEndpoint","Caption":"IP protocol endpoint information","Description":"Properties of an IP protocol connection endpoint","ElementName":"eth0","Name":"eth0","EnabledState":"2","SystemCreationClassName":"SCX_ComputerSystem","SystemName":"vimish-ubu-01.scx.com","CreationClassName":"SCX_IPProtocolEndpoint","IPv4Address":"10.217.247.100","SubnetMask":"255.255.254.0","IPv4BroadcastAddress":"10.217.247.255"}]'
+
+    @mock.omi_result['SCX_DiskDrive'] = '[{"ClassName":"SCX_DiskDrive","Caption":"Disk drive information","Description":"Information pertaining to a physical unit of secondary storage","Name":"sda","SystemCreationClassName":"SCX_ComputerSystem","SystemName":"vimish-ubu-01.scx.com","CreationClassName":"SCX_DiskDrive","DeviceID":"sda","MaxMediaSize":"136365211648","InterfaceType":"SCSI","Manufacturer":"Msft","Model":"Virtual Disk","TotalCylinders":"16578","TotalHeads":"255","TotalSectors":"266338304"}]'
+
+  @expected_result = [{"discovery_id"=>"SystemDiscoveryID", "class_name"=>"Universal Linux Computer", "discovery_data"=>[[{"CSName"=>"vimish-ubu-01.scx.com"}, {"CurrentTimeZone"=>"-420"}]]}, {"discovery_id"=>"ProcessorDiscoveryID", "class_name"=>"Processor", "parent"=>"Universal Linux Computer", "discovery_data"=>[[{"Name"=>"0"}]]}, {"discovery_id"=>"LogicalDiskDiscoveryID", "class_name"=>"Logical Disk", "parent"=>"Universal Linux Computer", "discovery_data"=>[[{"Name"=>"/"}, {"FileSystemSize"=>"132476702720"}, {"CompressionMethod"=>"Not Compressed"}, {"FileSystemType"=>"ext4"}], [{"Name"=>"/boot"}, {"FileSystemSize"=>"494512128"}, {"CompressionMethod"=>"Not Compressed"}, {"FileSystemType"=>"ext2"}]]}, {"discovery_id"=>"NetworkAdapterDiscoveryID", "class_name"=>"Network Adapter", "parent"=>"Universal Linux Computer", "discovery_data"=>[[{"ElementName"=>"eth0"}, {"Name"=>"eth0"}, {"IPv4Address"=>"10.217.247.100"}, {"SubnetMask"=>"255.255.254.0"}]]}, {"discovery_id"=>"OperatingSystemDiscoveryID", "class_name"=>"Universal Linux Operating System", "parent"=>"Universal Linux Computer", "discovery_data"=>[[{"Caption"=>"Ubuntu 16.04 (x86_64)"}, {"Version"=>"16.04"}]]}, {"discovery_id"=>"PhysicalDiskDiscoveryID", "class_name"=>"Physical Disk", "parent"=>"Universal Linux Computer", "discovery_data"=>[[{"Name"=>"sda"}, {"MaxMediaSize"=>"136365211648"}, {"InterfaceType"=>"SCSI"}, {"TotalCylinders"=>"16578"}, {"TotalHeads"=>"255"}, {"TotalSectors"=>"266338304"}]]}]
+
+  end
+  
+end # end In_OMS_WLM_Test


### PR DESCRIPTION
1. Added an input plugin wlm_discovery for discovering computer entities.
2. Updated oms_omi plugin to generate data for wlm monitors.

PBUILD was run successfully.