### PR TITLE
Modified debug statements to fix high eps plugin hang state

### DIFF
--- a/source/code/plugins/tailfilereader.rb
+++ b/source/code/plugins/tailfilereader.rb
@@ -193,8 +193,8 @@ module Tailscript
         attr_reader :io
 
         def on_notify
+          @log.debug "Seeking to read file - #{@io.path} from #{@io.pos} position and file size is #{@io.stat.size}"
           begin
-            @log.debug "Seeking to read file - #{@io.path} from #{@io.pos} position and file size is #{@io.stat.size}"
             read_more = false
             if @lines.empty?
               begin
@@ -217,7 +217,6 @@ module Tailscript
               end
             end
 
-            @log.debug "Number of lines read from #{@io.path} : #{@lines.length}"
             unless @lines.empty?
               if @receive_lines.call(@lines)
                 @pe.update_pos(@io.pos - @buffer.bytesize)


### PR DESCRIPTION
Moving one debug statement out of the loop and removing the second one from the code as these statements, when running customlogs with very high eps (approx 20k), cause the STDERR pipe to fill up and hang the tailfilereader process. 
