### PR TITLE
Improve package manager detection

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -293,21 +293,31 @@ ulinux_detect_installer()
 {
     INSTALLER=
 
-    # If DPKG lives here, assume we use that. Otherwise we use RPM.
-    check_if_program_in_path dpkg
-    if [ $? -eq 0 ]; then
+    ID_LIKE=$(cat /etc/*-release | uniq -u | grep -i ID_LIKE)
+
+    if [[ $ID_LIKE == *"debian"* ]]; then 
         INSTALLER=DPKG
+    elif [[ $ID_LIKE == *"rhel"* || $ID_LIKE == *"fedora"* ]]
+	INSTALLER=RPM
     else
-      check_if_program_in_path rpm
-      if [ $? -eq 0 ]; then
-        INSTALLER=RPM
-      else
-        #Exit with code 51 if system is not deb or rpm
-        echo "Error: This system does not have supported package manager"
-        echo "Supported Sytems: 'DPKG' & 'RPM'"
-        cleanup_and_exit $UNSUPPORTED_PKG_INSTALLER
-      fi
+	# Falling back to blindly detecting package managers if we're unable to determine ID_LIKE from release file.
+        # If DPKG lives here, assume we use that. Otherwise we use RPM.
+        check_if_program_in_path dpkg
+        if [ $? -eq 0 ]; then
+            INSTALLER=DPKG
+        else
+          check_if_program_in_path rpm
+          if [ $? -eq 0 ]; then
+            INSTALLER=RPM
+          else
+            #Exit with code 51 if system is not deb or rpm
+            echo "Error: This system does not have supported package manager"
+            echo "Supported Sytems: 'DPKG' & 'RPM'"
+            cleanup_and_exit $UNSUPPORTED_PKG_INSTALLER
+          fi
+        fi
     fi
+
 }
 
 # $1 - The name of the package to check as to whether it's installed

--- a/installer/scripts/uninstall.sh
+++ b/installer/scripts/uninstall.sh
@@ -19,13 +19,23 @@ ulinux_detect_installer()
 {
     INSTALLER=
 
-    # If DPKG lives here, assume we use that. Otherwise we use RPM.
-    which dpkg > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
+    ID_LIKE=$(cat /etc/*-release | uniq -u | grep -i ID_LIKE)
+
+    if [[ $ID_LIKE == *"debian"* ]]; then 
         INSTALLER=DPKG
+    elif [[ $ID_LIKE == *"rhel"* || $ID_LIKE == *"fedora"* ]]
+	INSTALLER=RPM
     else
-        INSTALLER=RPM
+	# Falling back to blindly detecting package managers if we're unable to determine ID_LIKE from release file.
+        # If DPKG lives here, assume we use that. Otherwise we use RPM.
+        which dpkg > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            INSTALLER=DPKG
+        else
+            INSTALLER=RPM
+        fi
     fi
+
 }
 
 # $1 - The package name of the package to be uninstalled


### PR DESCRIPTION
Should address issue #1199 where dpkg might be chosen on rpm systems if
the dpkg application is present.