### PR TITLE
Revert "Correctly pass parse hostname for IP as computer"

### DIFF
--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -2,10 +2,6 @@
 
 module OMS
 
-  MSDockerCImprovHostnameFilePath = '/var/opt/microsoft/docker-cimprov/state/containerhostname'
-  IPV6_REGEX = '\h{4}:\h{4}:\h{4}:\h{4}:\h{4}:\h{4}:\h{4}:\h{4}'
-  IPV4_Approximate_REGEX = '\d+\.\d+\.\d+\.\d+'
-
   class RetryRequestException < Exception
     # Throw this exception to tell the fluentd engine to retry and
     # inform the output plugin that it is indeed retryable
@@ -29,7 +25,7 @@ module OMS
     @@OSName = nil
     @@OSVersion = nil
     @@Hostname = nil
-    @@HostnameFilePath = MSDockerCImprovHostnameFilePath
+    @@HostnameFilePath = '/var/opt/microsoft/docker-cimprov/state/containerhostname'
     @@FQDN = nil
     @@InstalledDate = nil
     @@AgentVersion = nil
@@ -485,111 +481,6 @@ module OMS
     @@tzRightFolder = 'right/'
 
     class << self
-
-      # Internal methods
-      # (left public for easy testing, though protected may be better later)
-
-      def clean_hostname_string(hnBuffer)
-        return "" if hnBuffer.nil? # So give the rest of the program a string to deal with.
-        hostname_buffer = hnBuffer.strip
-        return hostname_buffer
-      end
-
-      def has_designated_hostnamefile?
-        return false if @@HostnameFilePath.nil?
-        return false unless @@HostnameFilePath =~ /\w/
-        return false unless File.exist?(@@HostnameFilePath)
-        return true
-      end
-
-      def is_dot_separated_string?(hnBuffer)
-        return true if /[^.]+\.[^.]+/ =~ hnBuffer
-        return false
-      end
-
-      def is_hostname_compliant?(hnBuffer)
-        # RFC 2181:
-        #   Size limit is 1 to 63 octets, so probably bytesize is appropriate method.
-        return false if hnBuffer.nil?
-        return false if /\./ =~ hnBuffer # Hostname by definition may not contain a dot.
-        return false if /:/ =~ hnBuffer # Hostname by definition may not contain a colon.
-        return false unless 1 <= hnBuffer.bytesize && hnBuffer.bytesize <= 63
-        return true
-      end
-
-      def is_like_ipv4_string?(hnBuffer)
-        return false unless /\A#{IPV4_Approximate_REGEX}\z/ =~ hnBuffer
-        qwa = hnBuffer.split('.')
-        return false unless qwa.length == 4
-        return false if qwa[0].to_i == 0
-        qwa.each do |quadwordstring|
-            bi = quadwordstring.to_i
-            # This may need more detail if 255 octets are sometimes allowed, but I don't think so.
-            return false unless 0 <= bi and bi < 255
-        end
-        return true
-      end
-
-      def is_like_ipv6_string?(hnBuffer)
-        return true if /\A#{IPV6_REGEX}\z/ =~ hnBuffer
-        return false
-      end
-
-      def look_for_socket_class_host_address
-        hostname_buffer = nil
-
-        begin
-          hostname_buffer = Socket.gethostname
-        rescue => error
-          OMS::Log.error_once("Unable to get the Host Name using socket facility: #{error}")
-          return
-        end
-        @@Hostname = clean_hostname_string(hostname_buffer)
-
-        return # Thwart accidental return to force correct use.
-      end
-
-      def look_in_designated_hostnamefile
-        # Issue:
-        #   When omsagent runs inside a container, gethostname returns the hostname of the container (random name)
-        #   not the actual machine hostname.
-        #   One way to solve this problem is to set the container hostname same as machine name, but this is not
-        #   possible when host-machine is a private VM inside a cluster.
-        # Solution:
-        #   Share/mount ‘/etc/hostname’ as '/var/opt/microsoft/omsagent/state/containername' with container and
-        #   omsagent will read hostname from shared file.
-        hostname_buffer = nil
-
-        unless File.readable?(@@HostnameFilePath)
-            OMS::Log.warn_once("File '#{@@HostnameFilePath}' exists but is not readable.")
-            return
-        end
-
-        begin
-          hostname_buffer = File.read(@@HostnameFilePath)
-        rescue => error
-          OMS::Log.warn_once("Unable to read the hostname from #{@@HostnameFilePath}: #{error}")
-        end
-        @@Hostname = clean_hostname_string(hostname_buffer)
-        return # Thwart accidental return to force correct use.
-      end
-
-      def validate_hostname_equivalent(hnBuffer)
-        # RFC 1123 and 2181
-        # Note that for now we are limiting the earlier maximum of 63 for fqdn labels and thus
-        # hostnames UNTIL we are assured azure will allow 255, as specified in RFC 1123, or
-        # we are otherwise instructed.
-        rfcl = "RFCs 1123, 2181 with hostname range of {1,63} octets for non-root item."
-        return if is_hostname_compliant?(hnBuffer)
-        return if is_like_ipv4_string?(hnBuffer) 
-        return if is_like_ipv6_string?(hnBuffer)
-        msg = "Hostname '#{hnBuffer}' not compliant (#{rfcl}).  Not IP Address Either."
-        OMS::Log.warn_once(msg)
-        raise NameError, msg
-      end
-
-      # End of Internal methods
-
       # get the unified timezone id by absolute file path of the timezone file
       # file path: the absolute path of the file
       def get_unified_timezoneid(filepath)
