### PR TITLE
Remove support for openssl 0.9.8

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -40,8 +40,8 @@ SEPOLICY_DIR_EL6=$(INTERMEDIATE_DIR)/selinux.el6
 
 ifeq ($(ULINUX),1)
 # Doesn't matter what version of SSL/Ruby we use to compile or link the OMI plugin
-RUBY_DEST_DIR := $(INTERMEDIATE_DIR)/098/ruby
-OMI_LIBRARY_DIR := $(OMI_ROOT)/output_openssl_0.9.8/lib
+RUBY_DEST_DIR := $(INTERMEDIATE_DIR)/100/ruby
+OMI_LIBRARY_DIR := $(OMI_ROOT)/output_openssl_1.0.0/lib
 else
 RUBY_DEST_DIR := $(INTERMEDIATE_DIR)/ruby
 OMI_LIBRARY_DIR := $(OMI_ROOT)/output/lib
@@ -200,9 +200,6 @@ ifeq ($(ULINUX),1)
 	@$(ECHO) "========================= Performing Building DSC Project"
 	cd $(DSC_DIR); ./configure --oms
 	ln -fs $(OMI_ROOT) $(DSC_DIR)/omi-1.0.8
-	cd $(OMI_ROOT); $(RMDIR) output; ln -s output_openssl_0.9.8 output
-	$(MAKE) -C $(DSC_DIR) dsc098
-	$(MAKE) -C $(DSC_DIR) dsckit098
 	cd $(OMI_ROOT); $(RMDIR) output; ln -s output_openssl_1.0.0 output
 	$(MAKE) -C $(DSC_DIR) dsc100
 	$(MAKE) -C $(DSC_DIR) dsckit100
@@ -266,8 +263,6 @@ $(RUBY_DEST_DIR) :
 	# Warning: This step will clean out checked out files from both Ruby and fluentd directories
 	#
 ifeq ($(ULINUX),1)
-	@$(ECHO) "========================= Performing Building Ruby for SSL v0.9.8 ..."
-	$(BASE_DIR)/build/buildRuby.sh 098
 	@$(ECHO) "========================= Performing Building Ruby for SSL v1.0.0 ..."
 	$(BASE_DIR)/build/buildRuby.sh 100
 ifeq ($(PF_ARCH),x64)
@@ -348,18 +343,13 @@ $(TARGET_DIR)/$(OUTPUT_PACKAGE_PREFIX_DEB).sh : $(INTERMEDIATE_DIR)/$(OUTPUT_PAC
 
 ifeq ($(PF_ARCH),x64)
 $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) $(AUOMS_TARGET_DIR)/auoms-bundle-test.sh \
-	$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).deb \
 	$(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).deb \
 	$(INTERMEDIATE_DIR)/110/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/110/$(OUTPUT_PACKAGE_PREFIX).deb
 
 	@echo "========================= Performing Building .tar file"
 
 	# Gather the DSC bits that we need
-	$(RM) $(INTERMEDIATE_DIR)/098/omsconfig-*.{rpm,deb} $(INTERMEDIATE_DIR)/100/omsconfig-*.{rpm,deb} $(INTERMEDIATE_DIR)/110/omsconfig-*.{rpm,deb}
-
-	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_098.*.rpm | sort | tail -1` $(INTERMEDIATE_DIR)/098
-	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_098.*.deb | sort | tail -1` $(INTERMEDIATE_DIR)/098
-	cd $(INTERMEDIATE_DIR)/098; for f in omsconfig-*.{rpm,deb}; do SOURCE=$$f; DEST=`echo $$SOURCE | sed 's/.ssl_098././'` ; $(MV) $$SOURCE $$DEST; done
+	$(RM) $(INTERMEDIATE_DIR)/100/omsconfig-*.{rpm,deb} $(INTERMEDIATE_DIR)/110/omsconfig-*.{rpm,deb}
 
 	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_100.*.rpm | sort | tail -1` $(INTERMEDIATE_DIR)/100
 	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_100.*.deb | sort | tail -1` $(INTERMEDIATE_DIR)/100
@@ -390,7 +380,6 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	cd $(INTERMEDIATE_DIR); $(SHELL) scx-*.sh --extract
 
 	# Gather SCX packages
