### PR TITLE
Graceful shutdown: will fix data loss/duplicate (corner cases)

### DIFF
--- a/build/buildRuby.sh
+++ b/build/buildRuby.sh
@@ -192,12 +192,6 @@ if [ ! -z ${RUBY_CONFIGURE_QUALS_JEMALLOC} ]; then
         sudo make install_bin install_include install_lib
         sudo ldconfig
     fi
-
-#    export PATH=${JEMALLOC_SRCDIR}/bin:$PATH
-#    LDFLAGS=\"-L${JEMALLOC_LIB_SO}\"
-#    RUBY_CONFIGURE_QUALS=( "${RUBY_CONFIGURE_QUALS[@]}" "CPPFLAGS=-I${JEMALLOC_SRCDIR}/include"  )
-#    export LD_LIBRARY_PATH=${JEMALLOC_LIBPATH}:$LD_LIBRARY_PATH
-#    export PKG_CONFIG_PATH=${JEMALLOC_LIBPATH}/pkgconfig:$PKG_CONFIG_PATH
 fi
 
 # Clean the version of Ruby from any existing files that aren't part of source

--- a/build/configure
+++ b/build/configure
@@ -237,6 +237,7 @@ apply_patch ${base_dir}/source/ext/patches/ruby/clear_options.patch ${base_dir}/
 
 # This patch is borrowed from FluentD 0.12.32 to resolve in_exec plugin failing repeatedly with command or parsing failing
 # Updating FluentD to version 0.12.32 or later may already include this patch
+# +Improving shutdown time.
 apply_patch ${base_dir}/source/ext/patches/fluentd/in_exec.patch ${base_dir}/source/ext/fluentd/lib/fluent/plugin/in_exec.rb
 
 # Patching in_syslog.rb to support configurable syslog delimiter
@@ -245,6 +246,11 @@ apply_patch ${base_dir}/source/ext/patches/fluentd/in_syslog.patch ${base_dir}/s
 # This patch make sure to only load external plugin files starting with in_, out_, filter_, buf_, parser_, formatter_ or storage_
 # It has not effect on fluentd internal plugins
 apply_patch ${base_dir}/source/ext/patches/fluentd/plugin.patch ${base_dir}/source/ext/fluentd/lib/fluent/plugin.rb
+
+# Patching root_agent.rb and in_monitor_agent.rb to reduce shutdown process
+apply_patch ${base_dir}/source/ext/patches/fluentd/in_monitor_agent.patch ${base_dir}/source/ext/fluentd/lib/fluent/plugin/in_monitor_agent.rb
+apply_patch ${base_dir}/source/ext/patches/fluentd/root_agent.patch ${base_dir}/source/ext/fluentd/lib/fluent/root_agent.rb
+apply_patch ${base_dir}/source/ext/patches/fluentd/agent.patch ${base_dir}/source/ext/fluentd/lib/fluent/agent.rb
 
 # This patch is borrowed from FluentD 1.x to support ruby +2.6
 apply_patch ${base_dir}/source/ext/patches/fluentd/fluentd_gemspec.patch ${base_dir}/source/ext/fluentd/fluentd.gemspec

--- a/installer/scripts/omsagent.systemd
+++ b/installer/scripts/omsagent.systemd
@@ -15,8 +15,8 @@ ExecStart=/opt/microsoft/omsagent/bin/omsagent \
   --no-supervisor
 ExecStop=/bin/rm -f %RUN_DIR_WS%/omsagent.pid
 KillMode=process
-KillSignal=SIGKILL
 TimeoutStartSec=10
+TimeoutStopSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -21,7 +21,8 @@
 
 OMSAGENT_START_WAIT_MAX=18
 OMSAGENT_STOP_WAIT_MAX=15
-STOP_PROCESS_WAIT_MAX=5
+STOP_SIGTERM_PROCESS_WAIT_MAX=10
+STOP_SIGKILL_PROCESS_WAIT_MAX=5
 WAIT_UNTIL_RUNNING_ITERATION_SLEEP=0.5
 WAIT_UNTIL_STOPPED_ITERATION_SLEEP=0.5
 
@@ -337,9 +338,17 @@ stop_omsagent_process()
     WS_STATUS=0 # Try yet again.
 
     echo -n "(Forced) "
