### PR TITLE
Added more debug logging to sudo tail and tailfilereader

### DIFF
--- a/source/code/plugins/tailfilereader.rb
+++ b/source/code/plugins/tailfilereader.rb
@@ -43,6 +43,7 @@ module Tailscript
             is_file = !File.directory?(p)
             if File.readable?(p) && is_file
               @log.info "Following tail of #{p}"
+              @log.debug "The current size of the file #{p} is #{File.size(p)}"
               expanded_paths << p
             elsif !File.readable?(p)
               @log.warn "#{p} is excluded since it's unreadable or doesn't have proper permissions."
@@ -57,6 +58,7 @@ module Tailscript
           file = file_exists(path)
           if !file.nil?
             if File.readable?(path) && !File.directory?(path)
+              @log.debug "The current size of the file #{path} is #{File.size(path)}"
               expanded_paths << file 
             elsif !File.readable?(path)
               @log.warn "#{path} is excluded since it's unreadable or doesn't have proper permissions."
@@ -210,6 +212,7 @@ module Tailscript
               end
             end
 
+            @log.debug "Number of lines read from #{@io.path} : #{@lines.length}"           
             unless @lines.empty?
               if @receive_lines.call(@lines)
                 @pe.update_pos(@io.pos - @buffer.bytesize)


### PR DESCRIPTION
1) Changed the log variable in sudo_tail from $log (global) to @log (inherited) so as to allow individual plugins to set their own log severity levels in configuration files or inherit the default from input. 
2) Added a counter debug statement to keep track of the number lines being outputted from the sudo tail plugin
3) Added debug logs in tailfilereader.rb to output the file size to check if there has been any change at all in the files being tailed
4) Added debug logs in tailfilereader.rb to output the number of lines read from each of the files being tailed to confirm that the plugin is actually reading and outputting the lines to sudo tail