### PR TITLE
Improve heartbeat diagnostic logging

### DIFF
--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -218,7 +218,7 @@ module MaintenanceModule
         log_error("Could not extract the update certificate endpoint.")
         return MISSING_CERT_UPDATE_ENDPOINT
       elsif update_attr.empty?
-        log_error("Could not find the updateCertificate tag in the heartbeat response")
+        log_error("Could not find the updateCertificate tag in the DSC AgentService heartbeat response")
         return ERROR_EXTRACTING_ATTRIBUTES
       end
 
@@ -352,10 +352,10 @@ module MaintenanceModule
         body_hb_xml = AgentTopologyRequestHandler.new.handle_request(@os_info, @omsadmin_conf_path,
             @AGENT_GUID, get_cert_server(@cert_path), @pid_path, telemetry=true)
         if !xml_contains_telemetry(body_hb_xml)
-          log_debug("No Telemetry data was appended to the heartbeat request")
+          log_debug("No Telemetry data was appended to the DSC AgentService heartbeat request")
         end
       rescue => e
-        log_error("Error when appending Telemetry to Heartbeat: #{e.message}")
+        log_error("Error when appending Telemetry to DSC AgentService Heartbeat: #{e.message}")
       end
 
       # Form headers
@@ -378,11 +378,11 @@ module MaintenanceModule
         res = nil
         res = http.start { |http_each| http.request(req) }
       rescue => e
-        log_error("Error sending the heartbeat: #{e.message}")
+        log_error("Error sending the AgentService heartbeat: #{e.message}")
       end
 
       if !res.nil?
-        log_info("Heartbeat response code: #{res.code}") if @verbose
+        log_info("DSC AgentService Heartbeat response code: #{res.code}") if @verbose
 
         if res.code == "200"
           cert_apply_res = apply_certificate_update_endpoint(res.body)
@@ -392,15 +392,15 @@ module MaintenanceModule
           elsif dsc_apply_res.class != String
             return dsc_apply_res
           else
-            log_info("Heartbeat success")
+            log_info("DSC AgentService Heartbeat success")
             return 0
           end
         else
-          log_error("Error sending the heartbeat. HTTP code #{res.code}")
+          log_error("Error sending the DSC AgentService heartbeat. HTTP code #{res.code}")
           return HTTP_NON_200
         end
       else
-        log_error("Error sending the heartbeat. No HTTP code")
+        log_error("Error sending the DSC AgentService heartbeat. No HTTP code")
         return ERROR_SENDING_HTTP
       end
     end

--- a/source/code/plugins/in_dsc_monitor.rb
+++ b/source/code/plugins/in_dsc_monitor.rb
@@ -47,7 +47,7 @@ module Fluent
         @install_status = check_install
 
         if @install_status == 1
-           router.emit(@tag, Time.now.to_f, {"message"=>"omconfig is not installed, OMS Portal \
+           router.emit(@tag, Time.now.to_f, {"message"=>"omsconfig is not installed, OMS Portal \
 configuration will not be applied and solutions such as Change Tracking and Update Assessment will \
 not function properly. omsconfig can be installed by rerunning the omsagent installation"})
         end

--- a/source/code/plugins/in_oms_heartbeat.rb
+++ b/source/code/plugins/in_oms_heartbeat.rb
@@ -8,6 +8,7 @@ module Fluent
     def initialize
       super
       require_relative 'heartbeat_lib'
+      require_relative 'oms_common'
     end
 
     config_param :interval, :time, :default => nil
@@ -45,6 +46,7 @@ module Fluent
     
       wrapper = @heartbeat_lib.enumerate(time)
       router.emit(@tag, time, wrapper) if wrapper
+      @log.info "Sending OMS Heartbeat succeeded at #{OMS::Common.format_time(time)}"
     end
 
     def run_periodic

--- a/test/code/plugins/in_dsc_monitor_plugintest.rb
+++ b/test/code/plugins/in_dsc_monitor_plugintest.rb
@@ -35,7 +35,7 @@ class DscMonitorTest < Test::Unit::TestCase
   end
 
   def test_dsc_install_failure_message
-    dsc_install_fail_message = "omconfig is not installed, OMS Portal \
+    dsc_install_fail_message = "omsconfig is not installed, OMS Portal \
 configuration will not be applied and solutions such as Change Tracking and Update Assessment will \
 not function properly. omsconfig can be installed by rerunning the omsagent installation" 
 


### PR DESCRIPTION
Previous log message "heartbeat" was too generic. It was easy to confuse heartbeat sent for OaaS (AgentService) with the heartbeat record that the agent sends to OMS. Improved
the logging to specify AgentService  for OaaS heartbeat to be specific.
@arjun-urs 