### PR TITLE
Added check to prevent onboarding to a workspace if omsagent is stopped

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -460,11 +460,7 @@ onboard()
     # If a test is not in progress then call service_control to check on the workspace status
     if [ -z "$TEST_WORKSPACE_ID" -a -z "$TEST_SHARED_KEY" ]; then
         $SERVICE_CONTROL is-running $WORKSPACE_ID > /dev/null 2>&1
-        #The service_control is-running method will always return 1 for workspaces that are not currently onboarded because the check method exits with error code 1 in that script
-        #But since we check for exit code 1 as success, it assumes the agent is running on that workspace and prevents onboarding. This can be fixed by using exit code 0 for 
-        #success, as is convention in Linux. But since Multihoming isn't currently supported, this actually acts as a prevention check for multihoming. After discussion, leaving it
-        #as it is for now. Can fix this in future when we want to support multihoming. 
-        if [ $? -eq 1 ]; then
+        if [ $? -eq 0 ]; then
             echo "Workspace $WORKSPACE_ID already onboarded and agent is running."
             if [ -z "$MULTI_HOMING_MARKER" -a ! -h $DF_CONF_DIR ]; then
                 echo "Symbolic links have not been created; re-onboarding to create them"
@@ -791,9 +787,9 @@ show_workspace_status()
     local is_primary=$3
     local status='Unknown'
 
-    # 1 if omsagent-ws_id is running, 0 otherwise
+    # 0 if omsagent-ws_id is running, 1 otherwise
     $SERVICE_CONTROL is-running $ws_id
-    if [ $? -eq 1 ]; then
+    if [ $? -eq 0 ]; then
         status='Onboarded(OMSAgent Running)'
     elif [ -f ${ws_conf_dir}/.service_registered ]; then
         status='Warning(OMSAgent Registered, Not Running)'

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -476,7 +476,6 @@ onboard()
     local ws_conf_dir=$ETC_DIR/conf
 
     if [ -h ${ws_conf_dir} ]; then
-        # symbolic link - multiple workspace folder structure
         local primary_ws_id=''
         if [ -f ${ws_conf_dir}/omsadmin.conf ]; then
             primary_ws_id=`grep WORKSPACE_ID ${ws_conf_dir}/omsadmin.conf | cut -d= -f2`

--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -469,6 +469,40 @@ onboard()
             fi
         fi
     fi
+
+    #check for workspaces alredy onboarded
+
+    local found_ws=0
+    local ws_conf_dir=$ETC_DIR/conf
+
+    if [ -h ${ws_conf_dir} ]; then
+        # symbolic link - multiple workspace folder structure
+        local primary_ws_id=''
+        if [ -f ${ws_conf_dir}/omsadmin.conf ]; then
+            primary_ws_id=`grep WORKSPACE_ID ${ws_conf_dir}/omsadmin.conf | cut -d= -f2`
+        fi
+
+        if [ "${primary_ws_id}" != "" ]; then
+            found_ws=1
+        else
+            for ws_id in `ls -1 $ETC_DIR | grep -E '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'`
+            do
+                found_ws=1
+            done
+        fi
+    else
+        # no default conf folder, check all the potential workspace folders
+        for ws_id in `ls -1 $ETC_DIR | grep -E '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'`
+        do
+            found_ws=1
+        done
+    fi
+
+    if [ $found_ws -ne 0 ]; then
+        echo "Already Onboarded to a workspace, please un-onboard first before trying to onboard to a new workspace"
+        return 0
+    fi
+
     create_workspace_directories $WORKSPACE_ID
 
     # Guard against blank omsadmin.conf

--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -248,16 +248,13 @@ this_omsagent_running()
 
 is_omsagent_running()
 {
-    # Returns 1 if 'omsagent' is running, 0 otherwise
-    #### Keeping return value on this as it originally was.  I deduce
-    #### that because this value is returned with the is-running qualifier
-    #### to service_control, that there are scripts in other languages
-    #### that use the more conventional values for booleans.  Meanwhile,
-    #### I recommend deprecation in all but the external interface.  XC
+    # Returns 0 if 'omsagent' is running, 1 otherwise
+    #### Changed the old behavior of returning 1 for true 0 for false
+    #### because the script would always wrongly return 1 for new ws-id
     if this_omsagent_running; then
-        return 1
-    else
         return 0
+    else
+        return 1
     fi
 } 
 


### PR DESCRIPTION
Currently if the omsagent is not running, then omsadmin.s -w <ws-id> -s <ws-key> command will allow it to re-onboard to the same workspace. This is because we only currently only check if the agent is running or stopped and if it is stopped we go forward with the onboarding. To prevent this, I added checks to make sure that if a workspace is already onboarded, regardless of the status of omsagent, we do not onboard, but rather ask the cx to un-onboard first. 
