### PR TITLE
[SLA] Limitation in shell bundler to return

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -1149,7 +1149,7 @@ case "$installMode" in
                 fi
 
                 echo "OMI server failed to start due to $ErrStr and exited with status $temp_status"
-                return $ErrCode
+                OMI_EXIT_STATUS=$ErrCode
              fi
 
 
@@ -1260,7 +1260,7 @@ case "$installMode" in
             fi
 
             echo "OMI server failed to start due to $ErrStr and exited with status $temp_status"
-            return $ErrCode
+            OMI_EXIT_STATUS=$ErrCode
         fi
 	
         # Install SCX


### PR DESCRIPTION
During testing it is observed that OMS bundler does not return the error code outside of a function though it works fine in shell script.