### PR TITLE
Topology Request Interval Nil Check

### DIFF
--- a/source/code/plugins/in_agent_telemetry.rb
+++ b/source/code/plugins/in_agent_telemetry.rb
@@ -22,7 +22,7 @@ module Fluent
     config_param :os_info, :string, :default => '/etc/opt/microsoft/scx/conf/scx-release' #optional
     config_param :install_info, :string, :default => '/etc/opt/microsoft/omsagent/sysconf/installinfo.txt' #optional
 
-    MIN_QUERY_INTERVAL = 1
+    MIN_QUERY_INTERVAL = 60
     MAX_QUERY_INTERVAL = 60 * 60 * 1
 
     def configure (conf)

--- a/source/code/plugins/in_heartbeat_request.rb
+++ b/source/code/plugins/in_heartbeat_request.rb
@@ -21,7 +21,7 @@ module Fluent
     config_param :os_info, :string, :default => '/etc/opt/microsoft/scx/conf/scx-release' #optional
     config_param :install_info, :string, :default => '/etc/opt/microsoft/omsagent/sysconf/installinfo.txt' #optional
 
-    MIN_QUERY_INTERVAL = 1
+    MIN_QUERY_INTERVAL = 60
     MAX_QUERY_INTERVAL = 60 * 60 * 24 * 7
 
     def configure (conf)
@@ -69,7 +69,7 @@ module Fluent
       @maintenance_script.heartbeat
       if defined?(OMS::Configuration.topology_interval)
         query_interval = OMS::Configuration.topology_interval
-        @run_interval = query_interval if query_interval.between?(MIN_QUERY_INTERVAL, MAX_QUERY_INTERVAL)
+        @run_interval = query_interval if !query_interval.nil? and query_interval.between?(MIN_QUERY_INTERVAL, MAX_QUERY_INTERVAL)
       end
     end
 


### PR DESCRIPTION
[Mooncake 174114364] Ensure topology request plugin will not crash when parsing request intervals from topology response fails for whatever reason. This replicates the check that was [already in place](https://github.com/microsoft/OMS-Agent-for-Linux/blob/master/source/code/plugins/in_agent_telemetry.rb#L74) for telemetry (which worked—telemetry requests were continuing every 5m despite failed parse). 

Also, noticed MIN_QUERY_INTERVALs were incorrectly low (interval is in seconds). 