### PR TITLE
Added regex check and a default fix value for UUID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ before_script:
   - sed -i 's/(subst \/build,,$(CURDIR))/(subst omsagent\/build,omsagent,$(CURDIR))/' Makefile
   # Substitue 'build' in Makefile for auoms as well
   - sed -i 's/(subst \/build,,$(CURDIR))/(subst auoms\/build,auoms,$(CURDIR))/' ../../auoms/build/Makefile
-  - docker pull abenbachir/oms-centos5-x64:latest || true
+  - docker pull abenbachir/oms-centos6-x64:latest || true
 
 script:
   # System tests are not run because OMS-Agent-for-Linux-testconfig.git is a private repo
-  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; ./configure --enable-ulinux --enable-ruby-jemalloc; make unittest"
-  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; make distclean; ./configure --enable-ulinux --enable-ruby-jemalloc; make"
+  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos6-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; ./configure --enable-ulinux --enable-ruby-jemalloc; make unittest"
+  #- docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; make distclean; ./configure --enable-ulinux --enable-ruby-jemalloc; make"
 

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -276,7 +276,13 @@ module OMS
             @@LogFacility = line.sub("LOG_FACILITY=","").strip
           end
           if line =~ /UUID/
-            @@UUID = line.sub("UUID=","").strip
+            uuid_str = line.sub("UUID=","").strip
+            uuid_regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+            if uuid_str =~ uuid_regex
+              @@UUID = uuid_str
+            else
+              @@UUID = "00000000-0000-0000-0000-000000000000" 
+            end          
           end
         end
 

--- a/test/code/plugins/oms_configuration_test.rb
+++ b/test/code/plugins/oms_configuration_test.rb
@@ -25,6 +25,9 @@ module OMS
                              'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' \
                              '</LinuxAgentTopologyResponse>'
                              # truncated to relevant portion, e.g. containing queryInterval, telemetryReportInterval
+    TEST_UUID = '2cb5b6af-422c-0e4f-b43b-c388b2a55d48'
+    TEST_UUID_INVALID = '2cb5b6af-422c-0e4f-b43b-c388b2a55d482cb5b6af-422c-0e4f-b43b-c388b2a55d48'
+    TEST_UUID_ZERO = '00000000-0000-0000-0000-000000000000'
 
     # Extend class to reset class variables
     class OMS::Configuration
@@ -40,12 +43,13 @@ module OMS
       Configuration.configurationLoaded = false
       Common.OSFullName = nil
       @tmp_conf_file = Tempfile.new('oms_conf_file')
+      @tmp_invalid_conf_file = Tempfile.new('oms_invalid_conf_file')
       @tmp_cert_file = Tempfile.new('temp_cert_file')
       @tmp_key_file = Tempfile.new('temp_key_file')
     end
 
     def teardown
-      [@tmp_conf_file, @tmp_cert_file, @tmp_key_file].each { |tmpfile|
+      [@tmp_conf_file, @tmp_cert_file, @tmp_key_file, @tmp_invalid_conf_file].each { |tmpfile|
         tmpfile.unlink
       }
     end
@@ -56,9 +60,21 @@ module OMS
       "LOG_FACILITY=local0\n" \
       "CERTIFICATE_UPDATE_ENDPOINT=#{TEST_CERT_UPDATE_ENDPOINT}\n" \
       "DSC_ENDPOINT=#{TEST_DSC_ENDPOINT}\n" \
-      "OMS_ENDPOINT=#{TEST_ODS_ENDPOINT}\n"
+      "OMS_ENDPOINT=#{TEST_ODS_ENDPOINT}\n" \
+      "UUID=#{TEST_UUID}\n"
 
       File.write(@tmp_conf_file.path, conf)
+
+      #conf file with an invalid UUID
+      invalid_conf = "WORKSPACE_ID=#{TEST_WORKSPACE_ID}\n" \
+      "AGENT_GUID=#{TEST_AGENT_GUID}\n" \
+      "LOG_FACILITY=local0\n" \
+      "CERTIFICATE_UPDATE_ENDPOINT=#{TEST_CERT_UPDATE_ENDPOINT}\n" \
+      "DSC_ENDPOINT=#{TEST_DSC_ENDPOINT}\n" \
+      "OMS_ENDPOINT=#{TEST_ODS_ENDPOINT}\n" \
+      "UUID=#{TEST_UUID_INVALID}\n"
+
+      File.write(@tmp_invalid_conf_file.path, invalid_conf)
 
       # this is a fake certificate
       cert = "-----BEGIN CERTIFICATE-----\n" \
@@ -132,12 +148,22 @@ module OMS
       assert_equal(TEST_ODS_ENDPOINT, Configuration.ods_endpoint.to_s, "ODS Endpoint should be loaded")
       assert_equal(TEST_GET_BLOB_ODS_ENDPOINT, Configuration.get_blob_ods_endpoint.to_s, "GetBlob ODS Endpoint should be loaded")
       assert_equal(TEST_NOTIFY_BLOB_ODS_ENDPOINT, Configuration.notify_blob_ods_endpoint.to_s, "NotifyBlobUpload ODS Endpoint should be loaded")
+      assert_equal(TEST_UUID, Configuration.uuid, "VM UUID should be loaded")
       assert_not_equal(nil, Configuration.cert, "Certificate should be loaded")
       assert_not_equal(nil, Configuration.key, "Key should be loaded")
       assert_equal(["Azure region value is not set. This must be onpremise machine"], $log.logs, "There was an error loading the configuration")
       Configuration.set_request_intervals(TEST_TOPOLOGY_INTERVAL, TEST_TELEMETRY_INTERVAL)
       assert_equal(TEST_TOPOLOGY_INTERVAL, Configuration.topology_interval, "Incorrect topology interval parsed")
       assert_equal(TEST_TELEMETRY_INTERVAL, Configuration.telemetry_interval, "Incorrect telemetry interval parsed")
+    end
+
+    def test_invalid_uuid()
+      prepare_files
+      $log = MockLog.new
+      success = Configuration.load_configuration(@tmp_invalid_conf_file.path, @tmp_cert_file.path, @tmp_key_file.path)
+      puts $log.logs
+      assert_equal(true, success, 'Configuration should be loaded')
+      assert_equal(TEST_UUID_ZERO, Configuration.uuid, "Default VM UUID should be loaded instead of invalid one")
     end
 
     def test_load_configuration_wrong_path()


### PR DESCRIPTION
Created a regex check to the UUID string that is pulled by the omsagent from /etc/opt/microsoft/omsagent/conf/omsadmin.conf  and added a default valued UUID to provide to the omsagent in case the original string fails the regex check.