### PR TITLE
[OLD, check other PR] out_oms_blob.rb: Fix both http 400 and event duplication

### DIFF
--- a/source/code/plugins/out_oms_blob.rb
+++ b/source/code/plugins/out_oms_blob.rb
@@ -1,14 +1,157 @@
 module Fluent
 
+  class ChunkUploadTracking
+    TagUploadTracking = Struct.new(:chunk_id, :tag, :phase, :status, :error, :metadata)
+
+    @@counter = 0
+    attr_accessor :log
+    def initialize
+      @trackingMap = {}
+      @accessMapMutex = Mutex.new
+      @log = $log
+    end
+
+    def print()
+      @log.trace "[#{Thread.current.object_id}] Start Printing Tracked chunks (#{@trackingMap.keys.length})"
+      @trackingMap.each { |chunk_id, tags|
+        tags.each { |tag, value|
+          @log.trace "[#{Thread.current.object_id}] Tracked chunk-tag '#{chunk_id}/#{tag}': phase=#{value.phase}, status=#{value.status}, error=#{value.error}, metadata.size=#{value.metadata.length()}"
+        }
+      }
+      @log.trace "[#{Thread.current.object_id}] Done Printing Tracked chunk/tags"
+    end
+
+    # Use this method to trigger exception for testing purposes
+    def raise_exception_for_testing()
+      number = rand(1..100)
+      if number % 2 == 0
+        raise OMS::RetryRequestException.new("Raising an exception for testing, number=#{number}")
+      end
+    end
+
+    def tag_exist(chunk_id, tag)
+        return !@trackingMap[chunk_id].nil? && !@trackingMap[chunk_id][tag].nil?
+    end
+
+    def init_chunk_tracking(chunk_id, tags)
+      @trackingMap[chunk_id] = {} if @trackingMap[chunk_id].nil?
+
+      tags.each { |tag, value|
+        if @trackingMap[chunk_id][tag].nil?
+          @trackingMap[chunk_id][tag] =  TagUploadTracking.new(chunk_id, tag, 'init', '', '', {})
+        end
+      }
+      
+    end
+
+    def is_chunk_tag_completed(chunk_id, tag)
+      if !tag_exist(chunk_id, tag)
+        @log.warn "[#{Thread.current.object_id}] #{__method__}() chunk_id=#{chunk_id} with tag=#{tag} doesn't exist"
+        return false
+      end
+
+      return @trackingMap[chunk_id][tag].status == "success" && @trackingMap[chunk_id][tag].phase == :done_tracking.to_s
+    end
+
+    def get_failed_phase_if_exist(chunk_id, tag)
+      if !tag_exist(chunk_id, tag)
+        @log.warn "[#{Thread.current.object_id}] #{__method__}() chunk_id=#{chunk_id} with tag=#{tag} doesn't exist"
+        return nil
+      end
+
+      @accessMapMutex.synchronize {
+        return @trackingMap[chunk_id][tag].phase if @trackingMap[chunk_id][tag].status == "failed"
+
+        return nil
+      }
+    end
+
+    def get_tag_metadata(chunk_id, tag)
+      if !tag_exist(chunk_id, tag)
+        @log.warn "[#{Thread.current.object_id}] #{__method__}() chunk_id=#{chunk_id} with tag=#{tag} doesn't exist"
+        return false
+      end
+
+      @accessMapMutex.synchronize {
+        return @trackingMap[chunk_id][tag].metadata
+      }
+    end
+
+    def set_tracking_phase(chunk_id, tag, phase)
+      if !tag_exist(chunk_id, tag)
+        @log.warn "[#{Thread.current.object_id}] #{__method__}() chunk_id=#{chunk_id} with tag=#{tag} doesn't exist"
+        return
+      end
+
+      @accessMapMutex.synchronize {
+        @trackingMap[chunk_id][tag].phase = phase
+        @trackingMap[chunk_id][tag].status = 'progress'
+        @trackingMap[chunk_id][tag].error = ''
+      }
+    end
+
+    def set_metadata(chunk_id, tag, metadata)
+      if !tag_exist(chunk_id, tag)
+        @log.warn "[#{Thread.current.object_id}] #{__method__}() chunk_id=#{chunk_id} with tag=#{tag} doesn't exist"
+        return
+      end
+
+      @accessMapMutex.synchronize {
+        @trackingMap[chunk_id][tag].metadata = metadata
+      }
+    end
+
+    def set_tracking_failure(chunk_id, tag, error)
+      if !tag_exist(chunk_id, tag)
+        @log.warn "[#{Thread.current.object_id}] #{__method__}() chunk_id=#{chunk_id} with tag=#{tag} doesn't exist"
+        return
+      end
+
+      @accessMapMutex.synchronize {
+        @trackingMap[chunk_id][tag].status = 'failed'
+        @trackingMap[chunk_id][tag].error = error
+
+        print()
+      }
+    end
+
+    def done_tracking(chunk_id, tag)
+      if !tag_exist(chunk_id, tag)
+        @log.warn "[#{Thread.current.object_id}] #{__method__}() chunk_id=#{chunk_id} with tag=#{tag} doesn't exist"
+        return
+      end
+
+      @accessMapMutex.synchronize {
+        @trackingMap[chunk_id][tag].phase = __method__.to_s
+        @trackingMap[chunk_id][tag].status = 'success'
+        @trackingMap[chunk_id][tag].error = ''
+        @log.trace "[#{Thread.current.object_id}] Successfully processed chunk=#{chunk_id} tag=#{tag}"
+
+        # check if all tags were completed
+        completed_count = 0
+        @trackingMap[chunk_id].each { |tag, values|
+          completed_count +=1 if is_chunk_tag_completed(chunk_id, tag)
+        }
+
+        if completed_count == @trackingMap[chunk_id].keys.length
+          @log.trace "[#{Thread.current.object_id}] All chunk was completed #{chunk_id}, will be removed from tracking"
+          @trackingMap.delete(chunk_id)
+        end
+
+        print()
+      }
+    end
+  end
+
   class OutputOMSBlob < BufferedOutput
 
     Plugin.register_output('out_oms_blob', self)
