### PR TITLE
Getting rid of '--remove' from documentation

### DIFF
--- a/docs/OMS-Agent-for-Linux.md
+++ b/docs/OMS-Agent-for-Linux.md
@@ -93,7 +93,6 @@ Options:
   --force                Force upgrade (override version checks).
   --install              Install the package from the system.
   --purge                Uninstall the package and remove all related data.
-  --remove               Uninstall the package from the system.
   --restart-deps         Reconfigure and restart dependent service
   --source-references    Show source code reference hashes.
   --upgrade              Upgrade the package in the system.

--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -84,7 +84,6 @@ usage()
     echo "  --force                    Force upgrade (override version checks)."
     echo "  --install                  Install the package from the system."
     echo "  --purge                    Uninstall the package and remove all related data."
-    echo "  --remove                   Uninstall the package from the system."
     echo "  --restart-deps             Reconfigure and restart dependent service(s)."
     echo "  --source-references        Show source code reference hashes."
     echo "  --upgrade                  Upgrade the package in the system."


### PR DESCRIPTION
I deleted the lines documenting '--remove' from both the Github docs and the bundle_skel.sh script.

NOTE: I didn't remove '--remove' from anywhere in the actual codebase, just the documentation.