-	cd $(INTERMEDIATE_DIR)/scxbundle.*; $(COPY) 098/scx-*.universal.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/098
 	cd $(INTERMEDIATE_DIR)/scxbundle.*; $(COPY) 100/scx-*.universal.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/100
 	cd $(INTERMEDIATE_DIR)/scxbundle.*; $(COPY) 110/scx-*.universal.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/110
 
@@ -398,13 +387,10 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	cd $(INTERMEDIATE_DIR)/scxbundle.*; $(COPY) *.sh $(INTERMEDIATE_DIR)/oss-kits
 
 	# Gather OMI packages from omi-kits
-	cd $(OMI_KITS); $(COPY) release/omi-*.ssl_098.ulinux.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/098
 	cd $(OMI_KITS); $(COPY) release/omi-*.ssl_100.ulinux.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/100
 	cd $(OMI_KITS); $(COPY) release/omi-*.ssl_110.ulinux.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/110
 
-	# Remove ssl_098, ssl_100 and ssl_110 from omi filenames
-	cd $(INTERMEDIATE_DIR)/098; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_098\./\./g"`
-	cd $(INTERMEDIATE_DIR)/098; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_098\./\./g"`
+	# Remove ssl_100 and ssl_110 from omi filenames
 	cd $(INTERMEDIATE_DIR)/100; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_100\./\./g"`
 	cd $(INTERMEDIATE_DIR)/100; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_100\./\./g"`
 	cd $(INTERMEDIATE_DIR)/110; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_110\./\./g"`
