### PR TITLE
Fix to manual vmResourceID using extension

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -206,6 +206,12 @@ save_config()
     chown_omsagent "$CONF_OMSADMIN"
 }
 
+update_azure_resource_id()
+{
+    sed -i "s,\(AZURE_RESOURCE_ID=\)\(.*\),\1$AZURE_RESOURCE_ID," $CONF_OMSADMIN
+    echo "Azure Resource ID updated."
+}
+
 cleanup()
 {
     rm "$BODY_ONBOARD" "$RESP_ONBOARD" "$ENDPOINT_FILE" > /dev/null 2>&1 || true
@@ -525,6 +531,8 @@ onboard()
         log_error "The Workspace ID is not valid"
         clean_exit $INVALID_CONFIG_PROVIDED
     fi
+
+    update_azure_resource_id
     
     # If a test is not in progress then call service_control to check on the workspace status 
     if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then


### PR DESCRIPTION
Added the logic to save vmResourceID when the user tries to update it manually using an Azure extension.

@NarineM 