-    kill -sigkill `cat $PIDFILE`
+    echo -n " Sending SIGTERM ..."
+    kill -sigterm `cat $PIDFILE`
     if [ $? -eq 0 ]; then
-        wait_until_omsagent_stopped $STOP_PROCESS_WAIT_MAX
+        wait_until_omsagent_stopped $STOP_SIGTERM_PROCESS_WAIT_MAX
+    fi
+    if [ $? -eq 1 ]; then
+        echo -n " Timeout reached, process could not be stopped, Sending SIGKILL ... "
+        kill -sigkill `cat $PIDFILE`
+        if [ $? -eq 0 ]; then
+            wait_until_omsagent_stopped $STOP_SIGKILL_PROCESS_WAIT_MAX
+        fi
     fi
     WS_STATUS=$?
     return $WS_STATUS

--- a/source/code/plugins/in_dsc_monitor.rb
+++ b/source/code/plugins/in_dsc_monitor.rb
@@ -102,6 +102,8 @@ OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-D
       super
       @finished_check_install = true
       @finished_check_status = true
+      @thread_check_install.exit
+      @thread_check_status.exit
       @thread_check_install.join
       @thread_check_status.join
     end

--- a/source/code/plugins/in_oms_heartbeat.rb
+++ b/source/code/plugins/in_oms_heartbeat.rb
@@ -32,6 +32,7 @@ module Fluent
     def shutdown
       if @interval
         @finished = true
+        @thread.exit
         @thread.join
       end
     end

--- a/source/code/plugins/in_sudo_tail.rb
+++ b/source/code/plugins/in_sudo_tail.rb
@@ -67,7 +67,8 @@ module Fluent
     end
 
     def shutdown
-      @finished = true 
+      @finished = true
+      @thread.exit
       @thread.join
     end
 

