### PR TITLE
Background jobs: use disposable process to run a job (sync / async)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ before_script:
 
 script:
   # System tests are not run because OMS-Agent-for-Linux-testconfig.git is a private repo
-  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos6-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; ./configure --enable-ulinux --enable-ruby-jemalloc; make unittest; make compile_only"
-  #- docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; make distclean; ./configure --enable-ulinux --enable-ruby-jemalloc; make"
+  - docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos6-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; ./configure --enable-ulinux; make unittest; make compile_only"
+  #- docker run --rm -t -v /home/travis/build/Microsoft/Build-OMS-Agent-for-Linux:/home/scratch/Build-OMS abenbachir/oms-centos5-x64:latest /bin/sh -c "cd /home/scratch/Build-OMS/omsagent/build; make distclean; ./configure --enable-ulinux; make"
 

--- a/build/configure
+++ b/build/configure
@@ -153,6 +153,7 @@ do
           exit 1
       fi
       enable_ulinux="--enable-ulinux"
+      enable_ruby_jemalloc="--with-jemalloc"
       ULINUX=1
     ;;
 
@@ -172,9 +173,9 @@ do
       opensource_distro=1
     ;;
 
-    --enable-ruby-jemalloc)
+    --disable-ruby-jemalloc)
       echo "Configured Jemalloc for Ruby"
-      enable_ruby_jemalloc="--with-jemalloc"
+      enable_ruby_jemalloc=""
     ;;
 
     *)
@@ -206,7 +207,7 @@ OPTIONS:
     --[no]enable-ulinux         Specifies platform as ULINUX (Linux only);
                                 ULINUX is assumed on universal build systems
     --enable-open-source        Build for open source distribution
-    --enable-ruby-jemalloc      Enable building ruby with jemalloc
+    --disable-ruby-jemalloc     Disable building ruby with jemalloc
 
 EOF
     exit 0

--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -45,6 +45,7 @@
   type out_oms_blob
   log_level info
   num_threads 5
+  run_in_background false
 
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt
@@ -65,6 +66,7 @@
   type out_oms
   log_level info
   num_threads 5
+  run_in_background false
 
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt
@@ -86,6 +88,7 @@
   type out_oms_diag
   log_level info
   num_threads 5
+  run_in_background false
 
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt

--- a/source/code/plugins/filter_syslog.rb
+++ b/source/code/plugins/filter_syslog.rb
@@ -25,12 +25,32 @@ module Fluent
     def shutdown
       super
     end
+
+    # For perf debugging
+    def check_eps()
+      if @eps_counter == nil
+        @eps_counter = 0
+      end
+
+      @eps_counter += 1
+      if @eps_counter == 1
+        @time_start = Time.now
+      end
+      current_time = Time.now
+      if current_time - @time_start >= 1
+        diff_time_ms = (current_time - @time_start)
+        $log.info("EPS #{@eps_counter}, for #{diff_time_ms} second")
+        @eps_counter = 0
+      end
+    end
+
     # TODO: fix after dsc removal: use fast_utc_to_iso8601_format from OMS_COMMON.rb
     def fast_utc_to_iso8601_format(utctime, fraction_digits=3)
       utctime.strftime("%FT%T.%#{fraction_digits}NZ")
     end
 
     def filter(tag, time, record)
+      # check_eps()
       pid = record["pid"]
       hostname = record["host"]
       tags = tag.split('.') # The tag should looks like this : oms.syslog.authpriv.notice

--- a/source/code/plugins/out_oms_blob.rb
+++ b/source/code/plugins/out_oms_blob.rb
@@ -32,6 +32,7 @@ module Fluent
     config_param :blob_uri_expiry, :string, :default => '00:10:00'
     config_param :url_suffix_template, :string, :default => "custom_data_type + '/00000000-0000-0000-0000-000000000002/' + OMS::Common.get_hostname + '/' + OMS::Configuration.agent_id + '/' + suffix + '.log'"
     config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf'
+    config_param :run_in_background, :bool, :default => false
 
     def configure(conf)
       super
@@ -45,6 +46,7 @@ module Fluent
 
     def shutdown
       super
+      OMS::BackgroundJobs.instance.cleanup
     end
 
     ####################################################################################################
@@ -370,7 +372,7 @@ module Fluent
       time = Time.now - start
       @log.trace "Success notify the data to BLOB #{time.round(3)}s"
       write_status_file("true","Sending success")
-      OMS::Telemetry.push_qos_event(OMS::SEND_BATCH, "true", "", tag, records, records.size, time)
+      return OMS::Telemetry.push_qos_event(OMS::SEND_BATCH, "true", "", tag, records, records.size, time)
     rescue OMS::RetryRequestException => e
       @log.info "Encountered retryable exception. Will retry sending data later."
       @log.debug "Error:'#{e}'"
@@ -379,8 +381,10 @@ module Fluent
       # it must be generic exception, otherwise, fluentd will stuck.
       raise e.message
     rescue => e
-      OMS::Log.error_once("Unexpected exception, dropping data. Error:'#{e}'")
-      write_status_file("false", "Unexpected exception")
+      msg = "Unexpected exception, dropping data. Error:'#{e}'"
+      OMS::Log.error_once(msg)
+      write_status_file("false","Unexpected exception")
+      return msg
     end # handle_record
 
     # This method is called when an event reaches to Fluentd.
@@ -389,16 +393,8 @@ module Fluent
       [tag, record].to_msgpack
     end
 
