### PR TITLE
Update OMS_Linux_Agent_Log_Collector.md

### DIFF
--- a/tools/LogCollector/OMS_Linux_Agent_Log_Collector.md
+++ b/tools/LogCollector/OMS_Linux_Agent_Log_Collector.md
@@ -12,7 +12,7 @@
 - Untar the archive file to extract OMS Log Collector source files:
 
    ```
-   tar -xvf omslinux_agentlog.tgz
+   tar -xvzf omslinux_agentlog.tgz
    ```
 - Make sure the following files are extracted successfully:
     - omslinux_agentlog.sh


### PR DESCRIPTION
The extract command should be 'tar -xvzf omslinux_agentlog.tgz' as this is a gz file

Error with tar -xvf omslinux_agentlog.tgz

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now