### PR TITLE
Check Agent Service Endpoint under the name "DSC_ENDPOINT"

### DIFF
--- a/tools/LogCollector/source/update_mgmt_health_check.py
+++ b/tools/LogCollector/source/update_mgmt_health_check.py
@@ -325,6 +325,9 @@ def get_jrds_endpoint(workspace):
 
 def get_agent_endpoint():
     line = find_line_in_file("agentservice", oms_admin_conf_path)
+    # try checking under different name
+    if line is None:
+        line = find_line_in_file("DSC_ENDPOINT", oms_admin_conf_path)
     # Fetch the text after https://
     if line is not None:
         return line.split("=")[1].split("/")[2].strip()


### PR DESCRIPTION
When the log collector tests for the agent service endpoint connectivity, it tries to find an endpoint under the name "agentservice", whereas the endpoint is actually stored under "DSC_ENDPOINT" in omsadmin.conf. Just in case, I added a check, where if searching for "agentservice" comes up with nothing, it will try to grab the endpoint from "DSC_ENDPOINT".