### PR TITLE
Custom Log wildcards issue fix

### DIFF
--- a/source/code/plugins/in_sudo_tail.rb
+++ b/source/code/plugins/in_sudo_tail.rb
@@ -13,7 +13,6 @@ module Fluent
     def initialize
       super
       @command = nil
-      @paths = []
     end
 
     attr_accessor :command
@@ -99,30 +98,8 @@ module Fluent
       $log.info "#{line}" if line.start_with?('INFO')
     end
  
-    def readable_path(path)
-      if system("sudo test -r #{path}")
-        OMS::Log.info_once("Following tail of #{path}")
-        return path
-      else
-        OMS::Log.warn_once("#{path} is not readable. Cannot tail the file.")
-      end
-    end
-
     def set_system_command
-      @paths = @path.split(',').map {|path| path.strip }
-      date = Time.now
-      paths = ""
-      @paths.each { |path|
-        path = date.strftime(path)
-        if path.include?('*')
-          Dir.glob(path).select { |p|
-            paths += readable_path(p) + " "
-          }
-        else
-          paths += readable_path(path) + " "
-        end
-      }
-      @command = "sudo " << RUBY_DIR << TAILSCRIPT << paths <<  " -p #{@pos_file}"
+      @command = "sudo " << RUBY_DIR << TAILSCRIPT << @path <<  " -p #{@pos_file}"
     end
 
     def run_periodic
@@ -139,7 +116,6 @@ module Fluent
       end
       until @finished
         begin
-          sleep @run_interval
           Open3.popen3(@command) {|writeio, readio, errio, wait_thread|
             writeio.close
             while line = readio.gets
@@ -152,6 +128,7 @@ module Fluent
             
             wait_thread.value #wait until child process terminates
           }
+          sleep @run_interval
         rescue
           $log.error "sudo_tail failed to run or shutdown child proces", error => $!.to_s, :error_class => $!.class.to_s
           $log.warn_backtrace $!.backtrace

--- a/source/code/plugins/tailfilereader.rb
+++ b/source/code/plugins/tailfilereader.rb
@@ -20,8 +20,38 @@ module Tailscript
 
     attr_reader :paths
 
+    def file_exists(path)
+      if system("sudo test -f #{path}")
+        @log.info "Following tail of #{path}"
+        return path
+      else
+        @log.warn "#{path} does not exist. Cannot tail the file."
+        return nil
+      end
+    end
+
+    def expand_paths()
+      arr_paths = @paths.split(',').map {|path| path.strip }
+      date = Time.now
+      expanded_paths = []
+      arr_paths.each { |path|
+        path = date.strftime(path)
+        if path.include?('*')
+          Dir.glob(path).select { |p|
+            @log.info "Following tail of #{p}"
+            expanded_paths << p
+          }
+        else
+          file = file_exists(path)
+          expanded_paths << file unless file.nil?
+        end
+      }
+      return expanded_paths
+    end
+
     def start
-      start_watchers(@paths) unless @paths.empty?
+      paths = expand_paths()
+      start_watchers(paths) unless paths.empty?
     end
 
     def shutdown
@@ -365,7 +395,7 @@ if __FILE__ == $0
     end
   end.parse!
 
-  a = Tailscript::NewTail.new(ARGV)
+  a = Tailscript::NewTail.new(ARGV[0])
   a.start
   a.shutdown
 end

--- a/test/code/plugins/tailfilereader_test.rb
+++ b/test/code/plugins/tailfilereader_test.rb
@@ -18,14 +18,14 @@ class TailFileReaderTest < Test::Unit::TestCase
 
   def create(opt={}, file)
     $options = opt
-    Tailscript::NewTail.new(file)
+    Tailscript::NewTail.new(file.join(","))
   end
 
   def test_initialize
     file = ["#{TMP_DIR}/tail.txt"]
     File.open(file[0], "w") 
     tailreader = create({}, file)
-    assert_equal(tailreader.paths, ["#{TMP_DIR}/tail.txt"])
+    assert_equal(tailreader.paths, "#{TMP_DIR}/tail.txt")
   end
   
   def test_rotate
@@ -100,7 +100,7 @@ class TailFileReaderTest < Test::Unit::TestCase
     tailreader.start
     output = $stdout.string.split("\n")
 
-    assert_equal(tailreader.paths, files)
+    assert_equal(tailreader.paths, files.join(","))
     assert_equal(2, output.length)
     assert_equal("test 3", output[0])
     assert_equal("test c", output[1])


### PR DESCRIPTION
This will fix the issue with custom log solution where files specified with wildcard pattern do not get picked up until agent restart and sometimes do not picked up at all as files are not readable to omsagent user.

- Moving the code that lists files with given pattern to "tailfilereader.rb" as we need sudo to list them