@@ -687,19 +578,33 @@ module OMS
         return @@OSVersion
       end
 
-      def get_hostname(ignoreOldValue = false)
+      def get_hostname
+        return @@Hostname if !@@Hostname.nil?
 
-        if not is_hostname_compliant?(@@Hostname) or ignoreOldValue then
+        # Issue:
+        #   When omsagent runs inside a container, gethostname returns the hostname of the container (random name)
+        #   not the actual machine hostname.
+        #   One way to solve this problem is to set the container hostname same as machine name, but this is not
+        #   possible when host-machine is a private VM inside a cluster.
+        # Solution:
+        #   Share/mount ‘/etc/hostname’ as '/var/opt/microsoft/omsagent/state/containername' with container and
+        #   omsagent will read hostname from shared file.
 
-            look_in_designated_hostnamefile         if has_designated_hostnamefile?
-
-            look_for_socket_class_host_address  unless is_hostname_compliant?(@@Hostname)
+        begin
+          if File.exist?(@@HostnameFilePath) && File.readable?(@@HostnameFilePath)
+            @@Hostname = File.read(@@HostnameFilePath).strip
+            return @@Hostname
+          end
+        rescue => error
+          OMS::Log.warn_once("Unable to read the hostname from #{@@HostnameFilePath}: #{error}")
         end
 
         begin
-          validate_hostname_equivalent(@@Hostname)
+          hostname = Socket.gethostname.split(".")[0]
         rescue => error
-          OMS::Log.warn_once("Hostname '#{@@Hostname}' found, but did NOT validate as compliant.  #{error}.  Using anyway.")
+          OMS::Log.error_once("Unable to get the Host Name: #{error}")
+        else
+          @@Hostname = hostname
         end
         return @@Hostname
       end

--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -12,57 +12,7 @@ require_relative ENV['BASE_DIR'] + '/source/code/plugins/agent_common'
 
 module OMS
 
