### PR TITLE
Add error trapping for non-dpkg and non-rpm systems

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -62,6 +62,7 @@ USE_UPGRADE=23
 INTERNAL_ERROR=30
 # Package pre-requisites fail
 UNSUPPORTED_OPENSSL=60
+UNSUPPORTED_PACKAGE=51
 INSTALL_PYTHON_CTYPES=61
 INSTALL_TAR=62
 INSTALL_SED=63
@@ -254,7 +255,14 @@ ulinux_detect_installer()
     if [ $? -eq 0 ]; then
         INSTALLER=DPKG
     else
+      check_if_program_in_path rpm
+      if [ $? -eq 0 ]; then
         INSTALLER=RPM
+      else
+        echo "Error: This system does not have supported package manager"
+        echo "Supported Sytems: 'deb' & 'rpm'"
+        cleanup_and_exit $UNSUPPORTED_PACKAGE
+      fi
     fi
 }
 
@@ -411,11 +419,11 @@ compare_arch()
     #check if the user is trying to install the correct bundle (x64 vs. x86)
     echo "Checking host architecture ..."
     HOST_ARCH=$(get_arch)
-    
+
     case $OMS_PKG in
-        *"$HOST_ARCH") 
+        *"$HOST_ARCH")
             ;;
-        *)         
+        *)
             echo "Cannot install $OMS_PKG on ${HOST_ARCH} platform"
             cleanup_and_exit $INVALID_PACKAGE_ARCH
             ;;
@@ -423,8 +431,8 @@ compare_arch()
 }
 
 compare_install_type()
-{   
-    # If the bundle has an INSTALL_TYPE, check if the bundle being installed 
+{
+    # If the bundle has an INSTALL_TYPE, check if the bundle being installed
     # matches the installer on the machine (rpm vs.dpkg)
     if [ ! -z "$INSTALL_TYPE" ]; then
         if [ $INSTALLER != $INSTALL_TYPE ]; then
@@ -437,8 +445,8 @@ compare_install_type()
 python_ctypes_installed()
 {
     # Check for Python ctypes library (required for omsconfig)
-    hasCtypes=1    
-	
+    hasCtypes=1
+
     # Attempt to run python with the single import command
     python -c "import ctypes" > /dev/null 2>&1
     [ $? -eq 0 ] && hasCtypes=0
@@ -975,7 +983,7 @@ if [ -n "${checkVersionAndCleanUp}" ]; then
 
     # omsconfig
     versionInstalled=`getInstalledVersion omsconfig`
-    versionAvailable=`getVersionNumber $DSC_PKG omsconfig-`    
+    versionAvailable=`getVersionNumber $DSC_PKG omsconfig-`
     if shouldInstall_omsconfig; then shouldInstall="Yes"; else shouldInstall="No"; fi
     printf '%-15s%-15s%-15s%-15s\n' omsconfig $versionInstalled $versionAvailable "$shouldInstall"
 


### PR DESCRIPTION
Error message for Non-DPKG and Non-RPM based systems with Exit Code '51'