### PR TITLE
Issue #883: Syslog messages are garbled due to incorrect utf-8 encoding

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -11,6 +11,7 @@ module OMS
 
   class Common
     require 'json'
+    require 'yajl'
     require 'net/http'
     require 'net/https'
     require 'time'
@@ -837,16 +838,18 @@ module OMS
       def parse_json_record_encoding(record)
         msg = nil
         begin
-          msg = JSON.dump(record)
+          msg = Yajl.dump(record)
         rescue => error 
           # failed encoding, encode to utf-8, iso-8859-1 and try again
           begin
+            OMS::Log.warn_once("Yajl.dump() failed due to encoding, will try iso-8859-1 for #{record}: #{error}")
+
             if !record["DataItems"].nil?
               record["DataItems"].each do |item|
                 item["Message"] = item["Message"].encode('utf-8', 'iso-8859-1')
               end
             end
-            msg = JSON.dump(record)
+            msg = Yajl.dump(record)
           rescue => error
             # at this point we've given up up, we don't recognize
             # the encode, so return nil and log_warning for the 

--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -501,7 +501,27 @@ module OMS
       record = "syslog record"
       parsed_record = Common.parse_json_record_encoding(record);
       assert_equal(record.to_json, parsed_record, "parse json record no encoding failed");
-      
+
+      record = {}
+      record["DataItems"] = [ {"Message" => "German: Grüß dich"} ];
+      parsed_record = Common.parse_json_record_encoding(record);
+      assert_equal("{\"DataItems\":[{\"Message\":\"German: Grüß dich\"}]}", parsed_record, "parse json record utf-8 encoding failed");
+
+      record = {}
+      record["DataItems"] = [ {"Message" => "Russian: Здравствуйте"} ];
+      parsed_record = Common.parse_json_record_encoding(record);
+      assert_equal("{\"DataItems\":[{\"Message\":\"Russian: Здравствуйте\"}]}", parsed_record, "parse json record utf-8 encoding failed");
+
+      record = {}
+      record["DataItems"] = [ {"Message" => "Greek: Καλημέρα"} ];
+      parsed_record = Common.parse_json_record_encoding(record);
+      assert_equal("{\"DataItems\":[{\"Message\":\"Greek: Καλημέρα\"}]}", parsed_record, "parse json record utf-8 encoding failed");
+
+      record = {}
+      record["DataItems"] = [ {"Message" => "Japanese: おはようございます。"} ];
+      parsed_record = Common.parse_json_record_encoding(record);
+      assert_equal("{\"DataItems\":[{\"Message\":\"Japanese: おはようございます。\"}]}", parsed_record, "parse json record utf-8 encoding failed");
+
       record = {}
       record["DataItems"] = [ {"Message" => "iPhone\xAE"} ];
       parsed_record = Common.parse_json_record_encoding(record);


### PR DESCRIPTION
the json package's dump() is not correctly handling utf-8 json strings in the particular ruby version that current OMS is shipping.