### PR TITLE
Shell bundle: Bundle both auoms 1.x and 2.x

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -25,7 +25,8 @@ endif
 
 DSC_TARGET_DIR := $(DSC_DIR)/release
 AUOMS_TARGET_DIR := $(AUOMS_DIR)/target/$(BUILD_CONFIGURATION)
-AUOMS_KITS_RELEASE_DIR := $(AUOMS_KITS_DIR)/release/1.3.0-3
+AUOMS_KITS_RELEASE_DIR := $(AUOMS_KITS_DIR)/release/2.0.1-19
+AUOMS_KITS_RELEASE_1_3_DIR := $(AUOMS_KITS_DIR)/release/1.3.0-3
 
 RUBY_DIR := $(BASE_DIR)/source/ext/ruby
 # This Ruby version number refers only to the major/minor version (not teeny)
@@ -368,6 +369,11 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	cd $(AUOMS_KITS_RELEASE_DIR); $(COPY) `ls auoms-*.universal.$(PF_ARCH).sh | sort | tail -1` $(INTERMEDIATE_DIR)/bundles
 	$(COPY) $(AUOMS_KITS_RELEASE_DIR)/auoms-bundle-test.sh $(INTERMEDIATE_DIR)/bundles
 
+	# adding auoms 1.3 for older distros (SLES11)
+	$(MKPATH) $(INTERMEDIATE_DIR)/bundles/v1
+	cd $(AUOMS_KITS_RELEASE_1_3_DIR); $(COPY) `ls auoms-*.universal.$(PF_ARCH).sh | sort | tail -1` $(INTERMEDIATE_DIR)/bundles/v1
+	$(COPY) $(AUOMS_KITS_RELEASE_1_3_DIR)/auoms-bundle-test.sh $(INTERMEDIATE_DIR)/bundles/v1
+
 	# Gather the SCX bits that we need
 	# Note: We take care to only copy the latest version if there are multiple versions
 	cd $(SCX_CORE_KITS)/release; $(COPY) `ls scx-*.$(PF_ARCH).sh | sort | tail -1` $(INTERMEDIATE_DIR)
@@ -393,7 +399,7 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	cd $(INTERMEDIATE_DIR)/110; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_110\./\./g"`
 	cd $(INTERMEDIATE_DIR)/110; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_110\./\./g"`
 
