### PR TITLE
change home directory for nxautomation user to fix permission issues

### DIFF
--- a/installer/datafiles/linux.data
+++ b/installer/datafiles/linux.data
@@ -85,12 +85,23 @@ if [ $? -ne 0 ]; then
     groupadd -r nxautomation
 fi
 
+# create the 'nxautomation' home directory directory if it does not already exist
+NXAUTOMATION_RUN_DIR=/home/nxautomation/run
+if [ ! -d "$NXAUTOMATION_RUN_DIR" ]; then
+    mkdir -p "$NXAUTOMATION_RUN_DIR"
+fi
+
 # Add the 'nxautomation' service account if it does not already exist
 egrep -q "^nxautomation:" /etc/passwd
 if [ $? -ne 0 ]; then
     echo "Creating nxautomation service account ..."
-    useradd -r -c "nxOMSAutomation" -d /var/opt/microsoft/omsagent/run -g nxautomation -s /bin/bash nxautomation
+    useradd -r -c "nxOMSAutomation" -d $NXAUTOMATION_RUN_DIR -g nxautomation -s /bin/bash nxautomation
 fi
+
+# set appropriate permissions on the nxautomation home directory
+NXAUTOMATION_HOME_DIR=/home/nxautomation
+chown -R nxautomation:omiusers $NXAUTOMATION_HOME_DIR
+chmod -R 750 $NXAUTOMATION_HOME_DIR
 
 # Ensure nxautomation is in the nxautomation group (primary), omsagent group (secondary) and omiusers group (secondary)
 /usr/sbin/usermod -g nxautomation -a -G omsagent,omiusers nxautomation 1> /dev/null 2> /dev/null


### PR DESCRIPTION
We recently made changes for the Linux Hybrid worker to set the HOME environment variable for the nxautomation user to "/home/nxautomation/run".
Now we have customers running into issues where some commands they execute do not respect the environment variable we set, but use the home directory set when creating the user, which has them run into permission issues.

To mitigate this we need to set the correct home directory when creating the user on the machine.
This PR introduces changes to:
- create the /home/nxautomation/run directory if it doesnt exist yet
- add the nxautomation user with the appropriate home directory
- change the owner and the permissions of the new home directory appropriately