### PR TITLE
Remove default rsyslog counters

### DIFF
--- a/installer/conf/rsyslog.conf
+++ b/installer/conf/rsyslog.conf
@@ -1,18 +1,1 @@
 # OMS Syslog collection for workspace %WORKSPACE_ID%
-kern.warning              @127.0.0.1:%SYSLOG_PORT%
-user.warning              @127.0.0.1:%SYSLOG_PORT%
-daemon.warning            @127.0.0.1:%SYSLOG_PORT%
-auth.warning              @127.0.0.1:%SYSLOG_PORT%
-syslog.warning            @127.0.0.1:%SYSLOG_PORT%
-uucp.warning              @127.0.0.1:%SYSLOG_PORT%
-authpriv.warning          @127.0.0.1:%SYSLOG_PORT%
-ftp.warning               @127.0.0.1:%SYSLOG_PORT%
-cron.warning              @127.0.0.1:%SYSLOG_PORT%
-local0.warning            @127.0.0.1:%SYSLOG_PORT%
-local1.warning            @127.0.0.1:%SYSLOG_PORT%
-local2.warning            @127.0.0.1:%SYSLOG_PORT%
-local3.warning            @127.0.0.1:%SYSLOG_PORT%
-local4.warning            @127.0.0.1:%SYSLOG_PORT%
-local5.warning            @127.0.0.1:%SYSLOG_PORT%
-local6.warning            @127.0.0.1:%SYSLOG_PORT%
-local7.warning            @127.0.0.1:%SYSLOG_PORT%


### PR DESCRIPTION
Remove default rsyslog counters. Reported by Azure Security Center enabled customers.
  @arjun-urs 