-	
+  
     # Endpoint URL ex. localhost.local/api/
 
     def initialize
       super
-	  
+    
       require 'base64'
       require 'digest'
       require 'json'
@@ -34,6 +177,8 @@ module Fluent
     config_param :proxy_conf_path, :string, :default => '/etc/opt/microsoft/omsagent/proxy.conf'
     config_param :run_in_background, :bool, :default => false
 
+    @@ChunkUploadTracking = ChunkUploadTracking.new
+
     def configure(conf)
       super
     end
@@ -42,6 +187,7 @@ module Fluent
       super
       @proxy_config = OMS::Configuration.get_proxy_config(@proxy_conf_path)
       @sha256 = Digest::SHA256.new
+      @@ChunkUploadTracking.log = @log
     end
 
     def shutdown
@@ -133,14 +279,20 @@ module Fluent
       extra_headers = {
         OMS::CaseSensitiveString.new('x-ms-client-request-retry-count') => "#{@num_errors}"
       }
+
       req = OMS::Common.create_ods_request(OMS::Configuration.get_blob_ods_endpoint.path, data, compress=false, extra_headers)
+
+      requestId = req.to_hash['X-Request-ID'].first
+
+      @log.trace("[#{Thread.current.object_id}] request_blob_json url=#{OMS::Configuration.get_blob_ods_endpoint.path}, requestId=#{requestId}")
 
       ods_http = OMS::Common.create_ods_http(OMS::Configuration.get_blob_ods_endpoint, @proxy_config)
       body = OMS::Common.start_request(req, ods_http)
 
+
       # remove the BOM (Byte Order Marker)
       clean_body = body.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace, :replace => "")
-      return JSON.parse(clean_body)
+      return JSON.parse(clean_body), requestId
     end # request_blob_json
 
     # get the blob SAS URI and committed blocks from ODS
@@ -153,7 +305,7 @@ module Fluent
     #   URI. blob SAS URI
     #   string[]. a list of committed blocks
     def get_blob_uri_and_committed_blocks(container_type, data_type, custom_data_type, suffix)
-      blob_json = request_blob_json(container_type, data_type, custom_data_type, suffix)
+      blob_json, requestId = request_blob_json(container_type, data_type, custom_data_type, suffix)
 
       if blob_json.has_key?("Uri")
         blob_uri = URI.parse(blob_json["Uri"])
@@ -172,7 +324,7 @@ module Fluent
         blob_size = 0
       end
 
-      return blob_uri, blocks_committed, blob_size
+      return blob_uri, blocks_committed, blob_size, requestId
     end # get_blob_uri_and_committed_blocks
 
     # append data to the blob
@@ -223,6 +375,7 @@ module Fluent
       request_id = SecureRandom.uuid
       append_uri = URI.parse("#{uri.to_s}&comp=block&blockid=#{base64_blockid}")
 