-  TestHostnameList = 
-  [
-          #         Address Type  Compliant Name
-
-    TestHostname.new(:RFC1123Hostname, true,  'onetwo'),
-    TestHostname.new(:RFC1123Hostname, true,  'xxx1234'),
-    TestHostname.new(:RFC1123Hostname, true,  'x'),
-    TestHostname.new(:RFC1123Hostname, true,  'www'),
-    TestHostname.new(:RFC1123Hostname, true,  'Microsoft'),
-    TestHostname.new(:RFC1123Hostname, true,  'xxx123456789012345678901234567890123456789012345678901234567890'),
-
-    TestHostname.new(:RFC1123Hostname, false, ''),
-    TestHostname.new(:RFC1123Hostname, false, 'xxx123456789012345678901234567890123456789012345678901234567890x'),
-    TestHostname.new(:RFC1123Hostname, false, 'one.two'),
-    TestHostname.new(:RFC1123Hostname, false, 'one:two'),
-    TestHostname.new(:RFC1123Hostname, false, 'microsoft.com'),
-    TestHostname.new(:RFC1123Hostname, false, 'microsoft:355'),
-    TestHostname.new(:RFC1123Hostname, false, nil),
-
-    TestHostname.new(:IPv4,            true,  '192.168.0.5'),
-    TestHostname.new(:IPv4,            true,  '1.2.3.4'),
-    TestHostname.new(:IPv4,            true,  '254.254.254.254'),
-    TestHostname.new(:IPv4,            true,  '1.0.0.0'),
-
-    TestHostname.new(:IPv4,            false, ''),
-    TestHostname.new(:IPv4,            false, '192.168.0.256'),
-    TestHostname.new(:IPv4,            false, '1.0.0.444'),
-    TestHostname.new(:IPv4,            false, '192.168.0.A'),
-    TestHostname.new(:IPv4,            false, '0.2.3.4'),
-    TestHostname.new(:IPv4,            false, '1.2.3.255'),
-    TestHostname.new(:IPv4,            false, '255.255.255.255'),
-    TestHostname.new(:IPv4,            false, '192.168.0'),
-    TestHostname.new(:IPv4,            false, '192.168..5'),
-    TestHostname.new(:IPv4,            false, '192.168.0.5.5'),
-    TestHostname.new(:IPv4,            false, '192.168.0.5.A'),
-
-    TestHostname.new(:IPv6,            true,  '2001:0db8:85a3:0000:0000:8a2e:0370:7334'),
-    TestHostname.new(:IPv6,            true,  '1234:DDDD:FFFF:EEEE:3333:8888:7777:1111'),
-    TestHostname.new(:IPv6,            true,  '0db8:85a3:0000:0000:8a2e:0370:7334:f135'),
-
-    TestHostname.new(:IPv6,            false, ''),
-    TestHostname.new(:IPv6,            false, '1000:::::::1000'),
-    TestHostname.new(:IPv6,            false, 'XXXX:0db8:85a3:0000:0000:8a2e:0370:7334'),
-    TestHostname.new(:IPv6,            false, 'xx:0db8:85a3:0000:0000:8a2e:0370:7334'),
-    TestHostname.new(:IPv6,            false, ':0db8:85a3:0000:0000:8a2e:0370:7334'),
-    TestHostname.new(:IPv6,            false, '0db8:85a3:0000:0000:8a2e:0370:7334'),
-    TestHostname.new(:IPv6,            false, ':0db8:85a3:0000:0000:8a2e:0370:7334'),
-  ]
-
   class CommonTest < Test::Unit::TestCase
-    include FlexMock::TestCase
 
     # Extend class to reset OSFullName class variable
     class OMS::Common
@@ -101,10 +51,6 @@ module OMS
 
         def HostnameFilePath=(hostname_file_path)
           @@HostnameFilePath = hostname_file_path
-        end
-
-        def GetHostnameInternalForTest
-          return @@Hostname
         end
       end
     end
@@ -150,106 +96,6 @@ module OMS
       "OSFullName=CentOS Linux 7.0 (x86_64)\n" \
       "OSAlias=UniversalR\n" \
       "OSManufacturer=Central Logistics GmbH\n"
