### PR TITLE
add a lock while writing to block blob and use newer blob APIs

### DIFF
--- a/source/code/plugins/blocklock.rb
+++ b/source/code/plugins/blocklock.rb
@@ -1,0 +1,10 @@
+class BlockLock
+    @lock = Mutex.new
+    class << self
+      Mutex.instance_methods(false).each do |method|
+        define_method(method) do |&block|
+          @lock.send(method, &block)
+        end
+      end
+    end
+  end

--- a/test/code/plugins/in_npmd_server_plugintest.rb
+++ b/test/code/plugins/in_npmd_server_plugintest.rb
@@ -15,6 +15,7 @@ class Logger
     end
 end
 
+
 class NPMDServerTest < Test::Unit::TestCase
     class OMS::Diag
         @@DiagSupported = true


### PR DESCRIPTION
- add a lock so that threads don't interrupt each other while writing to block blob
- fixes for https://msecg.visualstudio.com/web/wi.aspx?pcguid=22157839-63f2-460c-a4ef-7511a1ec89a4&id=104842 and https://msecg.visualstudio.com/web/wi.aspx?pcguid=22157839-63f2-460c-a4ef-7511a1ec89a4&id=104830
- these files are duplicated within dsc plugin directory too, I will update those in another PR after verification