### PR TITLE
Explicitly state log type in onboarding logs

### DIFF
--- a/installer/scripts/omsadmin.sh
+++ b/installer/scripts/omsadmin.sh
@@ -226,19 +226,19 @@ clean_exit()
 log_info()
 {
     echo -e "info\t$1"
-    logger -i -p "$LOG_FACILITY".info -t omsagent "$1"
+    logger -i -p "$LOG_FACILITY".info -t omsagent "[INFO] $1"
 }
 
 log_warning()
 {
     echo -e "warning\t$1"
-    logger -i -p "$LOG_FACILITY".warning -t omsagent "$1"
+    logger -i -p "$LOG_FACILITY".warning -t omsagent "[WARNING] $1"
 }
 
 log_error()
 {
     echo -e "error\t$1"
-    logger -i -p "$LOG_FACILITY".err -t omsagent "$1"
+    logger -i -p "$LOG_FACILITY".err -t omsagent "[ERROR] $1"
 }
 
 parse_args()


### PR DESCRIPTION
Currently the logs added to `/var/log/syslog` in `omsadmin.sh` don't explicitly state what kind of logs they are (info, warning, or error). I just added the type to the beginning of the log message for clarity, so the user can differentiate whether it was an info, warning, or error log that was created.