### PR TITLE
Fix Restart Failure

### DIFF
--- a/installer/scripts/service_control
+++ b/installer/scripts/service_control
@@ -470,11 +470,9 @@ stop_omsagent()
 
 restart_omsagent()
 {
+    enable_omsagent_service
     remove_PIDfile_unless_omsagent_running
-    if this_omsagent_running; then
-        enable_omsagent_service
-    else
-        start_omsagent
+    if [ "$WS_STATUS" -ne "0" ]; then
         return $WS_STATUS
     fi
 


### PR DESCRIPTION
Often we see in CRIs the message `restart_omsagent failed with result '1' on workspace ...`, this change seeks to fix that. Often with those CRIs if I had a call I was able to fix the state by running `systemctl restart omsagent-<wsid>`. 

In the old function, if omsagent _wasn't_ running then restart would call `start_omsagent`. However, I got access to a repro machine and noticed if I just changed `start_omsagent` to call `systemctl restart` it was fixed. Rather than changing that function with unexpected consequences, let's just make `restart_omsagent` work as expected and use the logic it already has to call `systemctl restart`.