### PR TITLE
Fixed the Custom JSON solution bug

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -874,8 +874,8 @@ module OMS
         msg = nil
 
         begin
-          msg = JSON.dump(records)
-        rescue JSON::GeneratorError => error
+          msg = Yajl.dump(records)
+        rescue => error
           OMS::Log.warn_once("Unable to dump to JSON string. #{error}")
           begin
             # failed to dump, encode to utf-8, iso-8859-1 and try again
@@ -891,16 +891,12 @@ module OMS
               end
             end
 
-            msg = JSON.dump(records)
+            msg = Yajl.dump(records)
           rescue => error
             # at this point we've given up, we don't recognize the encode,
             # so return nil and log_warning for the record
             OMS::Log.warn_once("Skipping due to failed encoding for #{records}: #{error}")
           end
-        rescue => error
-          # unexpected error when dumpping the records into JSON string
-          # skip here and return nil
-          OMS::Log.warn_once("Skipping due to unexpected error for #{records}: #{error}")
         end
 
         return msg

--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -569,28 +569,42 @@ module OMS
       assert($log.logs.empty?, "No exception should be logged")
     end
     
-    def test_safe_dump_simple_hash_array_firsterror_encoding_success
+    def test_safe_dump_non_ascii_hash_array_noerror
       $log = MockLog.new
+      
+      records = [ { "ID" => 1, "Japan" => "にほん" } ];
+      json = Common.safe_dump_simple_hash_array(records);
+      assert_equal("[{\"ID\":1,\"Japan\":\"にほん\"}]", json, "parse json record utf-8 encoding failed: #{json}");
+      
+      records = [ { "ID" => 1, "China" => "中国" } ];
+      json = Common.safe_dump_simple_hash_array(records);
+      assert_equal("[{\"ID\":1,\"China\":\"中国\"}]", json, "parse json record utf-8 encoding failed: #{json}");
 
-      records = [ { "ID" => 1, "Message" => "iPhone\xAE" } ];
+      records = [ { "ID" => 1, "Morocco" => "ﺎﻠﻤﻏﺮﺑ" } ];
+      json = Common.safe_dump_simple_hash_array(records);
+      assert_equal("[{\"ID\":1,\"Morocco\":\"ﺎﻠﻤﻏﺮﺑ\"}]", json, "parse json record utf-8 encoding failed: #{json}");
+
+      records = [ { "ID" => 1, "India" => "भारत" } ];
+      json = Common.safe_dump_simple_hash_array(records);
+      assert_equal("[{\"ID\":1,\"India\":\"भारत\"}]", json, "parse json record utf-8 encoding failed: #{json}");
+
+      records = [ { "ID" => 1, "South Korea" => "대한 민국" } ];
+      json = Common.safe_dump_simple_hash_array(records);
+      assert_equal("[{\"ID\":1,\"South Korea\":\"대한 민국\"}]", json, "parse json record utf-8 encoding failed: #{json}");
+
+      records = [ { "ID" => 1, "Russia" => "Россия" } ];
+      json = Common.safe_dump_simple_hash_array(records);
+      assert_equal("[{\"ID\":1,\"Russia\":\"Россия\"}]", json, "parse json record utf-8 encoding failed: #{json}");
+
+      records = [ { "ID" => 1, "Greece" => "Καλημέρα" } ];
+      json = Common.safe_dump_simple_hash_array(records);
+      assert_equal("[{\"ID\":1,\"Greece\":\"Καλημέρα\"}]", json, "parse json record utf-8 encoding failed: #{json}");
+
+      records = [ { "ID" => 1, "Message" => "iPhone\u00AE" } ];
       json = Common.safe_dump_simple_hash_array(records);
       assert_equal("[{\"ID\":1,\"Message\":\"iPhone®\"}]", json, "parse json record utf-8 encoding failed: #{json}");
-      assert_not_equal(0, $log.logs.length, "Exception should be logged")
-      assert($log.logs[-1].include?("source sequence is illegal/malformed utf-8"), "Except error in log: '#{$log.logs}'")
-    end
-
-    def test_safe_dump_simple_hash_array_firsterror_encoding_error
-      $log = MockLog.new
-
-      json = nil
-      records = [ { "ID" => 1, "Message\xAE" => "iPhone\xAE" } ];
-      assert_nothing_raised(RuntimeError, "No RuntimeError to dump unexpected type") do
-        json = Common.safe_dump_simple_hash_array(records);
-      end
-
-      assert_not_equal(0, $log.logs.length, "Exception should be logged")
-      assert($log.logs[-1].include?("source sequence is illegal/malformed utf-8"), "Except error in log: '#{$log.logs}'")
-      assert_equal(nil, json, "Expect nil: #{json}")
+      
+      assert($log.logs.empty?, "No exception should be logged")
     end
 
     def test_get_current_timezone


### PR DESCRIPTION
1) Fixed the json dump bug caused by ASCII-8BIT to UTF-8BIT conversion error in oms_common.rb by replacing JSON by Yajl as the json library for dumping a ruby Hash object into JSON string. 
2)Added unit tests for Non ASCII character json dump using Yajl. 
3)Removed tests specific to the older JSON library