### PR TITLE
vmss fix

### DIFF
--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -147,7 +147,7 @@ module OMS
             if (imds_instance_json_compute['vmScaleSetName'].empty?)
               azure_resource_id = azure_resource_id + 'virtualMachines/' + imds_instance_json_compute['name']
             else
-              azure_resource_id = azure_resource_id + 'virtualMachineScaleSets/' + imds_instance_json_compute['vmScaleSetName'] + '/virtualMachines/' + imds_instance_json_compute['name']
+              azure_resource_id = azure_resource_id + 'virtualMachineScaleSets/' + imds_instance_json_compute['vmScaleSetName'] + '/virtualMachines/' + imds_instance_json_compute['name'].split('_')[-1]
             end
 
             return azure_resource_id


### PR DESCRIPTION
Need to parse out instance number to match the schema where {instanceId} is just the VM's instance ID. 
/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}

Below you can see the instanceId being properly parsed out
![image](https://user-images.githubusercontent.com/43051891/57113755-dd2f5000-6cfa-11e9-80e3-b004868f126f.png)
