### PR TITLE
Rename "heartbeat" in the logs for agent service

### DIFF
--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -218,7 +218,7 @@ module MaintenanceModule
         log_error("Could not extract the update certificate endpoint.")
         return MISSING_CERT_UPDATE_ENDPOINT
       elsif update_attr.empty?
-        log_error("Could not find the updateCertificate tag in the DSC AgentService heartbeat response")
+        log_error("Could not find the updateCertificate tag in OMS Agent management service telemetry response")
         return ERROR_EXTRACTING_ATTRIBUTES
       end
 
@@ -328,9 +328,9 @@ module MaintenanceModule
       return req, http
     end
 
-    # Perform a heartbeat against the OMS endpoint
+    # Perform a topology request against the OMS endpoint
     def heartbeat
-      # Reload config in case of updates since last heartbeat
+      # Reload config in case of updates since last topology request
       @load_config_return_code = load_config
       if @load_config_return_code != 0
         log_error("Error loading configuration from #{@omsadmin_conf_path}")
@@ -343,7 +343,7 @@ module MaintenanceModule
         log_error("Missing required field from configuration file: #{@omsadmin_conf_path}")
         return MISSING_CONFIG
       elsif !file_exists_nonempty(@cert_path) or !file_exists_nonempty(@key_path)
-        log_error("Certificates for heartbeat request do not exist")
+        log_error("Certificates for topology request do not exist")
         return MISSING_CERTS
       end
 
@@ -352,10 +352,10 @@ module MaintenanceModule
         body_hb_xml = AgentTopologyRequestHandler.new.handle_request(@os_info, @omsadmin_conf_path,
             @AGENT_GUID, get_cert_server(@cert_path), @pid_path, telemetry=true)
         if !xml_contains_telemetry(body_hb_xml)
-          log_debug("No Telemetry data was appended to the DSC AgentService heartbeat request")
+          log_debug("No Telemetry data was appended to OMS agent management service topology request")
         end
       rescue => e
-        log_error("Error when appending Telemetry to DSC AgentService Heartbeat: #{e.message}")
+        log_error("Error when appending Telemetry to OMS agent management service topology request: #{e.message}")
       end
 
       # Form headers
@@ -371,18 +371,18 @@ module MaintenanceModule
                 OpenSSL::X509::Certificate.new(File.open(@cert_path)),
                 OpenSSL::PKey::RSA.new(File.open(@key_path)))
 
-      log_info("Generated heartbeat request:\n#{req.body}") if @verbose
+      log_info("Generated topology request:\n#{req.body}") if @verbose
 
       # Submit request
       begin
         res = nil
         res = http.start { |http_each| http.request(req) }
       rescue => e
-        log_error("Error sending the AgentService heartbeat: #{e.message}")
+        log_error("Error sending the topology request to OMS agent management service: #{e.message}")
       end
 
       if !res.nil?
-        log_info("DSC AgentService Heartbeat response code: #{res.code}") if @verbose
+        log_info("OMS agent management service topology request response code: #{res.code}") if @verbose
 
         if res.code == "200"
           cert_apply_res = apply_certificate_update_endpoint(res.body)
@@ -392,15 +392,15 @@ module MaintenanceModule
           elsif dsc_apply_res.class != String
             return dsc_apply_res
           else
-            log_info("DSC AgentService Heartbeat success")
+            log_info("OMS agent management service topology request success")
             return 0
           end
         else
-          log_error("Error sending the DSC AgentService heartbeat. HTTP code #{res.code}")
+          log_error("Error sending OMS agent management service topology request . HTTP code #{res.code}")
           return HTTP_NON_200
         end
       else
-        log_error("Error sending the DSC AgentService heartbeat. No HTTP code")
+        log_error("Error sending OMS agent management service topology request . No HTTP code")
         return ERROR_SENDING_HTTP
       end
     end


### PR DESCRIPTION
Rename heartbeat in the logs for agent service to be OMS topology request

@KrisBash , hi Kris can you take a look at this change and let me know if this wording fits the purpose better? 