### PR TITLE
Memory improvement using Glibc allocator

### DIFF
--- a/build/configure
+++ b/build/configure
@@ -13,7 +13,6 @@ enable_purify_server=""
 enable_omi_tools=""
 enable_omi_tools_flag=0
 opensource_distro=0
-enable_ruby_jemalloc=""
 build_type=Release
 ULINUX=0
 NOULINIX=0
@@ -153,7 +152,6 @@ do
           exit 1
       fi
       enable_ulinux="--enable-ulinux"
-      enable_ruby_jemalloc="--with-jemalloc"
       ULINUX=1
     ;;
 
@@ -171,11 +169,6 @@ do
 
     --enable-open-source)
       opensource_distro=1
-    ;;
-
-    --disable-ruby-jemalloc)
-      echo "Configured Jemalloc for Ruby"
-      enable_ruby_jemalloc=""
     ;;
 
     *)
@@ -207,7 +200,6 @@ OPTIONS:
     --[no]enable-ulinux         Specifies platform as ULINUX (Linux only);
                                 ULINUX is assumed on universal build systems
     --enable-open-source        Build for open source distribution
-    --disable-ruby-jemalloc     Disable building ruby with jemalloc
 
 EOF
     exit 0
@@ -262,6 +254,9 @@ apply_patch ${base_dir}/source/ext/patches/ruby/ssl_http_fix.patch ${base_dir}/s
 
 # This patch increase the minimum limit for jit to be triggered and increase the cache size to be able to jit more functions
 apply_patch ${base_dir}/source/ext/patches/ruby/mjit_options.patch ${base_dir}/source/ext/ruby/mjit.c
+
+# This patch reduce Ruby memory allocation by tweaking malloc
+apply_patch ${base_dir}/source/ext/patches/ruby/malloc_gc.patch ${base_dir}/source/ext/ruby/gc.c
 
 # Patching log.rb in order to support qos error reporting
 apply_patch ${base_dir}/source/ext/patches/fluentd/log.patch ${base_dir}/source/ext/fluentd/lib/fluent/log.rb
@@ -456,7 +451,6 @@ ruby_configure_quals=(
     --with-out-ext=${RUBY_EXTENSIONS}
   )
 
-ruby_config_quals_jemalloc=$enable_ruby_jemalloc
 ruby_config_quals_sysins="--prefix=/opt/microsoft/omsagent/ruby"
 
 ruby_test_directory="${home_dir}/bin/omsagent_test_ruby"
@@ -524,7 +518,6 @@ PACKAGE_SUFFIX=$PKG_SUFFIX
 RUBY_CONFIGURE_QUALS=( ${ruby_configure_quals[@]} )
 RUBY_CONFIGURE_QUALS_SYSINS="$ruby_config_quals_sysins"
 RUBY_CONFIGURE_QUALS_TESTINS="$ruby_config_quals_testins"
-RUBY_CONFIGURE_QUALS_JEMALLOC="${ruby_config_quals_jemalloc}"
 RUBY_TEST_DIRECTORY="$ruby_test_directory"
 
 EOF

--- a/installer/conf/omsagent.d/apache_logs.conf
+++ b/installer/conf/omsagent.d/apache_logs.conf
@@ -54,6 +54,8 @@
 <match oms.api.Apache**>
   type out_oms_api
   log_level info
+  run_in_background false
+
   buffer_chunk_limit 5m
   buffer_type file
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_apache*.buffer

--- a/installer/conf/omsagent.d/auditlog.conf
+++ b/installer/conf/omsagent.d/auditlog.conf
@@ -17,6 +17,7 @@
 <match oms.api.LinuxAuditLog.**>
   type out_oms_api
   log_level info
+  run_in_background false
 
   buffer_chunk_limit 5m
   buffer_type file

--- a/installer/conf/omsagent.d/mongo.conf
+++ b/installer/conf/omsagent.d/mongo.conf
@@ -30,6 +30,8 @@
 <match oms.api.MongoDBlog>
   type out_oms_api
   log_level info
+  run_in_background false
+
   buffer_chunk_limit 5m
   buffer_type file
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_workload_mongo*.buffer

--- a/installer/conf/omsagent.d/monitor.conf
+++ b/installer/conf/omsagent.d/monitor.conf
@@ -18,6 +18,7 @@
 <match oms.health.** oms.heartbeat.**>
   type out_oms
   log_level info
+  run_in_background false
 
   omsadmin_conf_path %CONF_DIR_WS%/omsadmin.conf
   cert_path %CERT_DIR_WS%/oms.crt

--- a/installer/conf/omsagent.d/mysql_logs.conf
+++ b/installer/conf/omsagent.d/mysql_logs.conf
@@ -81,6 +81,8 @@
 <match oms.api.MySQL.**>
   type out_oms_api
   log_level info
+  run_in_background false
+
   buffer_chunk_limit 5m
   buffer_type file
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_mysql_logs*.buffer

--- a/installer/conf/omsagent.d/postgresql_logs.conf
+++ b/installer/conf/omsagent.d/postgresql_logs.conf
@@ -23,6 +23,8 @@
 <match oms.api.PostgreSQL>
   type out_oms_api
   log_level info
+  run_in_background false
+
   buffer_chunk_limit 5m
   buffer_type file
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_postgres*.buffer

--- a/installer/conf/omsagent.d/vmware_esxi.conf
+++ b/installer/conf/omsagent.d/vmware_esxi.conf
@@ -18,6 +18,7 @@
 <match oms.api.VMware.**>
   type out_oms_api
   log_level info
+  run_in_background false
 
   buffer_chunk_limit 2m
   buffer_type file

