### PR TITLE
Adding separate entry to logrotate conf for LAD installation

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -1131,9 +1131,15 @@ configure_monitor_agent()
 configure_logrotate()
 {
     echo "Configure log rotate for workspace $WORKSPACE_ID..."
-    # create the logrotate file for the workspace if it doesn't exist
-    if [ ! -f /etc/logrotate.d/omsagent-$WORKSPACE_ID ]; then
-        cat $SYSCONF_DIR/logrotate.conf | sed "s/%WORKSPACE_ID%/$WORKSPACE_ID/g" > /etc/logrotate.d/omsagent-$WORKSPACE_ID
+
+    # create the logrotate file for omsagent if workspace is LAD
+    if [ "$WORKSPACE_ID" = "LAD" ]; then
+        echo "/var/opt/microsoft/omsagent/LAD/log/omsagent.log {\n\trotate 10\n\tmissingok\n\tnotifempty\n\tcompress\n\tsize 100M\n\tcopytruncate\n}" > /etc/logrotate.d/omsagent-$WORKSPACE_ID
+    else
+    	# create the logrotate file for the workspace if it doesn't exist
+    	if [ ! -f /etc/logrotate.d/omsagent-$WORKSPACE_ID ]; then
+            cat $SYSCONF_DIR/logrotate.conf | sed "s/%WORKSPACE_ID%/$WORKSPACE_ID/g" > /etc/logrotate.d/omsagent-$WORKSPACE_ID
+    	fi
     fi
 
     # Label omsagent log files according to selinux policy module for logrotate if selinux is present


### PR DESCRIPTION
Currently when LAD is installed, it uses the same config for logrotate as omsagent. Which contains entry for
1) ...<Workspace-ID>/omsagent.log (it is fine since it has a unique ws_id) 
2) urp.log (update management)
3) watcher.log (oms extension)
4) extension.log (oms extension)

The last 3 entries are not unique in their path and thus if a VM has both LAD and Omsagent installed then there are duplicate entries of them in the cron.d config. This causes cron to send a warning email/notification to customers mentioning duplication. This change will take care of that. 
Now if the installation type is LAD then we only add entry for /var/opt/microsoft/omsagent/LAD/log/omsagent.log to get rotated. 