### PR TITLE
add osname prop to antimalware assess

### DIFF
--- a/source/code/plugins/antimalware_lib.rb
+++ b/source/code/plugins/antimalware_lib.rb
@@ -39,6 +39,7 @@ module OMS
                 "DataItems"=>[
                     {
                         "DeviceName" => hostname,
+                        "OSName" => "Linux",
                         "ProtectionStatusRank" => results["ProtectionStatusRank"],
                         "ProtectionStatus" => results["ProtectionStatus"],
                         "ProtectionStatusDetails" => results["ProtectionStatusDetails"],

--- a/test/code/plugins/antimalware_lib_test.rb
+++ b/test/code/plugins/antimalware_lib_test.rb
@@ -19,6 +19,7 @@ class AntimalwareLibTest < Test::Unit::TestCase
         
         antimalware_item_0 = antimalware_blob["DataItems"][0]
         assert_equal("clairetest", antimalware_item_0["DeviceName"], "Incorrect 'DeviceName' value")
+        assert_equal("Linux", antimalware_item_0["OSName"], "Incorrect 'OSName' value")
         assert_equal(350, antimalware_item_0["ProtectionStatusRank"], "Incorrect 'ProtectionStatusRank' value")
         assert_equal("Action Required", antimalware_item_0["ProtectionStatus"], "Incorrect 'ProtectionStatus' value")
         assert_equal("Both quick scan and full scan are out of 7 days, please run an active scan", antimalware_item_0["ProtectionStatusDetails"], "Incorrect 'ProtectionStatusDetails' value")
@@ -67,6 +68,7 @@ class AntimalwareLibTest < Test::Unit::TestCase
 
         antimalware_item_0 = antimalware_blob["DataItems"][0]
         assert_equal("clairetest", antimalware_item_0["DeviceName"], "Incorrect 'DeviceName' value")
+        assert_equal("Linux", antimalware_item_0["OSName"], "Incorrect 'OSName' value")
         assert_equal(470, antimalware_item_0["ProtectionStatusRank"], "Incorrect 'ProtectionStatusRank' value")
         assert_equal("Unknown", antimalware_item_0["ProtectionStatus"], "Incorrect 'ProtectionStatus' value")
         assert_equal("", antimalware_item_0["ProtectionStatusDetails"], "Incorrect 'ProtectionStatusDetails' value")
@@ -106,6 +108,7 @@ class AntimalwareLibTest < Test::Unit::TestCase
 
         antimalware_item_0 = antimalware_blob["DataItems"][0]
         assert_equal("clairetest", antimalware_item_0["DeviceName"], "Incorrect 'DeviceName' value")
+        assert_equal("Linux", antimalware_item_0["OSName"], "Incorrect 'OSName' value")
         assert_equal(nil, antimalware_item_0["Error"], "Incorrect 'Error' value in antimalware results, should be null")
         assert_equal(350, antimalware_item_0["ProtectionStatusRank"], "Incorrect 'ProtectionStatusRank' value")
         assert_equal("Action Required", antimalware_item_0["ProtectionStatus"], "Incorrect 'ProtectionStatus' value")


### PR DESCRIPTION
Requested property to differentiate between Windows and Linux logs.
Adding the additional property does not impact current infrastructure, it is currently ignored on upload