-
-    # Begin:  Tests on Public internals; probably only for use inside the Singular object.
-
-    def test_clean_hostname_string
-      hostname = '        microsoft     '
-      b = Common.clean_hostname_string(hostname)
-      expected = 'microsoft'
-      assert_equal(b, expected, "method clean_hostname_string should return '#{expected}'.")
-      hostname = expected
-      b = Common.clean_hostname_string(hostname)
-      assert_equal(b, expected, "method clean_hostname_string should return '#{expected}'.")
-    end
-
-    def test_has_designated_hostnamefile?
-      container_hostname_tempfile = Tempfile.new('containerhostname')
-      test_hostname = 'test_hostname'
-      Common.HostnameFilePath = container_hostname_tempfile.path
-      File.write(container_hostname_tempfile.path, test_hostname)
-      r = Common.has_designated_hostnamefile?
-      assert(r, "method has_designated_hostnamefile? should see #{container_hostname_tempfile.path} exists at this point.")
-      container_hostname_tempfile.unlink
-      r = Common.has_designated_hostnamefile?
-      assert_false(r, "method has_designated_hostnamefile? should see #{container_hostname_tempfile.path} Does NOT exist at this point.")
-      Common.HostnameFilePath = nil
-      Common.Hostname = nil
-    end
-
-    def test_is_hostname_compliant?
-      TestHostnameList.each do |thno| # thno stands for TestHostname object
-        next unless thno.AddressType == :RFC1123Hostname
-        if thno.SpecCompliant then
-          assert(Common.is_hostname_compliant?(thno.Hostname),       "Common.is_hostname_compliant?(#{thno.Hostname}) should be true.")
-        else
-          assert_false(Common.is_hostname_compliant?(thno.Hostname), "Common.is_hostname_compliant?(#{thno.Hostname}) should NOT be true.")
-        end
-      end
-    end
-
-    def test_is_like_ipv4_string?
-      TestHostnameList.each do |thno| # thno stands for TestHostname object
-        next unless thno.AddressType == :IPv4
-        if thno.SpecCompliant then
-          assert(Common.is_like_ipv4_string?(thno.Hostname),       "Common.is_like_ipv4_string?(#{thno.Hostname}) should be true.")
-        else
-          assert_false(Common.is_like_ipv4_string?(thno.Hostname), "Common.is_like_ipv4_string?(#{thno.Hostname}) should NOT be true.")
-        end
-      end
-    end
-
-    def test_is_like_ipv6_string?
-      TestHostnameList.each do |thno| # thno stands for TestHostname object
-        next unless thno.AddressType == :IPv6
-        if thno.SpecCompliant then
-          assert(Common.is_like_ipv6_string?(thno.Hostname),       "Common.is_like_ipv6_string?(#{thno.Hostname}) should be true.")
-        else
-          assert_false(Common.is_like_ipv6_string?(thno.Hostname), "Common.is_like_ipv6_string?(#{thno.Hostname}) should NOT be true.")
-        end
-      end
-    end
-
-    def test_look_for_socket_class_host_address
-      Common.Hostname = nil
-      Common.look_for_socket_class_host_address
-      hostname = Common.GetHostnameInternalForTest
-      assert(hostname.length > 0, "Hostname internal should be non-zero length.")
-    end
-
-    def test_look_in_designated_hostnamefile
-      container_hostname_tempfile = Tempfile.new('containerhostname')
-      test_hostname = 'test_hostname'
-      Common.HostnameFilePath = container_hostname_tempfile.path
-      File.write(container_hostname_tempfile.path, test_hostname)
-      Common.Hostname = nil
-
-      Common.look_in_designated_hostnamefile
-      hostname = Common.GetHostnameInternalForTest
-      assert_equal(test_hostname, hostname, "Hostname internal should be #{test_hostname} file")
-
-      # Remove container host name file
-      container_hostname_tempfile.unlink
-      Common.Hostname = nil
-      Common.HostnameFilePath = nil
-    end
-
-    def test_validate_hostname_equivalent
-      TestHostnameList.each do |thno| # thno stands for TestHostname object
-        next unless thno.AddressType == :IPv6
-        if thno.SpecCompliant then
-          assert_nothing_raised do
-              Common.validate_hostname_equivalent(thno.Hostname)
-          end
-        else
-          assert_raise NameError do
-              Common.validate_hostname_equivalent(thno.Hostname)
-          end
-        end
-      end
-    end
-
-    # End:  Tests on Public Internals
 
     def test_get_os_full_name()
       File.write(@tmp_conf_file.path, @@OSConf)
@@ -362,40 +208,8 @@ module OMS
       Common.Hostname = nil
       container_hostname_tempfile.unlink
       hostname = Common.get_hostname
-      test_hostname = Socket.gethostname
+      test_hostname = Socket.gethostname.split(".")[0]
       assert_equal(test_hostname, hostname, 'get_hostname should read from Socket.gethostname')