+      @log.trace("[#{Thread.current.object_id}] upload_block: url=#{append_uri}")
       put_block_req = create_blob_put_request(append_uri, msg, request_id, nil)
       http = OMS::Common.create_secure_http(append_uri, @proxy_config)
       OMS::Common.start_request(put_block_req, http)
@@ -246,6 +399,8 @@ module Fluent
 
       blocklist_uri = URI.parse("#{uri.to_s}&comp=blocklist")
       request_id = SecureRandom.uuid
+      @log.trace("[#{Thread.current.object_id}] commit_blocks: url=#{blocklist_uri}, request_id=#{request_id} blocks_uncommitted=#{blocks_uncommitted} blocks_committed(#{blocks_committed.length()})")
+
       put_blocklist_req = create_blob_put_request(blocklist_uri, commit_msg, request_id, file_path)
       http = OMS::Common.create_secure_http(blocklist_uri, @proxy_config)
       response = OMS::Common.start_request(put_blocklist_req, http, ignore404 = false, return_entire_response = true)
@@ -296,9 +451,11 @@ module Fluent
       }
 
       req = OMS::Common.create_ods_request(OMS::Configuration.notify_blob_ods_endpoint.path, data, compress=false)
+      requestId = req.to_hash['X-Request-ID'].first
 
       ods_http = OMS::Common.create_ods_http(OMS::Configuration.notify_blob_ods_endpoint, @proxy_config)
       body = OMS::Common.start_request(req, ods_http)
+      return body, requestId
     end # notify_blob_upload_complete
     
     def write_status_file(success, message)
@@ -315,8 +472,14 @@ module Fluent
     # parameters:
     #   tag: string. the tag of the item
     #   records: string[]. an arrary of data
-    def handle_record(tag, records)
+    def handle_record(chunk_id, tag, records)
       filePath = nil
+
+      # skip if tag was already uploaded, preventing duplicate
+      if @@ChunkUploadTracking.is_chunk_tag_completed(chunk_id, tag)
+        @log.debug "[#{Thread.current.object_id}] Detecting that tag #{chunk_id}/#{tag} was already uploaded, skipping"
+        return
+      end
 
       tags = tag.split('.')
       if tags.size >= 4
@@ -348,33 +511,67 @@ module Fluent
         raise "The tag does not have at least 4 parts #{tag}"
       end
 
-      start = Time.now
-      blob_uri, blocks_committed, blob_size = get_blob_uri_and_committed_blocks(container_type, data_type, custom_data_type, suffix)
-      time = Time.now - start
-      @log.debug "Success getting the BLOB information in #{time.round(3)}s"
+      failed_phase = @@ChunkUploadTracking.get_failed_phase_if_exist(chunk_id, tag)
 
-      start = Time.now
-
-      if @num_threads > 1
-        # get a lock for the blob append to avoid storage errors when parallel threads are writing
+      if failed_phase == :notify_blob_upload_complete.to_s
+        @@ChunkUploadTracking.print()
+        metadata = @@ChunkUploadTracking.get_tag_metadata(chunk_id, tag);
+        dataSize = metadata[:dataSize]
+        etag = metadata[:etag]
+        blob_size = metadata[:blob_size]
+        blob_uri = metadata[:blob_uri]
+        @log.trace "[#{Thread.current.object_id}] Detecting failure happened on '#{:notify_blob_upload_complete.to_s}' phase for tag #{chunk_id}/#{tag}, Skipping #{:append_blob.to_s} phase"
+        @log.trace "[#{Thread.current.object_id}] Retrieving metadata from tracking chunk tag: #{metadata}"
+      else
+        # get a lock before getting the blob information and blob append to avoid 400 http
+        # storage errors when mltiple threads are writing to the same blob (same tag)
+        @log.trace "[#{Thread.current.object_id}] Trying to enter critical section before append_blob()"
         BlockLock.lock
         begin
+          start = Time.now
+          blob_uri, blocks_committed, blob_size = get_blob_uri_and_committed_blocks(container_type, data_type, custom_data_type, suffix)
+          time = Time.now - start
+          @log.debug "[#{Thread.current.object_id}] Success getting the BLOB information in #{time.round(3)}s"
+
+          start = Time.now
+
+          @log.trace "[#{Thread.current.object_id}] Entering critical section before append_blob()"
+          @@ChunkUploadTracking.set_tracking_phase(chunk_id, tag, :append_blob.to_s)
           dataSize, etag = append_blob(blob_uri, records, filePath, blocks_committed)
