### PR TITLE
Fix typo in bundle_skel.sh

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -486,6 +486,7 @@ install_purge_script()
             echo ""
             return 0
         fi
+    fi
 
     return 0
 }


### PR DESCRIPTION
Missing 'fi' at the end of purge script backup installation