### PR TITLE
Fix for on prem VM

### DIFF
--- a/installer/conf/omsagent.d/wlm_baseOS.conf
+++ b/installer/conf/omsagent.d/wlm_baseOS.conf
@@ -14,6 +14,7 @@
   omi_mapping_path %CONF_DIR_WS%/wlm_vmhealth_mapping.json
   tag oms.wlm.monitor
   wlm_data_type "WLM_PERF_DATA_BLOB"
+  discovery_time_file %CONF_DIR_WS%/.discovery_time
 </source>
 
 <source>
@@ -25,6 +26,7 @@
   omi_mapping_path %CONF_DIR_WS%/wlm_vmhealth_mapping.json
   tag oms.wlm.monitor
   wlm_data_type "WLM_PERF_DATA_BLOB"
+  discovery_time_file %CONF_DIR_WS%/.discovery_time
 </source>
 
 <source>
@@ -36,6 +38,7 @@
   omi_mapping_path %CONF_DIR_WS%/wlm_vmhealth_mapping.json
   tag oms.wlm.monitor
   wlm_data_type "WLM_PERF_DATA_BLOB"
+  discovery_time_file %CONF_DIR_WS%/.discovery_time
 </source>
 
 <source>
@@ -47,6 +50,7 @@
   omi_mapping_path %CONF_DIR_WS%/wlm_vmhealth_mapping.json
   tag oms.wlm.monitor
   wlm_data_type "WLM_PERF_DATA_BLOB"
+  discovery_time_file %CONF_DIR_WS%/.discovery_time
 </source>
 
 <source>
@@ -58,4 +62,5 @@
   omi_mapping_path %CONF_DIR_WS%/wlm_vmhealth_mapping.json
   tag oms.wlm.monitor
   wlm_data_type "WLM_PERF_DATA_BLOB"
+  discovery_time_file %CONF_DIR_WS%/.discovery_time
 </source>

--- a/source/code/plugins/in_wlm_discovery.rb
+++ b/source/code/plugins/in_wlm_discovery.rb
@@ -42,29 +42,31 @@ module Fluent
     end
 
     def discover
-      omi_lib = WLM::WLMOMIDiscoveryCollector.new(@omi_mapping_path)
-      discovery_data = omi_lib.get_discovery_data()
-      wlm_formatter = WLM::WLMDataFormatter.new(@wlm_class_file)
-      discovery_data.each do |wclass|
-	if wclass["class_name"].to_s == "Universal Linux Computer"
-          wclass["discovery_data"][0]["CSName"] = OMS::Common.get_fully_qualified_domain_name
-	end
-        discovery_xml = wlm_formatter.get_discovery_xml(wclass)
-        instance = {}
-        instance["Host"] = OMS::Common.get_fully_qualified_domain_name
-        instance["OSType"] = "Linux"
-        instance["ObjectName"] = wclass["class_name"]
-        instance["EncodedDataItem"] = Base64.strict_encode64(discovery_xml)
-        wrapper = {
-          "DataType"=>"WLM_LINUX_INSTANCE_DATA_BLOB",
-          "IPName"=>"InfrastructureInsights",
-          "DataItems"=>[instance]
-        }
-        router.emit("oms.wlm.discovery", Time.now.to_f, wrapper)
-      end # each
-      update_discovery_time(Time.now.to_i)
-      $log.debug "Discovery data for #{@omi_mapping_path} generated successfully"
-      get_vm_metadata()
+      get_vm_metadata_is_success = get_vm_metadata()
+      if get-vm_metadata_is_success
+        omi_lib = WLM::WLMOMIDiscoveryCollector.new(@omi_mapping_path)
+        discovery_data = omi_lib.get_discovery_data()
+        wlm_formatter = WLM::WLMDataFormatter.new(@wlm_class_file)
+        discovery_data.each do |wclass|
+          if wclass["class_name"].to_s == "Universal Linux Computer"
+            wclass["discovery_data"][0]["CSName"] = OMS::Common.get_fully_qualified_domain_name
+          end
+          discovery_xml = wlm_formatter.get_discovery_xml(wclass)
+          instance = {}
+          instance["Host"] = OMS::Common.get_fully_qualified_domain_name
+          instance["OSType"] = "Linux"
+          instance["ObjectName"] = wclass["class_name"]
+          instance["EncodedDataItem"] = Base64.strict_encode64(discovery_xml)
+          wrapper = {
+            "DataType"=>"WLM_LINUX_INSTANCE_DATA_BLOB",
+            "IPName"=>"InfrastructureInsights",
+            "DataItems"=>[instance]
+          }
+          router.emit("oms.wlm.discovery", Time.now.to_f, wrapper)
+        end # each
+        update_discovery_time(Time.now.to_i)
+        $log.debug "Discovery data for #{@omi_mapping_path} generated successfully"
+      end 
     end # method discover
 
     def run_periodic
@@ -138,7 +140,9 @@ module Fluent
         router.emit("oms.wlm.vm.metadata", Time.now.to_f, wrapper)
       rescue => e
         $log.error "Error sending VM metadata #{e}"
+        return false
       end # begin
+      return true
     end # method get_vm_metadata
 
   end # class WLMOMIDiscovery

--- a/source/code/plugins/in_wlm_oms_omi.rb
+++ b/source/code/plugins/in_wlm_oms_omi.rb
@@ -18,6 +18,7 @@ module Fluent
     config_param :omi_mapping_path, :string, :default => "/etc/opt/microsoft/omsagent/conf/omsagent.d/wlm_monitor_mapping.json"
     config_param :wlm_data_type, :string, :default => "WLM_LINUX_PERF_DATA_BLOB"
     config_param :wlm_ip, :string, :default => "InfrastructureInsights"
+    config_param :discovery_time_file, :string 
 
     def configure (conf)
       super
@@ -49,9 +50,11 @@ module Fluent
 
     def enumerate
       wrapper = nil
-      time = Time.now.to_f
-      wrapper = @omi_lib.enumerate(time, @wlm_data_type, @wlm_ip)
-      router.emit(@tag, time, wrapper) if wrapper
+      if File.exist?(@discovery_time_file)
+        time = Time.now.to_f
+        wrapper = @omi_lib.enumerate(time, @wlm_data_type, @wlm_ip)
+        router.emit(@tag, time, wrapper) if wrapper
+      end
     end
 
     def run_periodic
@@ -72,3 +75,4 @@ module Fluent
   end # WLM_OMS_OMI_Input
 
 end # module
+


### PR DESCRIPTION
Stopped the on prem VM data from landing in MDM by doing the following: 
1.	in_wlm_discovery.rb will get VM metadata before generating discovery data.
2.	If VM metadata cannot be retrieved it won't proceed to generate discovery data (this should ensure .discovery_time is not created).
3.	in_wlm_oms_omi.rb’s enumerate method will check for existence of file and proceed only if the file is present.