### PR TITLE
Remove dependency of omsagent packages on curl package

### DIFF
--- a/installer/datafiles/linux_dpkg.data
+++ b/installer/datafiles/linux_dpkg.data
@@ -3,8 +3,5 @@ PERFORMING_UPGRADE_NOT: '[ "$1" != "upgrade" -a "$1" != "purge" ]'
 PACKAGE_TYPE: 'DPKG'
 
 %Dependencies
-%% In omsadmin.sh: 'curl' requires 'curl'
-curl
-
 omi (>= 1.3.0.2)
 scx (>= 1.6.3.212)

--- a/installer/datafiles/linux_rpm.data
+++ b/installer/datafiles/linux_rpm.data
@@ -4,9 +4,6 @@ PACKAGE_TYPE: 'RPM'
 SEPKG_DIR_OMSAGENT: '/usr/share/selinux/packages/omsagent-logrotate'
 
 %Dependencies
-%% In omsadmin.sh: 'curl' requires 'curl',
-curl
-
 omi >= 1.3.0-2
 scx >= 1.6.3-212
 


### PR DESCRIPTION
This is being done to improve SLAs. OMS agent shell bundle anyway checks if curl package is installed or not in the system, if not it tries to install and if failed, error 64 is thrown. So this package dependency is not required. 
We have been seeing errors in installation of omsagent package (17) after last release (1.6.0-42) which were mainly due to some kind of failure in resolving/configuring dependency on curl package by package manager. RCA could not be done as there was no repro.