### PR TITLE
Don't upload the files which are greater than specified size.

### DIFF
--- a/source/code/plugins/changetracking_lib.rb
+++ b/source/code/plugins/changetracking_lib.rb
@@ -71,7 +71,7 @@ class ChangeTracking
         ret["Owner"] = fileInventoryHash["Owner"]
         ret["Group"] = fileInventoryHash["Group"]
         ret["Mode"] = fileInventoryHash["Mode"]
-        ret["ContentLength"] = fileInventoryHash["ContentLength"]
+        ret["ContentLength"] = fileInventoryHash["Contents"]
         ret["DateModified"] = OMS::Common.format_time_str(fileInventoryHash["ModifiedDate"])
         ret["DateCreated"] = OMS::Common.format_time_str(fileInventoryHash["CreatedDate"])
 

--- a/source/code/plugins/changetracking_lib.rb
+++ b/source/code/plugins/changetracking_lib.rb
@@ -71,7 +71,7 @@ class ChangeTracking
         ret["Owner"] = fileInventoryHash["Owner"]
         ret["Group"] = fileInventoryHash["Group"]
         ret["Mode"] = fileInventoryHash["Mode"]
-        ret["Contents"] = fileInventoryHash["Contents"]
+        ret["ContentLength"] = fileInventoryHash["ContentLength"]
         ret["DateModified"] = OMS::Common.format_time_str(fileInventoryHash["ModifiedDate"])
         ret["DateCreated"] = OMS::Common.format_time_str(fileInventoryHash["CreatedDate"])
 

--- a/source/code/plugins/out_oms_changetracking_file.rb
+++ b/source/code/plugins/out_oms_changetracking_file.rb
@@ -306,11 +306,15 @@ module Fluent
                 if !@@ContentlocationUri.nil? and !@@ContentlocationUri.empty? and !collection.empty?
                    key = collection["CollectionName"]
                    date = collection["DateModified"]
-                   fileName = date + '-' + File.basename(key)
-                   uri = @@ContentlocationUri + '/' + OMS::Common.get_hostname + '/' + OMS::Configuration.agent_id + '/' + fileName
-                   if collection["FileContentBlobLink"] == " " or (@@LastContentLocationUri.eql?(@@ContentlocationUri) == false)
-                      modifiedcollections[key] = uri
-                   end
+		   contentLength = collection["ContentLength"].to_i
+		   fileSize = collection["Size"].to_i
+		   if contentLength != "0" and contentLength >= fileSize
+                      fileName = date + '-' + File.basename(key)
+                      uri = @@ContentlocationUri + '/' + OMS::Common.get_hostname + '/' + OMS::Configuration.agent_id + '/' + fileName
+                      if collection["FileContentBlobLink"] == " " or (@@LastContentLocationUri.eql?(@@ContentlocationUri) == false)
+                         modifiedcollections[key] = uri
+                      end
+		   end
                 end
              }
           @@LastContentLocationUri = @@ContentlocationUri

--- a/test/code/plugins/filter_changetracking_test.rb
+++ b/test/code/plugins/filter_changetracking_test.rb
@@ -231,7 +231,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
     }
 
  expectedHash = {"CollectionName"=>"/etc/yum.conf",
- "Contents"=>"",
+ "ContentLength"=>"",
  "DateCreated"=>"2016-08-20T21:12:22.000Z",
  "DateModified"=>"2016-08-20T21:12:22.000Z",
  "FileContentChecksum"=>"1471727542",
@@ -316,7 +316,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
     expectedHash = {"DataItems"=>
     [{"Collections"=>
        [{"CollectionName"=>"/etc/yum.conf",
-         "Contents"=>"",
+         "ContentLength"=>"",
          "DateCreated"=>"2016-08-20T21:12:22.000Z",
          "DateModified"=>"2016-08-20T21:12:22.000Z",
          "FileSystemPath"=>"/etc/yum.conf",
@@ -326,7 +326,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
          "Owner"=>"root",
          "Size"=>"835"},
        {"CollectionName"=>"/etc/yum1.conf",
-         "Contents"=>"",
+         "ContentLength"=>"",
          "DateCreated"=>"2016-08-20T21:12:22.000Z",
          "DateModified"=>"2016-08-20T21:12:22.000Z",
          "FileSystemPath"=>"/etc/yum1.conf",
@@ -363,7 +363,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
     expectedHash = {"DataItems"=>
   [{"Collections"=>
      [{"CollectionName"=>"/etc/yum.conf",
-       "Contents"=>"",
+       "ContentLength"=>"",
        "DateCreated"=>"2016-08-20T21:12:22.000Z",
        "DateModified"=>"2016-08-20T21:12:22.000Z",
        "FileContentBlobLink"=>" ",
@@ -375,7 +375,7 @@ class ChangeTrackingTest < Test::Unit::TestCase
        "Owner"=>"root",
        "Size"=>"835"},
       {"CollectionName"=>"/etc/yum1.conf",
-       "Contents"=>"",
+       "ContentLength"=>"",
        "DateCreated"=>"2016-08-20T21:12:22.000Z",
        "DateModified"=>"2016-08-20T21:12:22.000Z",
        "FileContentChecksum"=>"1471727542",


### PR DESCRIPTION
This checkin, allows file upload to be controlled by settings from AMS.
The files below the specified file size will be uploaded. The specified file size will now come through 'ContentLength' in the change records returned by the resource.