### PR TITLE
Include libjemalloc.so as ruby lib dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = source/ext/fluentd
 	url = git@github.com:fluent/fluentd.git
 	ignore = dirty
+[submodule "source/ext/jemalloc"]
+	path = source/ext/jemalloc
+	url = git@github.com:jemalloc/jemalloc.git
+	branch = stable-4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,30 +17,28 @@ install:
   - git clone https://github.com/Microsoft/Build-OMS-Agent-for-Linux.git Microsoft/Build-OMS-Agent-for-Linux
   - cd Microsoft/Build-OMS-Agent-for-Linux
   # change url from ssh to https for submodules, travis-ci cannot download a submodule that isn’t on a public url
-  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules 
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
   - git submodule update --init --recursive auoms auoms-kits dsc dsc-kits omi omi-kits opsmgr-kits pal scxcore-kits
-  - git clone https://github.com/Microsoft/OMS-Agent-for-Linux.git omsagent 
-  - cd omsagent
-  # change url from ssh to https for submodules ruby and fluentd
-  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules 
-  - git submodule update --init --recursive
+  - git clone https://github.com/Microsoft/OMS-Agent-for-Linux.git omsagent
+  - git checkout master && git submodule foreach git checkout master
 
 before_script:
-  - cd ..
-  - git checkout master && git submodule foreach git checkout master
   - cd omsagent
   # PR validation during check-in will be setup in github in the settings section of our repo
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then git fetch origin refs/pull/$TRAVIS_PULL_REQUEST/head ; git checkout FETCH_HEAD; fi 
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then git fetch origin refs/pull/$TRAVIS_PULL_REQUEST/head ; git checkout FETCH_HEAD; fi
+  # change url from ssh to https for submodules ruby, fluentd and jemalloc
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - git submodule update --init --recursive
   - cd build
   # pwd: /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux/omsagent/build
   # Since 'build' is a keyword for travis-CI, change Makefile to substitute 'omsagent/build' instead of 'build'
-  - sed -i 's/(subst \/build,,$(CURDIR))/(subst omsagent\/build,omsagent,$(CURDIR))/' Makefile 
+  - sed -i 's/(subst \/build,,$(CURDIR))/(subst omsagent\/build,omsagent,$(CURDIR))/' Makefile
   # Substitue 'build' in Makefile for auoms as well
   - sed -i 's/(subst \/build,,$(CURDIR))/(subst auoms\/build,auoms,$(CURDIR))/' ../../auoms/build/Makefile
   - docker pull abenbachir/oms-centos5-x64:latest || true
 
 script:
   # System tests are not run because OMS-Agent-for-Linux-testconfig.git is a private repo
-  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; ./configure --enable-ulinux; make unittest"
-  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; make distclean; ./configure --enable-ulinux; make"
+  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; ./configure --enable-ulinux --enable-ruby-jemalloc; make unittest"
+  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; make distclean; ./configure --enable-ulinux --enable-ruby-jemalloc; make"
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -29,6 +29,7 @@ RUBY_DIR := $(BASE_DIR)/source/ext/ruby
 #      of the Ruby installed with the OMSAgent
 RUBY_VER := 2.4.0
 FLUENTD_DIR := $(BASE_DIR)/source/ext/fluentd
+JEMALLOC_DIR := $(BASE_DIR)/source/ext/jemalloc
 PLUGINS_DIR := $(BASE_DIR)/source/code/plugins
 
 INTERMEDIATE_DIR=$(BASE_DIR)/intermediate/$(BUILD_CONFIGURATION)
@@ -153,6 +154,8 @@ clean-ruby : clean
 	#
 	@echo "Cleaning fluentd source directory ..."
 	cd $(FLUENTD_DIR); git clean -dfx
+	@echo "Cleaning jemalloc source directory ..."
+	cd $(JEMALLOC_DIR); git clean -dfx
 
 clean-dsc : clean
 	-make -C $(DSC_DIR) clean
