### PR TITLE
Add --replacepkgs Flag

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -585,7 +585,7 @@ pkg_upd() {
         return $?
     else
         [ -n "${forceFlag}" ] && FORCE="--force" || FORCE=""
-        rpm --upgrade $FORCE ${pkg_filename}.rpm
+        rpm --upgrade --replacepkgs $FORCE ${pkg_filename}.rpm
         return $?
     fi
 }


### PR DESCRIPTION
This is a potential fix to address the issues on RedHat 7.5 during extension install. The displayed error is

```
[ExtensionOperationError] Non-zero exit code: 17, /var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-1.13.29/omsagent_shim.sh -install
[stdout]
2020/10/30 17:34:12 Shell bundle exiting with code 17


[stderr]
Python 2.7.5
able
Trying to stop omi with systemctl
omi is stopped.
Trying to start omi with systemctl
omi is started.
----- Upgrading package: omsagent (omsagent-1.13.29-0.universal.x64) -----
	package omsagent-1.13.29-0.x86_64 is already installed
omsagent-1.13.29-0.universal.x64 package failed to upgrade and exited with status 1
OMS Troubleshooter is installed.
You can run the Troubleshooter with the following command:

  $ sudo /opt/microsoft/omsagent/bin/troubleshooter

Shell bundle exiting with code 17
```

Info on this flag [here](http://ftp.rpm.org/max-rpm/s1-rpm-install-additional-options.html).