### PR TITLE
[Ignore this PR] Reduce string allocations

### DIFF
--- a/source/code/plugins/in_sudo_tail.rb
+++ b/source/code/plugins/in_sudo_tail.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: true
 require 'yajl'
 require 'fluent/input'
 require 'fluent/event'
@@ -47,7 +48,7 @@ module Fluent
       
       unless @pos_file
         raise ConfigError, "'pos_file' is required to keep track of file"
-      end 
+      end
 
       unless @tag 
         raise ConfigError, "'tag' is required on sudo tail"
@@ -56,7 +57,7 @@ module Fluent
       unless @run_interval
         raise ConfigError, "'run_interval' is required for periodic tailing"      
       end
- 
+
       @parser = Plugin.new_parser(conf['format'])
       @parser.configure(conf)
     end
@@ -99,7 +100,7 @@ module Fluent
     end
  
     def set_system_command
-      @command = "sudo " << RUBY_DIR << TAILSCRIPT << %Q{'#{@path}'} <<  " -p #{@pos_file}"
+      @command = "sudo ".dup << RUBY_DIR << TAILSCRIPT << %Q{'#{@path}'} <<  " -p #{@pos_file}"
     end
 
     def run_periodic

--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: true
 module OMS
 
   MSDockerCImprovHostnameFilePath = '/var/opt/microsoft/docker-cimprov/state/containerhostname'


### PR DESCRIPTION
Strings are the bottleneck of any app ingesting logs, this PR reduces a lot of useless string allocations.
The following numbers reflects 5 seconds of running omsagent with 1 seconds of buffer flushing interval, and 100 EPS. 

CustomLog plugins saving 440 allocations:
```
400  "Buffering oms.blob.CustomLog.CUSTOM_LOG_BLOB.customlog_CL_13a39935-8f3b-43f5-85f3-28c2d8ec4000.*" 
 /opt/microsoft/omsagent/plugin/out_oms_blob.rb:394
4  "." /opt/microsoft/omsagent/plugin/out_oms_blob.rb:320
8  "application/octet-stream" /opt/microsoft/omsagent/plugin/out_oms_blob.rb:86
8 "/" /opt/microsoft/omsagent/plugin/out_oms_blob.rb:114
4 "/" /opt/microsoft/omsagent/plugin/out_oms_blob.rb:338
8 "application/json" /opt/microsoft/omsagent/plugin/oms_common.rb:812
8  "x-ms-version" /opt/microsoft/omsagent/plugin/out_oms_blob.rb:90
```

Syslog plugins saving 3998 allocations:
```
500  "user"  /opt/microsoft/omsagent/plugin/filter_syslog.rb:53
499  "notice" /opt/microsoft/omsagent/plugin/filter_syslog.rb:53
500 "LINUX_SYSLOGS_BLOB"  /opt/microsoft/omsagent/plugin/filter_syslog.rb:65
500  "logmanagement" /opt/microsoft/omsagent/plugin/filter_syslog.rb:66
500  "" /opt/microsoft/omsagent/plugin/out_oms.rb:119
500 "DataType" /opt/microsoft/omsagent/plugin/out_oms.rb:118
500 "IPName" /opt/microsoft/omsagent/plugin/out_oms.rb:118
499  "Buffering oms.syslog.user.notice" /opt/microsoft/omsagent/plugin/out_oms.rb:98
```