### PR TITLE
Wlm: Fix for On prem VM

### DIFF
--- a/installer/conf/omsagent.d/wlm_baseOS.conf
+++ b/installer/conf/omsagent.d/wlm_baseOS.conf
@@ -1,6 +1,6 @@
 <source>
   type wlm_discovery
-  discovery_time_file %CONF_DIR_WS%/.discovery_time
+  discovery_time_file %CONF_DIR_WS%/.last_discovery_time
   omi_mapping_path %CONF_DIR_WS%/wlm_discovery_mapping.json
   wlm_class_file %CONF_DIR_WS%/universal.linux.json
 </source>
@@ -59,3 +59,8 @@
   tag oms.wlm.monitor
   wlm_data_type "WLM_PERF_DATA_BLOB"
 </source>
+
+<filter oms.wlm.monitor>
+  type wlm_oms_omi
+  discovery_time_file %CONF_DIR_WS%/.last_discovery_time
+</filter>

--- a/source/code/plugins/filter_wlm_oms_omi.rb
+++ b/source/code/plugins/filter_wlm_oms_omi.rb
@@ -1,0 +1,30 @@
+
+module Fluent
+
+  class WlmOmsOmiFilter < Filter
+
+    Plugin.register_filter('wlm_oms_omi', self)
+
+    config_param :discovery_time_file, :string
+
+    def configure(conf)
+      super
+    end
+
+    def start
+      super
+    end
+
+    def filter(tag, time, record)
+      if File.exist? (@discovery_time_file)
+        return record
+      else
+        return nil
+      end #if
+
+    end #filter
+
+  end #class
+
+end #module
+

--- a/source/code/plugins/in_wlm_discovery.rb
+++ b/source/code/plugins/in_wlm_discovery.rb
@@ -42,29 +42,31 @@ module Fluent
     end
 
     def discover
-      omi_lib = WLM::WLMOMIDiscoveryCollector.new(@omi_mapping_path)
-      discovery_data = omi_lib.get_discovery_data()
-      wlm_formatter = WLM::WLMDataFormatter.new(@wlm_class_file)
-      discovery_data.each do |wclass|
-	if wclass["class_name"].to_s == "Universal Linux Computer"
-          wclass["discovery_data"][0]["CSName"] = OMS::Common.get_fully_qualified_domain_name
-	end
-        discovery_xml = wlm_formatter.get_discovery_xml(wclass)
-        instance = {}
-        instance["Host"] = OMS::Common.get_fully_qualified_domain_name
-        instance["OSType"] = "Linux"
-        instance["ObjectName"] = wclass["class_name"]
-        instance["EncodedDataItem"] = Base64.strict_encode64(discovery_xml)
-        wrapper = {
-          "DataType"=>"WLM_LINUX_INSTANCE_DATA_BLOB",
-          "IPName"=>"InfrastructureInsights",
-          "DataItems"=>[instance]
-        }
-        router.emit("oms.wlm.discovery", Time.now.to_f, wrapper)
-      end # each
-      update_discovery_time(Time.now.to_i)
-      $log.debug "Discovery data for #{@omi_mapping_path} generated successfully"
-      get_vm_metadata()
+      is_azure_vm = get_vm_metadata()
+      if is_azure_vm
+        omi_lib = WLM::WLMOMIDiscoveryCollector.new(@omi_mapping_path)
+        discovery_data = omi_lib.get_discovery_data()
+        wlm_formatter = WLM::WLMDataFormatter.new(@wlm_class_file)
+        discovery_data.each do |wclass|
+          if wclass["class_name"].to_s == "Universal Linux Computer"
+            wclass["discovery_data"][0]["CSName"] = OMS::Common.get_fully_qualified_domain_name
+          end
+          discovery_xml = wlm_formatter.get_discovery_xml(wclass)
+          instance = {}
+          instance["Host"] = OMS::Common.get_fully_qualified_domain_name
+          instance["OSType"] = "Linux"
+          instance["ObjectName"] = wclass["class_name"]
+          instance["EncodedDataItem"] = Base64.strict_encode64(discovery_xml)
+          wrapper = {
+            "DataType"=>"WLM_LINUX_INSTANCE_DATA_BLOB",
+            "IPName"=>"InfrastructureInsights",
+            "DataItems"=>[instance]
+          }
+          router.emit("oms.wlm.discovery", Time.now.to_f, wrapper)
+        end # each
+        update_discovery_time(Time.now.to_i)
+        $log.debug "Discovery data for #{@omi_mapping_path} generated successfully"
+      end
     end # method discover
 
     def run_periodic
@@ -100,7 +102,7 @@ module Fluent
           $log.error "Error generating discovery data #{e}"
         end # begin
     end # method run_periodic
-    
+
     def update_discovery_time(time)
       begin
         time_file = File.open(@discovery_time_file, "w")
@@ -111,7 +113,7 @@ module Fluent
         time_file.close unless time_file.nil?
       end # begin
     end # method update_discovery_time
-    
+
     def get_last_discovery_time()
       begin
         last_discovery_time = File.open(@discovery_time_file, &:readline)
@@ -138,7 +140,9 @@ module Fluent
         router.emit("oms.wlm.vm.metadata", Time.now.to_f, wrapper)
       rescue => e
         $log.error "Error sending VM metadata #{e}"
+        return false
       end # begin
+      return true
     end # method get_vm_metadata
 
   end # class WLMOMIDiscovery


### PR DESCRIPTION
Stopped the on prem VM data from landing in MDM by adding a filter plugin that filters out the perf data sent by the VMs which don't emit metadata (On prem VMs).