### PR TITLE
Added support for HybridRP IMDS Endpoint 

### DIFF
--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -189,6 +189,10 @@ module OMS
             azure_resource_id = imds_instance_json_compute['resourceID']
             
             return azure_resource_id
+          else
+            #config file containing HyrbidRP IMDS endpoint not found. 
+            raise "The config file #{@@HybridRPConfFile} containing the HybridRP IMDS Endpoint is not found."
+          end
         rescue
           # this may be a container instance or a non Hybrid Agent VM
           OMS::Log.warn_once("Could not fetch Azure Resource ID from IMDS, Reason: #{e}")
@@ -211,11 +215,13 @@ module OMS
                 if azure_resource_id.nil?
                   sleep (retries * 120)
                   retries += 1
-                  next                  
+                  next  
+                end                
               else
                 sleep (retries * 120)
                 retries += 1
                 next
+              end
             end
 
             @@AzureResourceId = azure_resource_id unless @@AzureResourceId == azure_resource_id

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -191,11 +191,12 @@ module OMS
             return azure_resource_id
           else
             #config file containing HyrbidRP IMDS endpoint not found. 
-            raise "The config file #{@@HybridRPConfFile} containing the HybridRP IMDS Endpoint is not found."
+            OMS::Log.warn_once("The config file #{@@HybridRPConfFile} containing the HybridRP IMDS Endpoint is not found.")
+            return nil
           end
         rescue
           # this may be a container instance or a non Hybrid Agent VM
-          OMS::Log.warn_once("Could not fetch Azure Resource ID from IMDS, Reason: #{e}")
+          OMS::Log.warn_once("Could not fetch Azure Resource ID from HybridRP IMDS, Reason: #{e}")
           return nil
         end
       end

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -194,8 +194,8 @@ module OMS
             
             return azure_resource_id
           else
-            #config file containing HyrbidRP IMDS endpoint not found. 
-		        OMS::Log.warn_once("Could not find the config file #{@@HybridRPConfFile} containing the HybridRP IMDS Endpoint. Failed to fetch azure resource id.")
+            #config file containing HyrbidRP IMDS endpoint not found.
+            OMS::Log.warn_once("Could not find the config file #{@@HybridRPConfFile} containing the HybridRP IMDS Endpoint. Failed to fetch azure resource id.")
             return nil
           end
         rescue

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -211,22 +211,17 @@ module OMS
 
           loop do
             break if retries > max_retries
-            azure_resource_id = get_azure_resid_from_imds()
+            #Check if this is a non azure Hybrid Agent VM
+            if system("azcmagent show >/dev/null")
+              OMS::Log.info_once("This is an Azure Arc VM")
+              azure_resource_id = get_azure_resid_from_hybridagent()
+            else
+              azure_resource_id = get_azure_resid_from_imds()
+            end
             if azure_resource_id.nil?
-              #Check if this is a non azure Hybrid Agent VM
-              if system("azcmagent show >/dev/null")
-                OMS::Log.info_once("This is an Azure Arc VM")
-                azure_resource_id = get_azure_resid_from_hybridagent()
-                if azure_resource_id.nil?
-                  sleep (retries * 120)
-                  retries += 1
-                  next  
-                end                
-              else
-                sleep (retries * 120)
-                retries += 1
-                next
-              end
+              sleep (retries * 120)
+              retries += 1
+              next
             end
 
             @@AzureResourceId = azure_resource_id unless @@AzureResourceId == azure_resource_id

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -168,9 +168,13 @@ module OMS
           if File.file?(@@HybridRPConfFile)
             OMS::Log.info_once("Using The HybridRP IMDS_Endpoint to fetch resource id")
             data = File.read(@@HybridRPConfFile)
-            azureHybridIMDSEndpoint = data.scan(/"IMDS_ENDPOINT=.*"?/)[0].split("=")[1][0..-2]
+            azureHybridIMDSEndpoint = data.scan(/"IMDS_ENDPOINT=.*"?/)[0]
+            if azureHybridIMDSEndpoint.nil?
+              OMS::Log.warn_once("Failed to read the IMDS Endpoint from #{@@HybridRPConfFile}. Failed to fetch azure resource id")
+              return nil
+            end
+            azureHybridIMDSEndpoint = azureHybridIMDSEndpoint.split("=")[1][0..-2]
             azureHybridIMDSEndpoint += @@HyrbidRPIMDSPath + "?api-version=" + @@HybridRPAPIVersion
-
             uri = URI.parse(azureHybridIMDSEndpoint)
             http_get_req = Net::HTTP::Get.new(uri, initheader = {'Metadata' => 'true'})
             http_req = Net::HTTP.new(uri.host, uri.port)
@@ -191,7 +195,7 @@ module OMS
             return azure_resource_id
           else
             #config file containing HyrbidRP IMDS endpoint not found. 
-            OMS::Log.warn_once("The config file #{@@HybridRPConfFile} containing the HybridRP IMDS Endpoint is not found.")
+		        OMS::Log.warn_once("Could not find the config file #{@@HybridRPConfFile} containing the HybridRP IMDS Endpoint. Failed to fetch azure resource id.")
             return nil
           end
         rescue


### PR DESCRIPTION
oms_configuration.rb now checks if hybrid agent is installed on a VM and if it is, then it grabs the IMDS endpoint for the HybridRP from the config file located on the VM and queries that to get the Azure Resource ID. 

Testing Strategy - (Checked whether the following work as expected and report errors correctly)
1. Install the oms build into a VM without Hybrid agent (No Resource id found, heartbeat doesnt have all VM data)
2. Install Hybrid agent and restart and reinstall omsagent (HyrbidRP IMDS Resource id queried and used successfully)
3. Install oms build on Azure VMs (Regular IMDS resource id created and used successfully)