### PR TITLE
Keep Cisco event Id

### DIFF
--- a/source/code/plugins/security_lib.rb
+++ b/source/code/plugins/security_lib.rb
@@ -15,9 +15,9 @@ module OMS
 
     def self.get_ident(ident)
       # To allow a more flexible regex we accept any message containing 'CEF'
-      # or '%ASA' as a valid message and converting it into the correct identifier
       return 'CEF' if ident.include?('CEF')
-      return '%ASA' if ident.include?('%ASA')
+      # For Cisco we would like to keep the event ID attached
+      return ident if ident.include?('%ASA')
       OMS::Log.warn_once("Failed to find ident: '#{ident}'")
       return nil
     end


### PR DESCRIPTION
During the extraction of the identifier from Cisco ASA we removed the event ID.

In this PR we keep the event ID in the Identifier instead of returning just "%ASA"