### PR TITLE
Only load plugin starting with in_, out_, filter_ , parser_, formatter_ or storage_ (for external plugin)

### DIFF
--- a/build/configure
+++ b/build/configure
@@ -242,6 +242,10 @@ apply_patch ${base_dir}/source/ext/patches/fluentd/in_exec.patch ${base_dir}/sou
 # Patching in_syslog.rb to support configurable syslog delimiter
 apply_patch ${base_dir}/source/ext/patches/fluentd/in_syslog.patch ${base_dir}/source/ext/fluentd/lib/fluent/plugin/in_syslog.rb
 
+# This patch make sure to only load external plugin files starting with in_, out_, filter_, buf_, parser_, formatter_ or storage_
+# It has not effect on fluentd internal plugins
+apply_patch ${base_dir}/source/ext/patches/fluentd/plugin.patch ${base_dir}/source/ext/fluentd/lib/fluent/plugin.rb
+
 # This patch is borrowed from FluentD 1.x to support ruby +2.6
 apply_patch ${base_dir}/source/ext/patches/fluentd/fluentd_gemspec.patch ${base_dir}/source/ext/fluentd/fluentd.gemspec
 

--- a/source/ext/patches/fluentd/plugin.patch
+++ b/source/ext/patches/fluentd/plugin.patch
@@ -1,0 +1,27 @@
+--- ../source/ext/fluentd/lib/fluent/plugin.rb	2019-07-22 17:21:57.208065539 -0700
++++ ../source/ext/fluentd/lib/fluent/plugin.rb.new	2019-08-06 13:47:42.708962037 -0700
+@@ -79,13 +79,22 @@
+ 
+     def load_plugins
+       dir = File.join(File.dirname(__FILE__), "plugin")
+-      load_plugin_dir(dir)
++      dir = File.expand_path(dir)
++      # keep default behavior by loading all files under fluent/plugin
++      Dir.entries(dir).sort.each {|fname|
++        if fname =~ /\.rb$/
++          require File.join(dir, fname)
++        end
++      }
+     end
+ 
++    # This function will be called while external plugins are loaded (like OMSAgent)
++    # Load only plugin files starting with in_, out_, filter_, buf_, parser_, formatter_ or storage_
+     def load_plugin_dir(dir)
+       dir = File.expand_path(dir)
++
+       Dir.entries(dir).sort.each {|fname|
+-        if fname =~ /\.rb$/
++        if fname =~ /\.rb$/ and fname =~ /(^in_|^out_|^filter_|^buf_|^parser_|^formatter_|^storage_)/
+           require File.join(dir, fname)
+         end
+       }


### PR DESCRIPTION
Only load plugin starting with in_, out_, filter_, buf_, parser_, formatter_ or storage_
This PR fix an issue when /opt is a symlink. This cause fluentd to load filter from scom_common.rb twice which is causing a crash at start-up.