+          time = Time.now - start
+          @log.debug "[#{Thread.current.object_id}] Success sending #{tag} x #{records.length()} in #{time.round(2)}s to BLOB, size=#{dataSize} bytes, etag=#{etag}"
+          @log.trace "[#{Thread.current.object_id}] Finish append_blob()"
+          # reset phase with metadata
+          @@ChunkUploadTracking.set_metadata(chunk_id, tag, {
+            :blob_uri => blob_uri,
+            :blob_size => blob_size,
+            :dataSize => dataSize,
+            :etag => etag,
+          })
         ensure
           BlockLock.unlock
         end
-      else
-        dataSize, etag = append_blob(blob_uri, records, filePath, blocks_committed)
       end
 
-      time = Time.now - start
-      @log.debug "Success sending #{dataSize} bytes of data to BLOB #{time.round(3)}s"
+      @log.trace "[#{Thread.current.object_id}] Trying to enter critical section NotifyBlobUploadComplete"
+      BlockLock.lock
+      begin
+          @@ChunkUploadTracking.set_tracking_phase(chunk_id, tag, :notify_blob_upload_complete.to_s)
+          start = Time.now
+          @log.trace "[#{Thread.current.object_id}] Sending ODS notification for BLOB upload"
+          response, requestId = notify_blob_upload_complete(blob_uri, data_type, custom_data_type, blob_size, dataSize, etag)
+          time = Time.now - start
+          @log.trace "[#{Thread.current.object_id}] Success notify the data to BLOB #{time.round(3)}s, requestId=#{requestId}, etag=#{etag}"
+          write_status_file("true","Sending success")
+          @@ChunkUploadTracking.done_tracking(chunk_id, tag)
 
-      start = Time.now
-      notify_blob_upload_complete(blob_uri, data_type, custom_data_type, blob_size, dataSize, etag)
-      time = Time.now - start
-      @log.trace "Success notify the data to BLOB #{time.round(3)}s"
-      write_status_file("true","Sending success")
+          @log.trace "[#{Thread.current.object_id}] Sleep and hold lock for 16 seconds to prevent sending many ODS notifications, etag=#{etag}"
+          sleep 15
+          @log.trace "[#{Thread.current.object_id}] Done sleeping releasing lock, etag=#{etag}"
+      ensure
+          BlockLock.unlock
+      end
+
       return OMS::Telemetry.push_qos_event(OMS::SEND_BATCH, "true", "", tag, records, records.size, time)
     rescue OMS::RetryRequestException => e
       @log.info "Encountered retryable exception. Will retry sending data later."
@@ -382,6 +579,7 @@ module Fluent
       write_status_file("false", "Retryable exception")
       # Re-raise the exception to inform the fluentd engine we want to retry sending this chunk of data later.
       # it must be generic exception, otherwise, fluentd will stuck.
+      @@ChunkUploadTracking.set_tracking_failure(chunk_id, tag, "Error:'#{e}'")
       raise e.message
     rescue => e
       msg = "Unexpected exception, dropping data. Error:'#{e}'"
@@ -396,7 +594,12 @@ module Fluent
       [tag, record].to_msgpack
     end
 
+    def dump_unique_id_hex(unique_id)
+      unique_id.unpack('H*').first
+    end
+
     def self_write(chunk)
+      chunk_id = dump_unique_id_hex(chunk.unique_id)
       # Group records based on their datatype because OMS does not support a single request with multiple datatypes.
       datatypes = {}
       chunk.msgpack_each {|(tag, record)|
@@ -407,8 +610,12 @@ module Fluent
       }
 
       ret = []
+
+      @log.trace "[#{Thread.current.object_id}] Thread will process chunk #{chunk_id} in #{datatypes.length()} upload(s): #{datatypes.keys.join(', ')}"
+      @@ChunkUploadTracking.init_chunk_tracking(chunk_id, datatypes)
+
       datatypes.each do |key, records|
-        ret << {'source': key, 'event': handle_record(key, records)}
+        ret << {'source': key, 'event': handle_record(chunk_id, key, records)}
       end
 
       ret
@@ -433,4 +640,3 @@ module Fluent
   end # Class
 
 end # Module
-


### PR DESCRIPTION
This is a really nasty bug.
This PR fixes 2 bugs:
Bug 1: Getting http 400 erros due thread concurrency
Bug 2: Duplicate event were uploaded when the 2nd tag upload had failed and scheduled fore retry. During retry fluentd will call write() again with the whole chunk including both tags.