### PR TITLE
Fix invalid logrotate generation

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -1141,7 +1141,7 @@ configure_logrotate()
 
     # create the logrotate file for omsagent if workspace is LAD
     if [ "$WORKSPACE_ID" = "LAD" ]; then
-        echo "/var/opt/microsoft/omsagent/LAD/log/omsagent.log {\n\trotate 10\n\tmissingok\n\tnotifempty\n\tcompress\n\tsize 100M\n\tcopytruncate\n}" > /etc/logrotate.d/omsagent-$WORKSPACE_ID
+        echo -e "/var/opt/microsoft/omsagent/LAD/log/omsagent.log {\n\trotate 10\n\tmissingok\n\tnotifempty\n\tcompress\n\tsize 100M\n\tcopytruncate\n}" > /etc/logrotate.d/omsagent-$WORKSPACE_ID
     else
     	# create the logrotate file for the workspace if it doesn't exist
     	if [ ! -f /etc/logrotate.d/omsagent-$WORKSPACE_ID ]; then


### PR DESCRIPTION
#1111

`-e` option is required for `echo`

```
$ echo "/var/opt/microsoft/omsagent/LAD/log/omsagent.log {\n\trotate 10\n\tmissingok\n\tnotifempty\n\tcompress\n\tsize 100M\n\tcopytruncate\n}"
/var/opt/microsoft/omsagent/LAD/log/omsagent.log {\n\trotate 10\n\tmissingok\n\tnotifempty\n\tcompress\n\tsize 100M\n\tcopytruncate\n}
```

```
$ echo -e "/var/opt/microsoft/omsagent/LAD/log/omsagent.log {\n\trotate 10\n\tmissingok\n\tnotifempty\n\tcompress\n\tsize 100M\n\tcopytruncate\n}"
/var/opt/microsoft/omsagent/LAD/log/omsagent.log {
        rotate 10
        missingok
        notifempty
        compress
        size 100M
        copytruncate
}
```