### PR TITLE
Updating logging to provide better error message during Meta config creation

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -723,6 +723,11 @@ onboard()
                 echo "*/15 * * * * $AGENT_USER /opt/omi/bin/OMSConsistencyInvoker >/dev/null 2>&1" > /etc/cron.d/OMSConsistencyInvoker
             fi
 
+            if [ ! -f $METACONFIG_PY ]; then
+                log_error "MetaConfig generation script not available at $METACONFIG_PY"
+                return $ERROR_METACONFIG_PY_NOT_PRESENT
+            fi
+
             if [ "$USER_ID" -eq "0" ]; then
                 su - $AGENT_USER -c $METACONFIG_PY > /dev/null || error=$?
             else
@@ -731,11 +736,8 @@ onboard()
     
             if [ $error -eq 0 ]; then
                 log_info "Configured omsconfig"
-            elif [ ! -f $METACONFIG_PY ]; then
-                log_error "MetaConfig generation script not available at $METACONFIG_PY"
-                return $ERROR_METACONFIG_PY_NOT_PRESENT
             else
-                log_error "Error configuring omsconfig"
+                log_error "Error configuring omsconfig. Error: $error"
                 return $ERROR_GENERATING_METACONFIG
             fi
         fi


### PR DESCRIPTION
- Updating one of the error logs during meta config creation to print the actual error code.
- Moving the check for the existence of the metaconfig.py file to happen before we call the metaconfig.py file