### PR TITLE
Pickup custom openssl version from sbin

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -6,7 +6,7 @@
 
 # This script is a skeleton bundle file for ULINUX only for project OMS.
 
-PATH=/usr/bin:/usr/sbin:/bin:/sbin
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
 umask 022
 
 # Can't use something like 'readlink -e $0' because that doesn't work everywhere


### PR DESCRIPTION
let suppose customer installed his new openssl at /usr/local_ssl_1.1.0, here is the steps to install omsagent using NON-Default openssl.

Those steps were tested with success in SLES 11 SP4 which is a deprecated disto.

```
OPENSSL_1_PATH=/usr/local_ssl_1.1.0

ln -s $OPENSSL_1_PATH/bin/openssl /sbin/openssl

ln -s $OPENSSL_1_PATH/lib/libcrypto.so.1.1 /usr/lib64/libcrypto.so.1.1

ln -s $OPENSSL_1_PATH/lib/libssl.so.1.1 /usr/lib64/libssl.so.1.1

ln -s /etc/ssl $OPENSSL_1_PATH/ssl

PATH=$OPENSSL_1_PATH/bin:$PATH sh omsagent-1.10.patched.sh --upgrade --force -w <WORSPACE_ID> -s <SECRET_KEY>
```

During my testing cert.pem didn't exist in /etc/ssl which caused omsagent to not be able to upload events. The workaround was to copie /etc/ssl/ca-bundle.pem generated from SLES12 from different machine and then it worked.