-    # This method is called every flush interval. Send the buffer chunk to OMS. 
-    # 'chunk' is a buffer chunk that includes multiple formatted
-    # NOTE! This method is called by internal thread, not Fluentd's main thread. So IO wait doesn't affect other plugins.
-    def write(chunk)
-      # Quick exit if we are missing something
-      if !OMS::Configuration.load_configuration(omsadmin_conf_path, cert_path, key_path)
-        raise 'Missing configuration. Make sure to onboard. Will continue to buffer data.'
-      end
-
-      # Group records based on their datatype because OMS does not support a single request with multiple datatypes. 
+    def self_write(chunk)
+      # Group records based on their datatype because OMS does not support a single request with multiple datatypes.
       datatypes = {}
       chunk.msgpack_each {|(tag, record)|
         if !datatypes.has_key?(tag)
@@ -407,8 +403,27 @@ module Fluent
         datatypes[tag] << record['message']
       }
 
-      datatypes.each do |tag, records|
-        handle_records(tag, records)
+      ret = []
+      datatypes.each do |key, records|
+        ret << {'source': key, 'event': handle_record(key, records)}
+      end
+
+      ret
+    end
+
+    # This method is called every flush interval. Send the buffer chunk to OMS.
+    # 'chunk' is a buffer chunk that includes multiple formatted
+    # NOTE! This method is called by (out_oms_blob) plugin thread not Fluentd's main thread. So IO wait doesn't affect other plugins.
+    def write(chunk)
+      # Quick exit if we are missing something
+      if !OMS::Configuration.load_configuration(omsadmin_conf_path, cert_path, key_path)
+        raise 'Missing configuration. Make sure to onboard. Will continue to buffer data.'
+      end
+
+      if run_in_background
+        OMS::BackgroundJobs.instance.run_job_and_wait { self_write(chunk) }
+      else
+        self_write(chunk)
       end
     end
 

--- a/source/code/plugins/out_oms_diag.rb
+++ b/source/code/plugins/out_oms_diag.rb
@@ -21,6 +21,7 @@ module Fluent
     config_param :key_path, :string, :default => '/etc/opt/microsoft/omsagent/certs/oms.key'
     config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf'
     config_param :compress, :bool, :default => true
+    config_param :run_in_background, :bool, :default => false
 
     def configure(conf)
       super
@@ -33,6 +34,7 @@ module Fluent
 
     def shutdown
       super
+      OMS::BackgroundJobs.instance.cleanup
     end
 
     def handle_record(ipname, record)
@@ -49,8 +51,7 @@ module Fluent
         time = ends - start
         count = record[OMS::Diag::RECORD_DATAITEMS].size
         @log.debug "Success sending diagnotic logs #{ipname} x #{count} in #{time.round(2)}s"
-        OMS::Telemetry.push_qos_event(OMS::SEND_BATCH, "true", "", ipname, record, count, time)
-        return true
+        return OMS::Telemetry.push_qos_event(OMS::SEND_BATCH, "true", "", ipname, record, count, time)
       end
     rescue OMS::RetryRequestException => e
       @log.info "Encountered retryable exception. Will retry sending diagnostic data later."
@@ -61,7 +62,9 @@ module Fluent
       # We encountered something unexpected. We drop the data because
       # if bad data caused the exception, the engine will continuously
       # try and fail to resend it. (Infinite failure loop)
-      OMS::Log.error_once("Unexpecting exception, dropping diagnostic data. Error:'#{e}'")
+      msg = "Unexpected exception, dropping diagnostic data. Error:'#{e}'"
+      OMS::Log.error_once(msg)
+      return msg
     end
 
     # This method is called when an event reaches to Fluentd.
@@ -74,12 +77,7 @@ module Fluent
       end
     end
 
-    def write(chunk)
-      # Quick exit if we are missing something
-      if !OMS::Configuration.load_configuration(omsadmin_conf_path, cert_path, key_path)
-        raise OMS::RetryRequestException, 'Missing configuration. Make sure to onboard.'
-      end
-
+    def self_write(chunk)
       # ipname to dataitems array hash
       ipnameRecords = Hash.new
 
@@ -99,10 +97,26 @@ module Fluent
       end
 
       # getting diag records out of aggregated dataitems for serialization
+      ret = []
       ipnameRecords.each do |ipname, dataitemArray|
         OMS::Diag.ProcessDataItemsPostAggregation(dataitemArray, OMS::Configuration.agent_id)
         record = OMS::Diag.CreateDiagRecord(dataitemArray, ipname)
-        handle_record(ipname, record)
+        ret << handle_record(ipname, records)
+        ret << {'source': ipname, 'event':  handle_record(ipname, records)}
+      end
+      return ret
+    end
+
+    def write(chunk)
+      # Quick exit if we are missing something
+      if !OMS::Configuration.load_configuration(omsadmin_conf_path, cert_path, key_path)
+        raise OMS::RetryRequestException, 'Missing configuration. Make sure to onboard.'
+      end
+
+      if run_in_background
+        OMS::BackgroundJobs.instance.run_job_and_wait { self_write(chunk) }
+      else
+        self_write(chunk)
       end
     end
 


### PR DESCRIPTION
BJobs is able run code on different (disposable) process and get results once it finished, you can choose to wait for that job to complete or not wait, and pass a callback which will be called asynchronously.

By enabling BJobs for our output plugins out_oms, out_oms_blob showed 6x memory reduction.

We can turn ON/OFF this feature from configuration for output plugins.