### PR TITLE
Ods rate limiting

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -106,8 +106,9 @@ If none of these steps work for you the following channels for help are also ava
   buffer_path /var/opt/microsoft/omsagent/<workspace id>/state/out_oms*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
+  max_retry_wait 30m
 </match>
  ```
 
@@ -136,8 +137,9 @@ Comment out the OMS output plugin by adding a `#` in front of each line
 #  buffer_path /var/opt/microsoft/omsagent/<workspace id>/state/out_oms*.buffer
 #  buffer_queue_limit 10
 #  flush_interval 20s
-#  retry_limit 10
+#  retry_limit 6
 #  retry_wait 30s
+#  max_retry_wait 30m
 #</match>
 ```
 

--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -59,7 +59,7 @@
   flush_interval 60s
   retry_limit 10
   retry_wait 30s
-  max_retry_wait 9m
+  max_retry_wait 30m
 </match>
 
 <match oms.** docker.**>
@@ -81,7 +81,7 @@
   flush_interval 20s
   retry_limit 10
   retry_wait 30s
-  max_retry_wait 9m
+  max_retry_wait 30m
 </match>
 
 <match diag.oms diag.oms.**>
@@ -103,7 +103,7 @@
   flush_interval 10s
   retry_limit 10
   retry_wait 30s
-  max_retry_wait 9m
+  max_retry_wait 30m
 </match>
 
 # Catch all unprocessed data and output it

--- a/installer/conf/omsagent.conf
+++ b/installer/conf/omsagent.conf
@@ -57,7 +57,7 @@
   buffer_queue_limit 10
   buffer_queue_full_action drop_oldest_chunk
   flush_interval 60s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
   max_retry_wait 30m
 </match>
@@ -79,7 +79,7 @@
   buffer_queue_limit 10
   buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
   max_retry_wait 30m
 </match>
@@ -101,7 +101,7 @@
   buffer_queue_limit 50
   buffer_queue_full_action drop_oldest_chunk
   flush_interval 10s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
   max_retry_wait 30m
 </match>

--- a/installer/conf/omsagent.d/apache_logs.conf
+++ b/installer/conf/omsagent.d/apache_logs.conf
@@ -61,7 +61,7 @@
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_apache*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
-  retry_wait 5s
-  max_retry_wait 5m
+  retry_limit 6
+  retry_wait 30s
+  max_retry_wait 30m
 </match>

--- a/installer/conf/omsagent.d/auditlog.conf
+++ b/installer/conf/omsagent.d/auditlog.conf
@@ -24,9 +24,9 @@
   buffer_path /var/opt/microsoft/omsagent/state/var_log_audit_audit_log*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
-  retry_wait 5s
-  max_retry_wait 5m
+  retry_limit 6
+  retry_wait 30s
+  max_retry_wait 30m
 
   compress true
 </match>

--- a/installer/conf/omsagent.d/mongo.conf
+++ b/installer/conf/omsagent.d/mongo.conf
@@ -37,7 +37,8 @@
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_workload_mongo*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
+  max_retry_wait 30m
 </match>
 

--- a/installer/conf/omsagent.d/monitor.conf
+++ b/installer/conf/omsagent.d/monitor.conf
@@ -30,8 +30,8 @@
   buffer_queue_limit 5
   buffer_queue_full_action drop_oldest_chunk
   flush_interval 20s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
-  max_retry_wait 5m
+  max_retry_wait 30m
 </match>
 

--- a/installer/conf/omsagent.d/mysql_logs.conf
+++ b/installer/conf/omsagent.d/mysql_logs.conf
@@ -88,7 +88,7 @@
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_mysql_logs*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
-  retry_wait 5s
-  max_retry_wait 5m
+  retry_limit 6
+  retry_wait 30s
+  max_retry_wait 30m
 </match>

--- a/installer/conf/omsagent.d/postgresql_logs.conf
+++ b/installer/conf/omsagent.d/postgresql_logs.conf
@@ -30,7 +30,7 @@
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_postgres*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
-  retry_wait 5s
-  max_retry_wait 5m
+  retry_limit 6
+  retry_wait 30s
+  max_retry_wait 30m
 </match>

--- a/installer/conf/omsagent.d/vmware_esxi.conf
+++ b/installer/conf/omsagent.d/vmware_esxi.conf
@@ -25,6 +25,7 @@
   buffer_path /var/opt/microsoft/omsagent/state/out_oms_api_vmware_logs*.buffer
   buffer_queue_limit 10
   flush_interval 20s
-  retry_limit 10
+  retry_limit 6
   retry_wait 30s
+  max_retry_wait 30m
 </match>

--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -732,6 +732,11 @@ module OMS
           headers["Content-Encoding"] = "deflate"
         end
 
+        headers["User-Agent"] = "LinuxMonitoringAgent/#{OMS::Common.get_agent_version}"
+        headers[OMS::CaseSensitiveString.new("x-ms-app")] = "LinuxMonitoringAgent"
+        headers[OMS::CaseSensitiveString.new("x-ms-client-version")] = OMS::Common.get_agent_version
+        headers[OMS::CaseSensitiveString.new("x-ms-client-platform")] = "Linux"
+
         req = Net::HTTP::Post.new(path, headers)
         json_msg = serializer.call(record)
         if json_msg.nil?

--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -653,7 +653,7 @@ module OMS
           end
         end
 
-        return '0.0.0-0' if @@AgentVersion.nil? : @@AgentVersion
+        return @@AgentVersion.nil? ? '0.0.0-0': @@AgentVersion
       end
 
       def fast_utc_to_iso8601_format(utctime, fraction_digits=3)

--- a/source/code/plugins/oms_common.rb
+++ b/source/code/plugins/oms_common.rb
@@ -652,7 +652,8 @@ module OMS
             @@AgentVersion = agent_version
           end
         end
-        return @@AgentVersion
+
+        return '0.0.0-0' if @@AgentVersion.nil? : @@AgentVersion
       end
 
       def fast_utc_to_iso8601_format(utctime, fraction_digits=3)

--- a/source/code/plugins/out_oms.rb
+++ b/source/code/plugins/out_oms.rb
@@ -54,7 +54,10 @@ module Fluent
 
     def handle_record(key, record)
       @log.trace "Handling record : #{key}"
-      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record, @compress)
+      extra_headers = {
+        OMS::CaseSensitiveString.new('x-ms-client-request-retry-count') => "#{@num_errors}"
+      }
+      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record, @compress, extra_headers)
       unless req.nil?
         http = OMS::Common.create_ods_http(OMS::Configuration.ods_endpoint, @proxy_config)
         start = Time.now

--- a/source/code/plugins/out_oms_api.rb
+++ b/source/code/plugins/out_oms_api.rb
@@ -58,7 +58,9 @@ module Fluent
     #   time_generated_field_name: string. name of the time generated field
     #   records: hash[]. an array of data
     def post_data(log_type, time_generated_field_name, records, request_id)
-      headers = {}
+      headers = {
+        OMS::CaseSensitiveString.new('x-ms-client-request-retry-count') => "#{@num_errors}"
+      }
       headers[OMS::CaseSensitiveString.new("Log-Type")] = log_type
       headers[OMS::CaseSensitiveString.new("x-ms-date")] = Time.now.utc.httpdate()
 

--- a/source/code/plugins/out_oms_blob.rb
+++ b/source/code/plugins/out_oms_blob.rb
@@ -130,7 +130,10 @@ module Fluent
         "SupportWriteOnlyBlob" => true
       }
 
-      req = OMS::Common.create_ods_request(OMS::Configuration.get_blob_ods_endpoint.path, data, compress=false)
+      extra_headers = {
+        OMS::CaseSensitiveString.new('x-ms-client-request-retry-count') => "#{@num_errors}"
+      }
+      req = OMS::Common.create_ods_request(OMS::Configuration.get_blob_ods_endpoint.path, data, compress=false, extra_headers)
 
       ods_http = OMS::Common.create_ods_http(OMS::Configuration.get_blob_ods_endpoint, @proxy_config)
       body = OMS::Common.start_request(req, ods_http)

--- a/source/code/plugins/out_oms_changetracking_file.rb
+++ b/source/code/plugins/out_oms_changetracking_file.rb
@@ -383,7 +383,10 @@ module Fluent
 
     def handle_record_internal(key, record)
       @log.trace "Handling record : #{key}"
-      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record, @compress)
+      extra_headers = {
+        OMS::CaseSensitiveString.new('x-ms-client-request-retry-count') => "#{@num_errors}"
+      }
+      req = OMS::Common.create_ods_request(OMS::Configuration.ods_endpoint.path, record, @compress, extra_headers)
       unless req.nil?
         http = OMS::Common.create_ods_http(OMS::Configuration.ods_endpoint, @proxy_config)
         start = Time.now

--- a/source/code/plugins/out_oms_diag.rb
+++ b/source/code/plugins/out_oms_diag.rb
@@ -39,7 +39,10 @@ module Fluent
 
     def handle_record(ipname, record)
       @log.trace "Handling diagnostic records for ipname : #{ipname}"
-      req = OMS::Common.create_ods_request(OMS::Configuration.diagnostic_endpoint.path, record, @compress)
+      extra_headers = {
+        OMS::CaseSensitiveString.new('x-ms-client-request-retry-count') => "#{@num_errors}"
+      }
+      req = OMS::Common.create_ods_request(OMS::Configuration.diagnostic_endpoint.path, record, @compress, extra_headers)
       unless req.nil?
         http = OMS::Common.create_ods_http(OMS::Configuration.diagnostic_endpoint, @proxy_config)
         start = Time.now

--- a/test/code/plugins/VMInsightsDataCollector_subtest.rb
+++ b/test/code/plugins/VMInsightsDataCollector_subtest.rb
@@ -356,7 +356,10 @@ module VMInsights
             IO.popen("#{DF} --type=ext2 --type=ext3 --type=ext4 --block-size=1 | awk '{print $1,$6,$2}' | tail -n +2", { :in => :close}) { |io|
                 data = io.readlines
                 data.each { |line|
-                    raise ArgumentError, line unless line.start_with?("/dev/")
+                    if !line.start_with?("/dev/")
+                        puts "Warning: Line doesn't start with #{line}, will be skiped"
+                        next
+                    end
                     s = line.split(" ")
                     key = s[0].sub(/^\/dev\//, '')
                     omit "#{key} is mounted multiple times. Running in a container" if expected.has_key? key

--- a/test/code/plugins/heartbeat_lib_test.rb
+++ b/test/code/plugins/heartbeat_lib_test.rb
@@ -78,11 +78,11 @@ class HeartbeatLib_Test < Test::Unit::TestCase
     assert(heartbeat_data_item.has_key?("OSType"))
     assert(heartbeat_data_item.has_key?("Category"))
     assert(heartbeat_data_item.has_key?("SCAgentChannel"))
+    assert(heartbeat_data_item.has_key?("Version"))
     assert(!heartbeat_data_item.has_key?("OSName"))
     assert(!heartbeat_data_item.has_key?("OSMajorVersion"))
     assert(!heartbeat_data_item.has_key?("OSMinorVersion"))
     assert(!heartbeat_data_item.has_key?("InstalledDate"))
-    assert(!heartbeat_data_item.has_key?("Version"))
   end
 
   # wrapper to call get heartbeat

--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -237,7 +237,8 @@ module OMS
       fake_conf_path = @tmp_conf_file.path + '.fake'
       assert_equal(false, File.file?(fake_conf_path))
       agent_version = Common.get_agent_version(fake_conf_path)
-      assert_equal(nil, agent_version, "Should not find data in a non existing file")
+      assert_equal(nil, Common.AgentVersion, "Should not find data in a non existing file")
+      assert_equal('0.0.0-0', agent_version, "Should not find data in a non existing file")
 
       # Should retry the second time since it did not find anything before
       File.write(@tmp_conf_file.path, "1.1.0-124 20160412\n2016-05-24T00:27:55.0Z")
@@ -249,7 +250,8 @@ module OMS
       conf = "  "
       File.write(@tmp_conf_file.path, conf)
       agent_version = Common.get_agent_version(@tmp_conf_file.path)
-      assert_equal(nil, agent_version, "Should not find data when line is missing")
+      assert_equal(nil, Common.AgentVersion, "Should not find data when line is missing")
+      assert_equal('0.0.0-0', agent_version, "Should not find data when line is missing")
     end
 
     def test_get_installed_date()

--- a/test/code/plugins/oms_common_test.rb
+++ b/test/code/plugins/oms_common_test.rb
@@ -237,7 +237,6 @@ module OMS
       fake_conf_path = @tmp_conf_file.path + '.fake'
       assert_equal(false, File.file?(fake_conf_path))
       agent_version = Common.get_agent_version(fake_conf_path)
-      assert_equal(nil, Common.AgentVersion, "Should not find data in a non existing file")
       assert_equal('0.0.0-0', agent_version, "Should not find data in a non existing file")
 
       # Should retry the second time since it did not find anything before
@@ -250,7 +249,6 @@ module OMS
       conf = "  "
       File.write(@tmp_conf_file.path, conf)
       agent_version = Common.get_agent_version(@tmp_conf_file.path)
-      assert_equal(nil, Common.AgentVersion, "Should not find data when line is missing")
       assert_equal('0.0.0-0', agent_version, "Should not find data when line is missing")
     end
 


### PR DESCRIPTION
Send more headers to ODS like: User-Agent, retry-count.
Set the correct exponential back off configuration to match requirements: retry timeout of 30 seconds up to 6 attempts during ~30 mins.