--- a/source/ext/patches/fluentd/agent.patch
+++ b/source/ext/patches/fluentd/agent.patch
@@ -1,0 +1,32 @@
+--- ../source/ext/fluentd/lib/fluent/agent.rb	2019-07-25 17:44:00.793117309 -0700
++++ ../source/ext/fluentd/lib/fluent/agent.rb.new	2019-07-25 17:38:46.352455542 -0700
+@@ -78,12 +78,19 @@
+       }
+     end
+ 
++    def measure_shutdown(name, &block)
++      t0 = Time.now
++      yield
++      shutdown_time = (Time.now - t0).round(1)
++      log.info "!!! '#{name}' has #{shutdown_time} sec shutdown latency" if shutdown_time >= 1
++    end
++
+     def shutdown
+       @started_filters.map { |f|
+         Thread.new do
+           begin
+             log.info "shutting down filter#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(f.class), plugin_id: f.plugin_id
+-            f.shutdown
++            measure_shutdown(Plugin.lookup_name_from_class(f.class)) { f.shutdown }
+           rescue => e
+             log.warn "unexpected error while shutting down filter plugins", plugin: f.class, plugin_id: f.plugin_id, error_class: e.class, error: e
+             log.warn_backtrace
+@@ -97,7 +104,7 @@
+         Thread.new do
+           begin
+             log.info "shutting down output#{@context.nil? ? '' : " in #{@context}"}", type: Plugin.lookup_name_from_class(o.class), plugin_id: o.plugin_id
+-            o.shutdown
++            measure_shutdown(Plugin.lookup_name_from_class(o.class)) { o.shutdown }
+           rescue => e
+             log.warn "unexpected error while shutting down output plugins", plugin: o.class, plugin_id: o.plugin_id, error_class: e.class, error: e
+             log.warn_backtrace

--- a/source/ext/patches/fluentd/in_exec.patch
+++ b/source/ext/patches/fluentd/in_exec.patch
@@ -1,6 +1,43 @@
---- ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb	2018-10-19 03:51:40.507620900 -0700
-+++ ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb.new	2018-10-23 16:32:45.263000000 -0700
-@@ -131,6 +131,7 @@
+--- ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb	2019-07-25 17:44:35.237194903 -0700
++++ ../source/ext/fluentd/lib/fluent/plugin/in_exec.rb.new	2019-07-25 17:37:30.812313080 -0700
+@@ -109,15 +109,16 @@
+     def shutdown
+       if @run_interval
+         @finished = true
+-        # call Thread#run which interupts sleep in order to stop run_periodic thread immediately.
+-        @thread.run
+-        @thread.join
+-      else
++        @pid = @run_periodic_pid
++      end
++
++      if @pid
+         begin
+           Process.kill(:TERM, @pid)
+         rescue #Errno::ECHILD, Errno::ESRCH, Errno::EPERM
+         end
+-        if @thread.join(60)  # TODO wait time
++
++        if @thread.join(0.1)
+           return
+         end
+ 
+@@ -125,12 +126,21 @@
+           Process.kill(:KILL, @pid)
+         rescue #Errno::ECHILD, Errno::ESRCH, Errno::EPERM
+         end
+-        @thread.join
++
++        begin
++          # Need to reap the process because it will become a zombie process
++          Process.detach(@pid)
++        rescue #Errno::ECHILD, Errno::ESRCH, Errno::EPERM
++        end
++        # cleanup the thread
++        Thread.kill(@thread)
++        @thread.join(0.1)
+       end
+     end
  
      def run
        @parser.call(@io)
@@ -8,3 +45,15 @@
      end
  
      def run_periodic
+@@ -138,8 +148,10 @@
+       until @finished
+         begin
+           io = IO.popen(@command, "r")
++          @run_periodic_pid = io.pid
+           @parser.call(io)
+-          Process.waitpid(io.pid)
++          Process.waitpid(@run_periodic_pid)
++          @run_periodic_pid = nil
+         rescue
+           log.error "exec failed to run or shutdown child process", error: $!.to_s, error_class: $!.class.to_s
+           log.warn_backtrace $!.backtrace

--- a/source/ext/patches/fluentd/in_monitor_agent.patch
+++ b/source/ext/patches/fluentd/in_monitor_agent.patch
@@ -1,0 +1,11 @@
+--- ../source/ext/fluentd/lib/fluent/plugin/in_monitor_agent.rb	2019-07-16 19:29:38.330949523 -0700
++++ ../source/ext/fluentd/lib/fluent/plugin/in_monitor_agent.rb.new	2019-07-16 19:22:22.801824834 -0700
+@@ -302,6 +302,8 @@
+         @loop.watchers.each { |w| w.detach }
+         @loop.stop
+         @loop = nil
++        log.debug "in_monitor_agent: thread_for_emit state before shutdown '#{@thread_for_emit.status}'"
++        @thread_for_emit.exit
+         @thread_for_emit.join
+         @thread_for_emit = nil
+       end

--- a/source/ext/patches/fluentd/root_agent.patch
+++ b/source/ext/patches/fluentd/root_agent.patch
@@ -1,0 +1,45 @@
+--- ../source/ext/fluentd/lib/fluent/root_agent.rb	2019-07-25 17:44:03.645123703 -0700
++++ ../source/ext/fluentd/lib/fluent/root_agent.rb.new	2019-07-25 17:41:18.932764790 -0700
+@@ -119,23 +119,38 @@
+ 
+     def shutdown
+       # Shutdown Input plugin first to prevent emitting to terminated Output plugin
+-      @started_inputs.map { |i|
++      threads = @started_inputs.map { |i|
+         Thread.new do
+           begin
+-            log.info "shutting down input", type: Plugin.lookup_name_from_class(i.class), plugin_id: i.plugin_id
+-            i.shutdown
++            log.info "shutdown input", type: Plugin.lookup_name_from_class(i.class), plugin_id: i.plugin_id
++            measure_shutdown(Plugin.lookup_name_from_class(i.class)) { i.shutdown }
+           rescue => e
+             log.warn "unexpected error while shutting down input plugin", plugin: i.class, plugin_id: i.plugin_id, error_class: e.class, error: e
+             log.warn_backtrace
+           end
+         end
+-      }.each { |t| t.join }
++      }
++
++      sleep 1
++
++      threads.each { |t|
++        t.terminate if t.status == 'sleep'
++        t.join(0.1)
++      }
+ 
+       @labels.each { |n, l|
+         l.shutdown
+       }
+ 
+       super
++
++      # if other threads still alive clean them up
++      Thread.list.each {|t|
++        if t != Thread.current
++          t.kill
++          t.join(0.1)
++        end
++      }
+     end
+ 
+     def flush!


### PR DESCRIPTION
Reduce OMS shutdown to 1 second.
Set 3 seconds timeout while root_agent is calling shutdown on each input plugin.
Send SIGTERM instead of SIGKILL to give the agent time to cleanup during shutdown.