### PR TITLE
Fix invalid ERMSPeering config issue

### DIFF
--- a/source/code/plugins/npmd_config_lib.rb
+++ b/source/code/plugins/npmd_config_lib.rb
@@ -422,8 +422,8 @@ module NPMDConfig
                             _urls.push(_urlHash)
                         end
                         _msRule["URLs"] = _urls
+                        _ruleList.push(_msRule)
                     end
-                    _ruleList.push(_msRule)
                     _er[:"MSPeeringRules"] = _ruleList if !_ruleList.empty?
                 end
             end


### PR DESCRIPTION
This PR is to fix  issue related to invalid ERMSPeering config receipt at npmd_agent level even though there is no ER config set.

Following is the log seen at npmd_agent level even though no ER config is seen:

U10/06/19 08:17:40 140015045965568 E void NPM::Plugin::ERMonitorPlugin::HandleMSPeeringRules(NPM::Schemas::MSPeeringRulesConfig): ER MSPeeringRule config is invalid

Reason is that, "npmd_agent" is receiving ER config as ""ER":{"MSPeeringRules":[null]}".
 
This PR addresses fix for the issue mentioned.