### PR TITLE
Sending File Hashes in Change Snapshot

### DIFF
--- a/source/code/plugins/changetracking_lib.rb
+++ b/source/code/plugins/changetracking_lib.rb
@@ -64,6 +64,7 @@ class ChangeTracking
     def self.fileInventoryXMLtoHash(fileInventoryXML, isInventorySnapshot = false)
         fileInventoryHash = instanceXMLtoHash(fileInventoryXML)
         ret = {}
+        ret["FileContentChecksum"] = fileInventoryHash["Checksum"]
         ret["FileSystemPath"] = fileInventoryHash["DestinationPath"]
         ret["CollectionName"] = fileInventoryHash["DestinationPath"]
         ret["Size"] = fileInventoryHash["FileSize"]

--- a/test/code/plugins/filter_changetracking_test.rb
+++ b/test/code/plugins/filter_changetracking_test.rb
@@ -234,6 +234,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
  "Contents"=>"",
  "DateCreated"=>"2016-08-20T21:12:22.000Z",
  "DateModified"=>"2016-08-20T21:12:22.000Z",
+ "FileContentChecksum"=>"1471727542",
  "FileSystemPath"=>"/etc/yum.conf",
  "Group"=>"root",
  "InventoryChecksum"=>
@@ -366,6 +367,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
        "DateCreated"=>"2016-08-20T21:12:22.000Z",
        "DateModified"=>"2016-08-20T21:12:22.000Z",
        "FileContentBlobLink"=>" ",
+       "FileContentChecksum"=>"1471727542",
        "FileSystemPath"=>"/etc/yum.conf",
        "Group"=>"root",
        "IsInventorySnapshot"=>false,
@@ -376,6 +378,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
        "Contents"=>"",
        "DateCreated"=>"2016-08-20T21:12:22.000Z",
        "DateModified"=>"2016-08-20T21:12:22.000Z",
+       "FileContentChecksum"=>"1471727542",
        "FileSystemPath"=>"/etc/yum1.conf",
        "Group"=>"root",
        "IsInventorySnapshot"=>false,


### PR DESCRIPTION
The checksum is already generated by the nxFileInventory resource. This change only uses that Checksum and propagates it to Log Search.