-	chmod +x $(INTERMEDIATE_DIR)/bundles/*.sh
+	chmod +x $(INTERMEDIATE_DIR)/bundles/**/*.sh
 
 	# Build the tar file containing both .rpm and .deb packages
 	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 100/*.{deb,rpm} 110/*.{deb,rpm} oss-kits/* bundles/*
@@ -439,6 +445,11 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	cd $(AUOMS_KITS_RELEASE_DIR); $(COPY) `ls auoms-*.universal.$(PF_ARCH).sh | sort | tail -1` $(INTERMEDIATE_DIR)/bundles
 	$(COPY) $(AUOMS_KITS_RELEASE_DIR)/auoms-bundle-test.sh $(INTERMEDIATE_DIR)/bundles
 
+	# adding auoms 1.3 for older distros (SLES11)
+	$(MKPATH) $(INTERMEDIATE_DIR)/bundles/v1
+	cd $(AUOMS_KITS_RELEASE_1_3_DIR); $(COPY) `ls auoms-*.universal.$(PF_ARCH).sh | sort | tail -1` $(INTERMEDIATE_DIR)/bundles/v1
+	$(COPY) $(AUOMS_KITS_RELEASE_1_3_DIR)/auoms-bundle-test.sh $(INTERMEDIATE_DIR)/bundles/v1
+
 	# Gather the SCX bits that we need
 	# Note: We take care to only copy the latest version if there are multiple versions
 	cd $(SCX_CORE_KITS)/release; $(COPY) `ls scx-*.$(PF_ARCH).sh | sort | tail -1` $(INTERMEDIATE_DIR)
@@ -460,7 +471,7 @@ $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).tar : $(RUBY_DEST_DIR) $(IN_PLUGINS
 	cd $(INTERMEDIATE_DIR)/100; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_100\./\./g"`
 	cd $(INTERMEDIATE_DIR)/100; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_100\./\./g"`
 
-	chmod +x $(INTERMEDIATE_DIR)/bundles/*.sh
+	chmod +x $(INTERMEDIATE_DIR)/bundles/**/*.sh
 
 	# Build the tar file containing both .rpm and .deb packages
 	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 100/*.{deb,rpm} oss-kits/* bundles/*

--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -71,6 +71,8 @@ INSTALL_CURL=55 #64, temporary as 55 excludes from SLA
 INSTALL_GPG=65
 UNSUPPORTED_PKG_INSTALLER=66
 OPENSSL_PATH="openssl"
+BUNDLES_PATH="bundles"
+BUNDLES_LEGACY_PATH="bundles/v1"
 
 usage()
 {
@@ -1233,17 +1235,23 @@ case "$installMode" in
                     fi
                 fi
             done
-            for i in bundles/*-bundle-test.sh; do
+
+            # Handling auoms 1.x vs 2.x installation
+            is_suse11_platform_with_openssl1
+            if [ $? -eq 0 ];then
+               BUNDLES_PATH=$BUNDLES_LEGACY_PATH
+            fi
+            for i in ${BUNDLES_PATH}/*-bundle-test.sh; do
                 # If filespec didn't expand, break out of loop
                 [ ! -f $i ] && break
 
                 # It's possible we have a test file without bundle; if so, ignore it
                 BUNDLE=`basename $i -bundle-test.sh`
-                [ ! -f bundles/${BUNDLE}-*universal.*.sh ] && continue
+                [ ! -f ${BUNDLES_PATH}/${BUNDLE}-*universal.*.sh ] && continue
 
                 ./$i
                 if [ $? -eq 0 ]; then
-                    ./bundles/${BUNDLE}-*universal.*.sh --install $FORCE $restartDependencies
+                    ./${BUNDLES_PATH}/${BUNDLE}-*universal.*.sh --install $FORCE $restartDependencies
                     TEMP_STATUS=$?
                     if [ $TEMP_STATUS -ne 0 ]; then
                         echo "$BUNDLE package failed to install and exited with status $TEMP_STATUS"
@@ -1355,17 +1363,23 @@ case "$installMode" in
                 fi
             fi
         done
-        for i in bundles/*-bundle-test.sh; do
+
+        # Handling auoms 1.x vs 2.x installation
+        is_suse11_platform_with_openssl1
+        if [ $? -eq 0 ];then
+           BUNDLES_PATH=$BUNDLES_LEGACY_PATH
+        fi
+        for i in ${BUNDLES_PATH}/*-bundle-test.sh; do
             # If filespec didn't expand, break out of loop
             [ ! -f $i ] && break
 
             # It's possible we have a test file without bundle; if so, ignore it
             BUNDLE=`basename $i -bundle-test.sh`
-            [ ! -f bundles/${BUNDLE}-*universal.*.sh ] && continue
+            [ ! -f ${BUNDLES_PATH}/${BUNDLE}-*universal.*.sh ] && continue
 
             ./$i
             if [ $? -eq 0 ]; then
-                ./bundles/${BUNDLE}-*universal.*.sh --upgrade $FORCE $restartDependencies
+                ./${BUNDLES_PATH}/${BUNDLE}-*universal.*.sh --upgrade $FORCE $restartDependencies
                 TEMP_STATUS=$?
                 if [ $TEMP_STATUS -ne 0 ]; then
                     echo "$BUNDLE package failed to upgrade and exited with status $TEMP_STATUS"


### PR DESCRIPTION
auoms 1.x will only be installed on SLES11-openssl1, otherwise we install auoms 2.x

-> our installer will be increased by 6.4 MB