-    end
-
-    def test_get_hostname_as_mocks_from_socket_gethostname
-      result_hostname = nil
-      TestHostnameList.each do |thno| # thno stands for TestHostname object
-        $log = MockLog.new
-        flexmock(Socket, :strict, Socket => :gethostname, :gethostname => thno.Hostname) do
-          load "#{ENV['BASE_DIR']}/source/code/plugins/oms_common.rb"
-          assert_nothing_raised do
-            result_hostname = Common.get_hostname
-          end
-          if thno.Hostname.nil? then
-              assert_equal(result_hostname, '', 'Did not get correct hostname')
-          else
-              assert_equal(result_hostname, thno.Hostname, 'Did not get correct hostname')
-          end
-          if thno.SpecCompliant then
-            assert($log.logs.empty?, "No exception should be logged")
-          else
-            assert_false($log.logs.empty?, "Error should be logged")
-            # Checks on error logs for the validation specifics may be appropriate, but leaving
-            # out for now until there is a task specifying the log text so we don't generate
-            # unknown issues.
-            assert($log.logs[-1].include?('did NOT validate as compliant.'), "Warning in log: #{$log.logs}")
-          end
-        end
-        flexmock(Socket).flexmock_teardown
-        sleep 0.1
-      end
-      # Then back to normal (a validation afterwards would be better, but that is another project)
-      flexmock(Socket).flexmock_teardown
-      load "#{ENV['BASE_DIR']}/source/code/plugins/oms_common.rb"
     end
 
     def test_get_fqdn
@@ -557,7 +371,7 @@ module OMS
       record["DataItems"] = [ {"Message" => "iPhone\u00AE"} ];
       parsed_record = Common.parse_json_record_encoding(record);
       assert_equal("{\"DataItems\":[{\"Message\":\"iPhone®\"}]}", parsed_record, "parse json record utf-8 encoding failed");
-    end
+    end	
     
     def test_safe_dump_simple_hash_array_noerror
       $log = MockLog.new
@@ -567,7 +381,7 @@ module OMS
       assert_equal("[{\"ID\":1,\"Enabled\":true,\"Nil\":null,\"Float\":1.2,\"Message\":\"iPhone®\"}]", json, "parse json record utf-8 encoding failed: #{json}");
 
       assert($log.logs.empty?, "No exception should be logged")
-    end
+    end	
     
     def test_safe_dump_non_ascii_hash_array_noerror
       $log = MockLog.new

--- a/test/code/plugins/omstestlib.rb
+++ b/test/code/plugins/omstestlib.rb
@@ -41,36 +41,4 @@ module OMS
     end
   end
 
-  class TestHostname
-    attr_reader :AddressType
-    attr_reader :Hostname
-    attr_reader :SpecCompliant
-
-    def initialize(addressTypeArg=:RFC1123Hostname,specComplianceArg,hostNameArg)
-      case addressTypeArg
-        when :RFC1123Hostname
-          @AddressType = addressTypeArg
-        when :IPv4
-          @AddressType = addressTypeArg
-        when :IPv6
-          @AddressType = addressTypeArg
-        else
-          raise TypeError, "#{addressTypeArg} not a valid address type for these tests."
-      end
-
-        # NOTE:  As of 2017/10/04 Spec Compliant is presumed to mean the hostname string
-        # is any of:
-        # 1.  A valid hostname according to RFC 1123, but taking the lower maximum size of 63 until otherwise instructed.
-        # 2.  A valid IPv4 address.
-        # 3.  A valid IPv6 address.
-      if [true, false].include? specComplianceArg
-        @SpecCompliant = specComplianceArg
-      else
-        raise TypeError, "#{specComplianceArg} must be explicitly true or false."
-      end
-
-      @Hostname = hostNameArg
-    end
-  end
-
 end


### PR DESCRIPTION
This reverts commit 8c81f4c7f94583384f7e253ae2be5b85118537cb.
#582 incorrectly assumed that Socket.gethostname would never return FQDN. Based on this assumption they ran
`hostname_buffer = Socket.gethostname`
rather than the original
`hostname = Socket.gethostname.split(".")[0]`

For the sake of safety we are reverting the entire commit; since this change was never in DSC modules, all agents have essentially been running with the "old" code for 2 years anyways without issue.