### PR TITLE
Update supported distros

### DIFF
--- a/source/code/troubleshooter/modules/install/check_os.py
+++ b/source/code/troubleshooter/modules/install/check_os.py
@@ -4,12 +4,12 @@ from error_codes import *
 from errors      import error_info
 from helpers     import get_os_bits, get_os_version
 
-supported_dists = {'redhat' : ['6', '7'], # CentOS
-                   'centos' : ['6', '7'], # CentOS
-                   'red hat' : ['6', '7'], # Oracle, RHEL
-                   'oracle' : ['6', '7'], # Oracle
+supported_dists = {'redhat' : ['6', '7', '8'], # CentOS
+                   'centos' : ['6', '7', '8'], # CentOS
+                   'red hat' : ['6', '7', '8'], # Oracle, RHEL
+                   'oracle' : ['6', '7', '8'], # Oracle
                    'debian' : ['8', '9'], # Debian
-                   'ubuntu' : ['14.04', '16.04', '18.04'], # Ubuntu
+                   'ubuntu' : ['14.04', '16.04', '18.04', '20.04'], # Ubuntu
                    'suse' : ['12'], 'sles' : ['15'], # SLES
                    'amzn' : ['2017.09']
 }


### PR DESCRIPTION
Update OMSAgent list of supported distros / versions in the TST to be up to date with the [OMS 1.13.33 release](https://github.com/microsoft/OMS-Agent-for-Linux/releases/tag/OMSAgent_v1.13.33-0).