@@ -168,8 +171,10 @@ clean-auoms : clean
 distclean : clean clean-ruby clean-dsc clean-auoms
 	-$(RMDIR) $(OMI_ROOT)/output*
 
-	cd $(BASE_DIR)/source/ext/fluentd; git checkout -- lib/fluent/env.rb lib/fluent/plugin/in_exec.rb
-	cd $(BASE_DIR)/source/ext/ruby; git checkout -- ext/openssl/ossl_ssl.c ext/openssl/extconf.rb
+	# reset all submodules
+	cd $(BASE_DIR); git submodule foreach --recursive git reset --hard
+	cd $(BASE_DIR); git submodule foreach --recursive git clean -fdx
+
 	-$(RM) $(BASE_DIR)/build/Makefile.version
 	-$(RM) $(BASE_DIR)/build/config.mak
 	-$(RM) $(PAL_DIR)/build/config.mak

--- a/build/configure
+++ b/build/configure
@@ -13,6 +13,7 @@ enable_purify_server=""
 enable_omi_tools=""
 enable_omi_tools_flag=0
 opensource_distro=0
+enable_ruby_jemalloc=""
 build_type=Release
 ULINUX=0
 NOULINIX=0
@@ -171,6 +172,11 @@ do
       opensource_distro=1
     ;;
 
+    --enable-ruby-jemalloc)
+      echo "Configured Jemalloc for Ruby"
+      enable_ruby_jemalloc="--with-jemalloc"
+    ;;
+
     *)
       echo "configure: invalid option '$opt'" >& 2
       echo "Try configure --help' for more information." >& 2
@@ -200,6 +206,7 @@ OPTIONS:
     --[no]enable-ulinux         Specifies platform as ULINUX (Linux only);
                                 ULINUX is assumed on universal build systems
     --enable-open-source        Build for open source distribution
+    --enable-ruby-jemalloc      Enable building ruby with jemalloc
 
 EOF
     exit 0
@@ -426,6 +433,7 @@ ruby_configure_quals=(
     --with-out-ext=${RUBY_EXTENSIONS}
   )
 
+ruby_config_quals_jemalloc=$enable_ruby_jemalloc
 ruby_config_quals_sysins="--prefix=/opt/microsoft/omsagent/ruby"
 
 ruby_test_directory="${home_dir}/bin/omsagent_test_ruby"
@@ -488,6 +496,7 @@ PACKAGE_SUFFIX=$PKG_SUFFIX
 RUBY_CONFIGURE_QUALS=( ${ruby_configure_quals[@]} )
 RUBY_CONFIGURE_QUALS_SYSINS="$ruby_config_quals_sysins"
 RUBY_CONFIGURE_QUALS_TESTINS="$ruby_config_quals_testins"
+RUBY_CONFIGURE_QUALS_JEMALLOC="${ruby_config_quals_jemalloc}"
 RUBY_TEST_DIRECTORY="$ruby_test_directory"
 
 EOF

--- a/installer/datafiles/ruby.data
+++ b/installer/datafiles/ruby.data
@@ -5,6 +5,7 @@ RUBY_DEST:                '/opt/microsoft/omsagent/ruby'
 
 ${{RUBY_DEST}}/lib/pkgconfig/ruby-2.4.pc;                                ${{RUBY_INT}}/lib/pkgconfig/ruby-2.4.pc;                         644; root; root
 
+${{RUBY_DEST}}/lib/libjemalloc.so.2;                                     ${{RUBY_INT}}/lib/libjemalloc.so.2;                              755; root; root
 ${{RUBY_DEST}}/lib/libruby-static.a;                                     ${{RUBY_INT}}/lib/libruby-static.a;                              644; root; root
 
 ${{RUBY_DEST}}/lib/ruby/2.4.0/date.rb;                                   ${{RUBY_INT}}/lib/ruby/2.4.0/date.rb;                            644; root; root


### PR DESCRIPTION
Add jemalloc as external dependency
Building jemalloc and including libjemalloc.so into ruby lib folder
Make jemalloc as optional, in order to enable jemalloc build use: ./configure --enable-ulinux --enable-ruby-jemalloc