### PR TITLE
Less restrictive regex

### DIFF
--- a/installer/conf/omsagent.d/security_events.conf
+++ b/installer/conf/omsagent.d/security_events.conf
@@ -4,7 +4,7 @@
   bind 127.0.0.1
   protocol_type udp
   tag oms.security
-  format /^(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+):? ?(?:(?<host>[^: ]+) ?:?)? (?<ident>[a-zA-Z0-9_%\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?: *(?<message>.*)$/
+  format /^(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+):? ?(?:(?<host>[^: ]+) ?:?)? (?<ident>.*(?:CEF|ASA).*): *(?<message>.*)$/
 </source>
 
 <filter oms.security.**>

--- a/installer/conf/omsagent.d/security_events.conf
+++ b/installer/conf/omsagent.d/security_events.conf
@@ -4,7 +4,7 @@
   bind 127.0.0.1
   protocol_type udp
   tag oms.security
-  ^(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+):? ?(?:(?<host>[^: ]+) ?:?)? (?<ident>.*(?:CEF|%ASA).*?) *(?<message>0\|.*)$
+  format /^(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+):? ?(?:(?<host>[^: ]+) ?:?)? (?<ident>.*(?:CEF|%ASA).*?) *(?<message>0\|.*)$/
 </source>
 
 <filter oms.security.**>

--- a/installer/conf/omsagent.d/security_events.conf
+++ b/installer/conf/omsagent.d/security_events.conf
@@ -4,7 +4,7 @@
   bind 127.0.0.1
   protocol_type udp
   tag oms.security
-  format /^(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+):? ?(?:(?<host>[^: ]+) ?:?)? (?<ident>.*(?:CEF|ASA).*): *(?<message>.*)$/
+  ^(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+):? ?(?:(?<host>[^: ]+) ?:?)? (?<ident>.*(?:CEF|%ASA).*?) *(?<message>0\|.*)$
 </source>
 
 <filter oms.security.**>

--- a/source/code/plugins/filter_syslog_security.rb
+++ b/source/code/plugins/filter_syslog_security.rb
@@ -35,7 +35,7 @@ module Fluent
     def filter(tag, time, record)
       # Get the data type name (blob in ODS) from record tag
       # Only records that can be associated to a blob are processed
-      ident = record['ident']
+      ident =  OMS::Security.get_ident(record['ident'])
       data_type = OMS::Security.get_data_type(ident)
       return nil if data_type.nil?
 

--- a/source/code/plugins/security_lib.rb
+++ b/source/code/plugins/security_lib.rb
@@ -5,8 +5,8 @@ module OMS
     require_relative 'omslog'
 
     @@LOG_TYPE_MAPPING = {
-      '%ASA' => 'SECURITY_CISCO_ASA_BLOB',
-      'CEF' => 'SECURITY_CEF_BLOB'
+        '%ASA' => 'SECURITY_CISCO_ASA_BLOB',
+        'CEF' => 'SECURITY_CEF_BLOB'
     }
 
     def self.log_type_mapping
@@ -16,8 +16,8 @@ module OMS
     def self.get_data_type(ident)
       return nil if ident.nil?
 
-      return 'SECURITY_CEF_BLOB' if ident.start_with?('CEF')
-      return 'SECURITY_CISCO_ASA_BLOB' if ident.start_with?('%ASA')
+      return 'SECURITY_CEF_BLOB' if ident.include?('CEF')
+      return 'SECURITY_CISCO_ASA_BLOB' if ident.include?('%ASA')
 
       OMS::Log.warn_once("Failed to find data type for record with ident: '#{ident}'")
       nil

--- a/source/code/plugins/security_lib.rb
+++ b/source/code/plugins/security_lib.rb
@@ -5,8 +5,8 @@ module OMS
     require_relative 'omslog'
 
     @@LOG_TYPE_MAPPING = {
-        '%ASA' => 'SECURITY_CISCO_ASA_BLOB',
-        'CEF' => 'SECURITY_CEF_BLOB'
+      '%ASA' => 'SECURITY_CISCO_ASA_BLOB',
+      'CEF' => 'SECURITY_CEF_BLOB'
     }
 
     def self.log_type_mapping

--- a/source/code/plugins/security_lib.rb
+++ b/source/code/plugins/security_lib.rb
@@ -13,11 +13,17 @@ module OMS
       @@LOG_TYPE_MAPPING
     end
 
+    def self.get_ident(ident)
+      return 'CEF' if ident.include?('CEF')
+      return '%ASA' if ident.include?('%ASA')
+      return nil
+    end
+
     def self.get_data_type(ident)
       return nil if ident.nil?
 
-      return 'SECURITY_CEF_BLOB' if ident.include?('CEF')
-      return 'SECURITY_CISCO_ASA_BLOB' if ident.include?('%ASA')
+      return 'SECURITY_CEF_BLOB' if ident.start_with?('CEF')
+      return 'SECURITY_CISCO_ASA_BLOB' if ident.start_with?('%ASA')
 
       OMS::Log.warn_once("Failed to find data type for record with ident: '#{ident}'")
       nil


### PR DESCRIPTION
Users has encountered issues with regex filtering valid cef messages due to strict regular expression.
In order to provide a more tolerant regex we changed the omsagent to search the string 'CEF' (or '%ASA' in Cisco) in a larger string and extracting the identifier from it.

the new identifier from the regex will extract any string holding 'CEF' as sub string and the 'Message' will be extracted from the '0|' 

the new regex consist on the fact the a 'CEF' message will look at the following way 
[... syslog header] **CEF|0**[message...]


