### PR TITLE
OMI hang documentation

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -341,6 +341,7 @@ Follow these steps to recover from a bad state, like changing/removing important
 * Connection to the OMS Service is blocked
 * VM was rebooted
 * OMI package was manually upgraded to a newer version compared to what was installed by OMS Agent package
+* OMI is frozen, blocking OMS agent
 * DSC resource logs "class not found" error in `omsconfig.log` log file
 * OMS Agent for Linux data is backed up
 * DSC logs "Current configuration does not exist. Execute Start-DscConfiguration command with -Path parameter to specify a configuration file and create a current configuration first." in `omsconfig.log` log file, but no log message exists about `PerformRequiredConfigurationChecks` operations.
@@ -352,6 +353,7 @@ Follow these steps to recover from a bad state, like changing/removing important
 * If using a proxy, check proxy troubleshooting steps above
 * In some Azure distribution systems omid OMI server daemon does not start after Virtual machine is rebooted. This will result in not seeing Audit, ChangeTracking or UpdateManagement solution related data. Workaround is manually start omi server by running `sudo /opt/omi/bin/service_control restart`
 * After OMI package is manually upgraded to a newer version it has to be manually restarted for OMS Agent to conitnue functioning. This step is required for some distros where OMI server does not automatically start after upgrade. Please run `sudo /opt/omi/bin/service_control restart` to restart OMI.
+* In some situations, OMI can become frozen. The OMS agent may enter a blocked state waiting for OMI, blocking all data collection. The OMS agent process will be running but there will be no activity, evidenced by no new log lines (such as sent heartbeats) present in `omsagent.log`. Restart OMI with `sudo /opt/omi/bin/service_control restart` to recover the agent.
 * If you see DSC resource "class not found" error in omsconfig.log, please run `sudo /opt/omi/bin/service_control restart`
 * In some cases, when the OMS Agent for Linux cannot talk to the OMS Service, data on the Agent is backed up to the full buffer size: 50 MB. The OMS Agent for Linux should be restarted by running the following command `/opt/microsoft/omsagent/bin/service_control restart`
  * **Note:** This issue is fixed in Agent version >= 1.1.0-28


### PR DESCRIPTION
On a couple occasions it has been noted that a hung OMI agent process will correspondingly cause OMS agent to hang. This is reproduceable on an agent where perf counters are enabled:
- send SIGSTOP to omiagent; omsagent will stop processing data and no more lines will be written to `omsagent.log`
- send SIGCONT to omiagent; omsagent will recover and immediately write many lines to `omsagent.log`
- if all perf counters are removed from `omsagent.conf` and related `.conf` files, SIGSTOP of omiagent has not effect on omsagent

The reason for this is that omsagent collects perf counters from omiagent in a non-threaded manner. The call to enumerate counters is made [here](https://github.com/microsoft/OMS-Agent-for-Linux/blob/master/source/code/plugins/oms_omi_lib.rb#L145) and handled in [omi_interface.cpp](https://github.com/microsoft/OMS-Agent-for-Linux/blob/master/source/code/plugins/omi_interface.cpp) where the collection timeout either does not work properly or it is set too high ([90s](https://github.com/microsoft/OMS-Agent-for-Linux/blob/master/source/code/plugins/omi_interface.cpp#L592)). 

Given that the changes to this path would be difficult (omi_interface.cpp not documented) and this is a single point of failure for all perf counter collection, and considering the timeline for AMA introduction and the future of OMS, and the historical lack of any incidents related to this 4-5 year-old bug, we will opt out of making changes to address this. Instead, adding documentation here, in azure docs, and internal wiki to mitigate possible impact.