### PR TITLE
Make CEF format regex not greedy

### DIFF
--- a/installer/conf/omsagent.d/security_events.conf
+++ b/installer/conf/omsagent.d/security_events.conf
@@ -4,7 +4,7 @@
   bind 127.0.0.1
   protocol_type tcp
   tag oms.security
-  format /(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.[\w\-\:\+]{3,12}):?\s*(?:(?<host>[^: ]+) ?:?)?\s*(?<ident>.*CEF.+?(?=0\|)|%ASA[0-9\-]{8,10})\s*:?(?<message>0\|.*|.*)/
+  format /(?<time>(?:\w+ +){2,3}(?:\d+:){2}\d+|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.[\w\-\:\+]{3,12}):?\s*(?:(?<host>[^: ]+) ?:?)?\s*(?<ident>.*?CEF.+?(?=0\|)|%ASA[0-9\-]{8,10})\s*:?(?<message>0\|.*|.*)/
   <parse>
      message_format auto
   </parse>


### PR DESCRIPTION
Investigation an open CRI, we discovered that the current regex is too greedy in if there is somewhere in the log message 
another occurrence of "CEF:0|" than the message gets trimmed in the middle.
This little change tells the regex not to be greedy and to stop on the first occurrence of "CEF:0|" which is the header in the beginning of the message.