### PR TITLE
ChangeTracking hotfix: Fixing the log statements

### DIFF
--- a/source/code/plugins/changetracking_lib.rb
+++ b/source/code/plugins/changetracking_lib.rb
@@ -216,7 +216,6 @@ class ChangeTracking
 
     def self.wrap (inventory_hash, host, time)
         timestamp = OMS::Common.format_time(time)
-        OMS::Log.info_once("The keys in inventory_hash - #{inventory_hash.keys}")
         wrapper = {
                     "DataType"=>"CONFIG_CHANGE_BLOB",
                     "IPName"=>"changetracking",
@@ -256,9 +255,6 @@ class ChangeTracking
         if wrapper["DataItems"].size == 1
             return wrapper
         elsif wrapper["DataItems"].size > 1
-            OMS::Log.warn_once("Multiple change types found. Incorrect inventory xml generated.\n 
-                        The inventory XML should only have one change type, but this XML had -
-                        #{inventory_hash.keys}")
             return {} # Returning null.
         else
             return {} # Returning null.
@@ -268,7 +264,6 @@ class ChangeTracking
     def self.getHash(file_path)
             ret = {}
             if File.exist?(file_path) # If file exists
-                OMS::Log.info_once("Found the file {file_path}. Fetching the Hash")
                 File.open(file_path, "r") do |f| # Open file
                         f.each_line do |line|
                         line.split(/\r?\n/).reject{ |l|
@@ -280,7 +275,6 @@ class ChangeTracking
                 end
                 return ret
             else
-                OMS::Log.warn_once("Could not find the file #{file_path}")
                 return nil
             end
     end
@@ -311,8 +305,7 @@ class ChangeTracking
     end
 
     def self.transform_and_wrap(inventoryFile, inventoryHashFile, inventoryTimestampFile)
-        if File.exist?(inventoryFile)                       
-            OMS::Log.info_once("Found the change tracking inventory file.")
+        if File.exist?(inventoryFile)
             # Get the parameters ready.
             time = Time.now
             force_send_run_interval_hours = 10
@@ -346,8 +339,7 @@ class ChangeTracking
                 if !previousSnapshot.nil?
                   previous_inventory_checksum = JSON.parse(previousSnapshot[PREV_HASH])
                 end
-            rescue 
-                OMS::Log.warn_once("Error parsing previous hash file")
+            rescue
                 previousSnapshot = nil
             end
 
@@ -366,7 +358,6 @@ class ChangeTracking
                return {}
             end
         else
-            OMS::Log.warn_once("The ChangeTracking inventory xml file does not exists")
             return {}
         end 
     end


### PR DESCRIPTION
Removing the OMS::Log statements to mitigate the ongoing CT issue.