@@ -413,37 +399,32 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	chmod +x $(INTERMEDIATE_DIR)/bundles/*.sh
 
 	# Build the tar file containing both .rpm and .deb packages
-	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 098/*.{deb,rpm} 100/*.{deb,rpm} 110/*.{deb,rpm} oss-kits/* bundles/*
+	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 100/*.{deb,rpm} 110/*.{deb,rpm} oss-kits/* bundles/*
 
 $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX_RPM).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) \
-	$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/110/$(OUTPUT_PACKAGE_PREFIX).rpm 
+	$(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/110/$(OUTPUT_PACKAGE_PREFIX).rpm 
 
 	@echo "========================= Performing Building RPM .tar file"
 
 	# Build the tar file containing .rpm packages
-	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_RPM).tar 098/*.rpm 100/*.rpm 110/*.rpm oss-kits/*
+	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_RPM).tar 100/*.rpm 110/*.rpm oss-kits/*
 
 $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX_DEB).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) \
-	$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).deb $(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).deb $(INTERMEDIATE_DIR)/110/$(OUTPUT_PACKAGE_PREFIX).deb
+	$(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).deb $(INTERMEDIATE_DIR)/110/$(OUTPUT_PACKAGE_PREFIX).deb
 
 	@echo "========================= Performing Building DEB .tar file"
 
 	# Build the tar file containing .deb packages
-	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_DEB).tar 098/*.deb 100/*.deb 110/*.deb oss-kits/*
+	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_DEB).tar 100/*.deb 110/*.deb oss-kits/*
 
 else
 $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) $(AUOMS_TARGET_DIR)/auoms-bundle-test.sh \
-	$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).deb \
 	$(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).deb
 
 	@echo "========================= Performing Building .tar file"
 
 	# Gather the DSC bits that we need
-	$(RM) $(INTERMEDIATE_DIR)/098/omsconfig-*.{rpm,deb} $(INTERMEDIATE_DIR)/100/omsconfig-*.{rpm,deb}
-
-	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_098.*.rpm | sort | tail -1` $(INTERMEDIATE_DIR)/098
-	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_098.*.deb | sort | tail -1` $(INTERMEDIATE_DIR)/098
-	cd $(INTERMEDIATE_DIR)/098; for f in omsconfig-*.{rpm,deb}; do SOURCE=$$f; DEST=`echo $$SOURCE | sed 's/.ssl_098././'` ; $(MV) $$SOURCE $$DEST; done
+	$(RM) $(INTERMEDIATE_DIR)/100/omsconfig-*.{rpm,deb}
 
 	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_100.*.rpm | sort | tail -1` $(INTERMEDIATE_DIR)/100
 	cd $(DSC_DIR)/release; $(COPY) `ls omsconfig-*.ssl_100.*.deb | sort | tail -1` $(INTERMEDIATE_DIR)/100
@@ -470,100 +451,39 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	cd $(INTERMEDIATE_DIR); $(SHELL) scx-*.sh --extract
 
 	# Gather SCX packages
-	cd $(INTERMEDIATE_DIR)/scxbundle.*; $(COPY) 098/scx-*.universal.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/098
 	cd $(INTERMEDIATE_DIR)/scxbundle.*; $(COPY) 100/scx-*.universal.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/100
 
 	# Gather apache and mysql cimprov bundle scripts from SCX
 	cd $(INTERMEDIATE_DIR)/scxbundle.*; $(COPY) *.sh $(INTERMEDIATE_DIR)/oss-kits
 
 	# Gather OMI packages from omi-kits
-	cd $(OMI_KITS); $(COPY) release/omi-*.ssl_098.ulinux.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/098
 	cd $(OMI_KITS); $(COPY) release/omi-*.ssl_100.ulinux.$(PF_ARCH).{deb,rpm} $(INTERMEDIATE_DIR)/100
 
-	# Remove ssl_098, ssl_100 from omi filenames
-	cd $(INTERMEDIATE_DIR)/098; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_098\./\./g"`
-	cd $(INTERMEDIATE_DIR)/098; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_098\./\./g"`
+	# Remove ssl_100 from omi filenames
 	cd $(INTERMEDIATE_DIR)/100; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_100\./\./g"`
 	cd $(INTERMEDIATE_DIR)/100; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_100\./\./g"`
 
 	chmod +x $(INTERMEDIATE_DIR)/bundles/*.sh
 
 	# Build the tar file containing both .rpm and .deb packages
-	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 098/*.{deb,rpm} 100/*.{deb,rpm} oss-kits/* bundles/*
+	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 100/*.{deb,rpm} oss-kits/* bundles/*
 
 $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX_RPM).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) \
-	$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).rpm 
+	$(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).rpm 
 
 	@echo "========================= Performing Building RPM .tar file"
 
 	# Build the tar file containing .rpm packages
-	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_RPM).tar 098/*.rpm 100/*.rpm oss-kits/*
+	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_RPM).tar 100/*.rpm oss-kits/*
 
 $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX_DEB).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS_LIB) \
-	$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).deb $(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).deb
+	$(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).deb
 
 	@echo "========================= Performing Building DEB .tar file"
 
 	# Build the tar file containing .deb packages
-	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_DEB).tar 098/*.deb 100/*.deb oss-kits/*
+	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX_DEB).tar 100/*.deb oss-kits/*
 endif
-
-$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).rpm:
-	@echo "========================= Performing Building RPM package (SSL 0.9.8)"
-	$(MKPATH) $(INSTALLER_TMPDIR)
-	$(MKPATH) $(INTERMEDIATE_DIR)/098
-
-	sudo $(RMDIR) $(STAGING_DIR)
-	python $(PAL_DIR)/installer/InstallBuilder/installbuilder.py \
-		--BASE_DIR=$(BASE_DIR) \
-		--TARGET_DIR=$(INTERMEDIATE_DIR) \
-		--INTERMEDIATE_DIR=$(INSTALLER_TMPDIR) \
-		--STAGING_DIR=$(STAGING_DIR) \
-		--BUILD_TYPE=$(BUILD_TYPE) \
-		--BUILD_CONFIGURATION=$(BUILD_CONFIGURATION) \
-		--RUBY_INT=intermediate/$(BUILD_CONFIGURATION)/098/ruby \
-		--RUBY_ARCH=$(RUBY_ARCH) \
-		--RUBY_ARCM=$(RUBY_ARCM) \
-		--PFARCH=$(PF_ARCH) \
-		--PFDISTRO=$(PF_DISTRO) \
-		--PFMAJOR=$(PF_MAJOR) \
-		--PFMINOR=$(PF_MINOR) \
-		--VERSION=$(OMS_BUILDVERSION_MAJOR).$(OMS_BUILDVERSION_MINOR).$(OMS_BUILDVERSION_PATCH) \
-		--RELEASE=$(OMS_BUILDVERSION_BUILDNR) \
-		--VERSION_IDENT="$(OMS_BUILDVERSION_DATE) $(OMS_BUILDVERSION_STATUS)" \
-		--DATAFILE_PATH=$(BASE_DIR)/installer/datafiles \
-		--OUTPUTFILE=$(OUTPUT_PACKAGE_PREFIX) \
-		$(INSTALLER_DATAFILES_RPM)
-	mv $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).rpm $(INTERMEDIATE_DIR)/098
-
-$(INTERMEDIATE_DIR)/098/$(OUTPUT_PACKAGE_PREFIX).deb:
-	@echo "========================= Performing Building DEB package (SSL 0.9.8)"
-	$(MKPATH) $(INSTALLER_TMPDIR)
-	$(MKPATH) $(INTERMEDIATE_DIR)/098
-
-	sudo $(RMDIR) $(STAGING_DIR)
-	python $(PAL_DIR)/installer/InstallBuilder/installbuilder.py \
-		--BASE_DIR=$(BASE_DIR) \
-		--TARGET_DIR=$(INTERMEDIATE_DIR) \
-		--INTERMEDIATE_DIR=$(INSTALLER_TMPDIR) \
-		--STAGING_DIR=$(STAGING_DIR) \
-		--BUILD_TYPE=$(BUILD_TYPE) \
-		--BUILD_CONFIGURATION=$(BUILD_CONFIGURATION) \
-		--RUBY_INT=intermediate/$(BUILD_CONFIGURATION)/098/ruby \
-		--RUBY_ARCH=$(RUBY_ARCH) \
-		--RUBY_ARCM=$(RUBY_ARCM) \
-		--PFARCH=$(PF_ARCH) \
-		--PFDISTRO=$(PF_DISTRO) \
-		--PFMAJOR=$(PF_MAJOR) \
-		--PFMINOR=$(PF_MINOR) \
-		--VERSION=$(OMS_BUILDVERSION_MAJOR).$(OMS_BUILDVERSION_MINOR).$(OMS_BUILDVERSION_PATCH) \
-		--RELEASE=$(OMS_BUILDVERSION_BUILDNR) \
-		--VERSION_IDENT="$(OMS_BUILDVERSION_DATE) $(OMS_BUILDVERSION_STATUS)" \
-		$(DPKG_LOCATION) \
-		--DATAFILE_PATH=$(BASE_DIR)/installer/datafiles \
-		--OUTPUTFILE=$(OUTPUT_PACKAGE_PREFIX) \
-		$(INSTALLER_DATAFILES_DPKG)
-	mv $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).deb $(INTERMEDIATE_DIR)/098
 
 $(INTERMEDIATE_DIR)/100/$(OUTPUT_PACKAGE_PREFIX).rpm:
 	@echo "========================= Performing Building RPM package (SSL 1.0)"

--- a/build/buildRuby.sh
+++ b/build/buildRuby.sh
@@ -8,9 +8,8 @@
 # Usage: buildRuby.sh <parameter>
 #
 #   Parameter may be one of:
-#        "110": Build for SSL v1.1.0
+#       "110": Build for SSL v1.1.0
 #       "100": Build for SSL v1.0.0
-#       "098": Build for SSL v0.9.8
 #       blank: Build for the local system
 #       test:  Build for test purposes
 #       
@@ -91,14 +90,6 @@ case $RUBY_BUILD_TYPE in
         RUNNING_FOR_TEST=1
 	;;
 
-    098)
-        INT_APPEND_DIR="/${RUBY_BUILD_TYPE}"
-        RUBY_CONFIGURE_QUALS=( "${RUBY_CONFIGURE_QUALS_098[@]}" "${RUBY_CONFIGURE_QUALS[@]}" "${RUBY_CONFIGURE_QUALS_SYSINS}" )
-
-        export LD_LIBRARY_PATH=$SSL_098_LIBPATH:$LD_LIBRARY_PATH
-        export PKG_CONFIG_PATH=${SSL_098_LIBPATH}/pkgconfig:$PKG_CONFIG_PATH
-        ;;
-
     100)
         INT_APPEND_DIR="/${RUBY_BUILD_TYPE}"
         RUBY_CONFIGURE_QUALS=( "${RUBY_CONFIGURE_QUALS_100[@]}" "${RUBY_CONFIGURE_QUALS[@]}" "${RUBY_CONFIGURE_QUALS_SYSINS}" )
@@ -120,7 +111,7 @@ case $RUBY_BUILD_TYPE in
         RUBY_CONFIGURE_QUALS=( "${RUBY_CONFIGURE_QUALS[@]}" "${RUBY_CONFIGURE_QUALS_SYSINS}" )
 
         if [ -n "$RUBY_BUILD_TYPE" ]; then
-            echo "Invalid parameter passed (${RUBY_BUILD_TYPE}): Must be test, 098, 100, 110 or blank" >& 2
+            echo "Invalid parameter passed (${RUBY_BUILD_TYPE}): Must be test, 100, 110 or blank" >& 2
             exit 1
         fi
 esac

--- a/build/configure
+++ b/build/configure
@@ -250,26 +250,26 @@ fi
 if [ $ULINUX -eq 1 ]; then
     if [ `uname -m` = "x86_64" ]; then
     # We only build openssl 1.1 for x64 bit
-        if [ ! -d /usr/local_ssl_0.9.8 -o ! -d /usr/local_ssl_1.0.0 -o ! -d /usr/local_ssl_1.1.0 ]; then
+        if [ ! -d /usr/local_ssl_1.0.0 -o ! -d /usr/local_ssl_1.1.0 ]; then
             echo "Missing /usr/local_ssl_* directories to build a ULINUX kit" >& 2
             exit 1
         fi
     else
-        if [ ! -d /usr/local_ssl_0.9.8 -o ! -d /usr/local_ssl_1.0.0 ]; then
+        if [ ! -d /usr/local_ssl_1.0.0 ]; then
             echo "Missing /usr/local_ssl_* directories to build a ULINUX kit" >& 2
             exit 1
         fi
     fi
 fi
 
-if [ $ULINUX -eq 0 -a -d /usr/local_ssl_0.9.8 -a -d /usr/local_ssl_1.0.0 ]; then
+if [ $ULINUX -eq 0 -a -d /usr/local_ssl_1.0.0 -a -d /usr/local_ssl_1.1.0 ]; then
     echo "This appears to be a ULINUX system, but you're not doing a ULINUX build." >& 2
     echo "Given that OMI makes assumptions based on these directories, there is an" >& 2
     echo "extraordinarily good chance that your build will fail. You should do a" >& 2
     echo "ULINUX build (--enable-ulinux) on this system." >& 2
     echo "" >& 2
     echo "If you really do not want a universal (ULINUX) build, then run:" >& 2
-    echo "    sudo rm -rf /usr/local_ssl_0.9.8 /usr/local_ssl_1.0.0 /usr/local_ssl_1.1.0" >& 2
+    echo "    sudo rm -rf /usr/local_ssl_1.0.0 /usr/local_ssl_1.1.0" >& 2
     echo "and then re-run configure. IMPORTANT: Only try this on a private system," >& 2
     echo "Do NOT do this on a shared system without consulting your team!" >& 2
     exit 1
@@ -437,10 +437,6 @@ sudo rm -rf ${ruby_test_directory}
 [ ! -d ~/bin ] && mkdir ~/bin
 
 if [ "$ULINUX" = "1" ]; then
-    ssl_098_dirpath=/usr/local_ssl_0.9.8
-    ruby_configure_quals_098=( --with-openssl-dir=$ssl_098_dirpath
-        \"LDFLAGS=-Wl,-rpath=/opt/omi/lib\" )
-
     ssl_100_dirpath=/usr/local_ssl_1.0.0
     ruby_configure_quals_100=( --with-openssl-dir=$ssl_100_dirpath
         \"LDFLAGS=-Wl,-rpath=/opt/omi/lib\" )
@@ -494,13 +490,10 @@ EOF
 
 if [ "$ULINUX" = "1" ]; then
     # SSL "lib" directory name can vary based on platform AND OpenSSL version ...OpenSSL 1.1 is supported only for x64 bit
-    ssl_098_libpath=`eval echo ${ssl_098_dirpath}/lib*`
     ssl_100_libpath=`eval echo ${ssl_100_dirpath}/lib*`
     if [ `uname -m` = "x86_64" ]; then
         ssl_110_libpath=`eval echo ${ssl_110_dirpath}/lib*`
     fi
-    echo "SSL_098_LIBPATH=${ssl_098_libpath}" >> config.mak
-    echo "RUBY_CONFIGURE_QUALS_098=( ${ruby_configure_quals_098[@]} )" >> config.mak
     echo "SSL_100_LIBPATH=${ssl_100_libpath}" >> config.mak
     echo "RUBY_CONFIGURE_QUALS_100=( ${ruby_configure_quals_100[@]} )" >> config.mak
     if [ `uname -m` = "x86_64" ]; then

--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -226,21 +226,18 @@ verifyPrivileges()
 ulinux_detect_openssl_version()
 {
     TMPBINDIR=
-    # the system OpenSSL version is 0.9.8.  Likewise with OPENSSL_SYSTEM_VERSION_100 or OPENSSL_SYSTEM_VERSION_110
+    # the system OpenSSL version is 1.0.0.  Likewise with OPENSSL_SYSTEM_VERSION_110
     OPENSSL_SYSTEM_VERSION_FULL=`openssl version | awk '{print $2}'`
-    OPENSSL_SYSTEM_VERSION_098=`echo $OPENSSL_SYSTEM_VERSION_FULL | grep -Eq '^0.9.8'; echo $?`
     OPENSSL_SYSTEM_VERSION_100=`echo $OPENSSL_SYSTEM_VERSION_FULL | grep -Eq '^1.0.'; echo $?`
     OPENSSL_SYSTEM_VERSION_110=`echo $OPENSSL_SYSTEM_VERSION_FULL | grep -Eq '^1.1.'; echo $?`
-    if [ $OPENSSL_SYSTEM_VERSION_098 = 0 ]; then
-        TMPBINDIR=098
-    elif [ $OPENSSL_SYSTEM_VERSION_100 = 0 ]; then
+    if [ $OPENSSL_SYSTEM_VERSION_100 = 0 ]; then
         TMPBINDIR=100
     elif [ $OPENSSL_SYSTEM_VERSION_110 = 0 ]; then
         TMPBINDIR=110
     else
         echo "Error: This system does not have a supported version of OpenSSL installed."
         echo "This system's OpenSSL version: $OPENSSL_SYSTEM_VERSION_FULL"
-        echo "Supported versions: 0.9.8*, 1.0.*, 1.1.*"
+        echo "Supported versions: 1.0.*, 1.1.*"
         cleanup_and_exit $UNSUPPORTED_OPENSSL
     fi
 }

--- a/installer/bundle/create_bundle.sh
+++ b/installer/bundle/create_bundle.sh
@@ -31,8 +31,8 @@ usage()
     echo "only on Linux, and only for universal installations. As such, package names"
     echo "are determined via directory lookups."
     echo
-    echo "Note that the \"directory\" parameter must contain \"098\" and \"100\" and \"110\""
-    echo "directories (for SSL 0.9.8 and SSL 1.0.0 and SSL 1.1.0), so that we have .rpm and .deb"
+    echo "Note that the \"directory\" parameter must contain \"100\" and \"110\""
+    echo "directories (for SSL 1.0.0 and SSL 1.1.0), so that we have .rpm and .deb"
     echo "files for each of the SSL-sensitive files."
     exit 1
 }
@@ -90,7 +90,7 @@ fi
 INTERMEDIATE_DIR=`(cd $INTERMEDIATE; pwd -P)`
 
 # Switch to one of the output directories to avoid directory prefixes
-cd $INTERMEDIATE/098
+cd $INTERMEDIATE/100
 
 OMS_PACKAGE=`ls omsagent-*.rpm | sed 's/.rpm$//' | tail -1`
 DSC_PACKAGE=`ls omsconfig-*.rpm | sed 's/.rpm$//' | tail -1`


### PR DESCRIPTION
Azure Automation DSC team has already removed the support for openssl
0.9.8. So any machines running openssl v0.9.8 will stop working.
Removing support from oms agent too.