### PR TITLE
40% CPU improvements of tailfilereader.rb

### DIFF
--- a/source/code/plugins/tailfilereader.rb
+++ b/source/code/plugins/tailfilereader.rb
@@ -162,6 +162,7 @@ module Tailscript
           @buffer = ''.force_encoding('ASCII-8BIT')
           @iobuf = ''.force_encoding('ASCII-8BIT')
           @lines = []
+          @SEPARATOR = -"\n"
         end
 
         attr_reader :io
@@ -177,8 +178,8 @@ module Tailscript
                   else
                     @buffer << @io.readpartial(2048, @iobuf)
                   end
-                  while line = @buffer.slice!(/.*?\n/m)
-                    @lines << line
+                  while idx = @buffer.index(@SEPARATOR)
+                    @lines << @buffer.slice!(0, idx + 1)
                   end
                   if @lines.size >= @read_lines_limit
                     # not to use too much memory in case the file is very large


### PR DESCRIPTION
Profiling shows slice()! taking 59% cpu time with 50 MB file.
Tailling was reduced from 1.25s to 0.76s.

```
Total: 1.251383

 %self      total      self      wait     child     calls  name
 59.75      0.748     0.748     0.000     0.000    74897   String#slice!
 20.12      1.248     0.252     0.000     0.996        1   Tailscript::NewTail::TailWatcher::IOHandler#on_notify
  4.07      0.051     0.051     0.000     0.000    50002   IO#write
  3.55      0.044     0.044     0.000     0.000    24898   IO#readpartial
  2.73      0.034     0.034     0.000     0.000    50002   Array#<<
  2.72      0.085     0.034     0.000     0.051       50   IO#puts
```

