### PR TITLE
Generate DSC Metaconfig

### DIFF
--- a/source/code/plugins/agent_maintenance_script.rb
+++ b/source/code/plugins/agent_maintenance_script.rb
@@ -123,6 +123,7 @@ module MaintenanceModule
     # Update omsadmin.conf with the specified variable's value
     def update_config(var, val)
       if !File.exist?(@omsadmin_conf_path)
+        log_error("Missing configuration file: #{@omsadmin_conf_path}")
         return OMS::MISSING_CONFIG_FILE
       end
 
@@ -132,6 +133,10 @@ module MaintenanceModule
       File.open(@omsadmin_conf_path, "w") { |file|
         file.puts(new_text)
       }
+
+      if old_text != new_text
+        log_info("omsadmin.conf updated with #{var}=#{val}")
+      end
     end
 
     # Updates the CERTIFICATE_UPDATE_ENDPOINT variable and renews certificate if requested
@@ -233,6 +238,7 @@ module MaintenanceModule
     # Save DSC_ENDPOINT and CERTIFICATE_UPDATE_ENDPOINT variables in file to be read outside of this script
     def apply_endpoints_file(xml_file, output_file)
       if !OMS::Common.file_exists_nonempty(xml_file)
+        log_error("Missing configuration file: #{xml_file}")
         return OMS::MISSING_CONFIG_FILE
       end
 

--- a/source/code/plugins/in_heartbeat_request.rb
+++ b/source/code/plugins/in_heartbeat_request.rb
@@ -71,6 +71,7 @@ module Fluent
         query_interval = OMS::Configuration.topology_interval
         @run_interval = query_interval if !query_interval.nil? and query_interval.between?(MIN_QUERY_INTERVAL, MAX_QUERY_INTERVAL)
       end
+      @maintenance_script.generate_dsc_metaconfig
     end
 
     def run_periodic

--- a/source/code/plugins/oms_configuration.rb
+++ b/source/code/plugins/oms_configuration.rb
@@ -304,13 +304,13 @@ module OMS
             @@AzureResourceId = ENV['customResourceId']
             
             # Only if environment variable is empty/nil load it from imds and refresh it periodically.
-            if @@AzureResourceId.nil? || @@AzureResourceId.empty?              
+            if @@AzureResourceId.nil? || @@AzureResourceId.empty?
               @@AzureResourceId = line.sub("AZURE_RESOURCE_ID=","").strip
               if @@AzureResourceId.include? "Microsoft.ContainerService"
-                OMS::Log.info_once("Azure resource id in configuration file is for AKS. It will be used")                  
+                OMS::Log.info_once("Azure resource id in configuration file is for AKS. It will be used")
               else
                 Thread.new(&method(:update_azure_resource_id)) if @@AzureResIDThreadLock.try_lock
-              end            
+              end
             else
               OMS::Log.info_once("There is non empty value set for overriden-resourceId environment variable. It will be used")
             end
@@ -334,7 +334,7 @@ module OMS
               @@UUID = uuid_str
             else
               @@UUID = "00000000-0000-0000-0000-000000000000" 
-            end          
+            end
           end
         end
 
@@ -363,6 +363,15 @@ module OMS
         @@TelemetryInterval = telemetry_interval
         OMS::Log.info_once("OMS agent management service topology request interval now #{@@TopologyInterval}")
         OMS::Log.info_once("OMS agent management service telemetry request interval now #{@@TelemetryInterval}")
+      end
+
+      # Check whether DSC has been disabled (which prevents automatic config management)
+      def is_dsc_disabled
+        begin
+          return File.exist?("/etc/opt/omi/conf/omsconfig/omshelper_disable")
+        rescue => e
+          OMS::Log.error_once("Failed to get DSC enabled/disabled status. #{e}")
+        end
       end
 
       def cert


### PR DESCRIPTION
CRI 177130188
ADO 6369194

Need to regenerate DSC metaconfig when we get DSC endpoint in topology request response. Testing methodology:
- emplace modified `agent_maintenance_script.rb`
- `/opt/microsoft/omsagent/bin/service_control restart`
- modify `DSC_ENDPOINT` in `omsadmin.conf` with fake value
- `su - omsagent -c /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py`
- check that `/etc/opt/omi/conf/omsconfig/generated_meta_config.mof` has new fake value
- wait for topology request, check `generated_meta_config.mof` again for replaced, corrected value