--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -53,6 +53,7 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/bin/configure_syslog.sh;                        installer/scripts/configure_syslog.sh;                 755; root; root
 /opt/microsoft/omsagent/bin/hdinsightmanifestreader.rb;                 installer/scripts/hdinsightmanifestreader.rb;          744; root; root
 /opt/microsoft/omsagent/bin/regenerate_scom_cert.sh;                    installer/scripts/regenerate_scom_cert.sh;             755; root; root
+/opt/microsoft/omsagent/bin/omsagent.env;                               installer/scripts/omsagent.env;                        755; root; root
 
 /opt/microsoft/omsagent/plugin/filter_syslog.rb;                        source/code/plugins/filter_syslog.rb;                  744; root; root
 /opt/microsoft/omsagent/plugin/out_oms.rb;                              source/code/plugins/out_oms.rb;                        744; root; root

--- a/installer/scripts/omsagent.env
+++ b/installer/scripts/omsagent.env
@@ -1,0 +1,15 @@
+## OMSAgent env variables
+
+# RUBY GC tuning: don't use GC parameters for Ruby this will increase CPU usage
+#RUBY_GC_HEAP_GROWTH_FACTOR=1.1
+#RUBY_GC_MALLOC_LIMIT=4000100
+#RUBY_GC_MALLOC_LIMIT_MAX=16000100
+#RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=1.1
+#RUBY_GC_OLDMALLOC_LIMIT=16000100
+#RUBY_GC_OLDMALLOC_LIMIT_MAX=16000100
+#RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0.9
+
+
+# enable/disable jemalloc
+#LD_PRELOAD=/opt/microsoft/omsagent/ruby/lib/libjemalloc.so.2
+

--- a/installer/scripts/omsagent.systemd
+++ b/installer/scripts/omsagent.systemd
@@ -8,6 +8,7 @@ Type=simple
 User=omsagent
 Group=omiusers
 PIDFile=%RUN_DIR_WS%/omsagent.pid
+EnvironmentFile=/opt/microsoft/omsagent/bin/omsagent.env
 ExecStart=/opt/microsoft/omsagent/bin/omsagent \
   -d %RUN_DIR_WS%/omsagent.pid \
   -o %LOG_DIR_WS%/omsagent.log \

--- a/installer/scripts/omsagent.ulinux
+++ b/installer/scripts/omsagent.ulinux
@@ -52,6 +52,12 @@ else
     exit 1
 fi
 
+# Read configuration variable file if it is present
+if [ -r /opt/microsoft/omsagent/bin/omsagent.env ]; then
+    set -a
+    . /opt/microsoft/omsagent/bin/omsagent.env
+    set +a
+fi
 
 RETVAL=0
 USER_REQ=""

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -533,15 +533,6 @@ find_systemd_dir()
 
 enable_omsagent_service()
 {
-#    Don't use GC parameters for Ruby this will increase CPU usage
-#    export RUBY_GC_HEAP_GROWTH_FACTOR=1.1
-#    export RUBY_GC_MALLOC_LIMIT=4000100
-#    export RUBY_GC_MALLOC_LIMIT_MAX=16000100
-#    export RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=1.1
-#    export RUBY_GC_OLDMALLOC_LIMIT=16000100
-#    export RUBY_GC_OLDMALLOC_LIMIT_MAX=16000100
-#    export RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0.9
-
     if [ ! -f $CONF_DIR/.service_registered ] && [ -f $OMSADMIN_CONF ]; then
         echo "INFO:  Configuring OMS agent service $WORKSPACE_ID ..."
         if [ ! -f $BIN_DIR/$OMSAGENT_WS ]; then

--- a/source/ext/patches/ruby/malloc_gc.patch
+++ b/source/ext/patches/ruby/malloc_gc.patch
@@ -1,0 +1,30 @@
+--- ../source/ext/ruby/gc.c	2019-08-28 17:11:51.342961037 -0700
++++ ../source/ext/ruby/gc.c.new	2019-08-28 17:12:45.271108954 -0700
+@@ -6655,7 +6655,11 @@
+ 
+     gc_prof_timer_start(objspace);
+     {
+-	gc_marks(objspace, do_full_mark);
++	    gc_marks(objspace, do_full_mark);
++        /* Explicitly free all eligible pages to the kernel. */
++        if (do_full_mark) {
++            malloc_trim(0);
++        }
+     }
+     gc_prof_timer_stop(objspace);
+ 
+@@ -10127,6 +10131,14 @@
+ #undef OPT
+ 	OBJ_FREEZE(opts);
+     }
++
++    /*
++     * Ruby doesn't benefit from many glibc malloc arenas due to GVL,
++     * remove or increase when we get Guilds
++     */
++    if (!getenv("MALLOC_ARENA_MAX")) {
++        mallopt(M_ARENA_MAX, 2);
++    }
+ }
+ 
+ #ifdef ruby_xmalloc

--- a/test/perf/omsagent-loadtest.py
+++ b/test/perf/omsagent-loadtest.py
@@ -787,9 +787,9 @@ class LoadBench:
         # wait more times for collecting more data
         # force flushing
         processes = self.clear_dead_process(processes)
-        for proc in processes:
-            if proc.is_running():
-                proc.send_signal(psutil.signal.SIGUSR1)
+#         for proc in processes:
+#             if proc.is_running():
+#                 proc.send_signal(psutil.signal.SIGUSR1)
 
         return profiler, response_times, nb_events
 


### PR DESCRIPTION
- Fix some bugs in telemetry and oms_common
- Add support to load env variables from a file omsagent.env
- Load jemalloc from LD_PRELOAD (disabled)
- Reduce memory consumption by:
  -  Setting malloc arena to 2
  -  Calling malloc_trim after a full GC pass  