### PR TITLE
Fix DSC status parsing

### DIFF
--- a/source/code/plugins/in_dsc_monitor.rb
+++ b/source/code/plugins/in_dsc_monitor.rb
@@ -67,7 +67,7 @@ not function properly. omsconfig can be installed by rerunning the omsagent inst
         OMS::Log.error_once("Unable to run TestDscConfiguration.py for dsc : #{error}")
         return 1
       end
-      if dsc_status.match("ReturnValue=0") and dsc_status.match("InDesiredState=true")
+      if $?.success? and dsc_status.match('"InDesiredState": true')
         return 0
       else
         return 1

--- a/source/code/plugins/in_dsc_monitor.rb
+++ b/source/code/plugins/in_dsc_monitor.rb
@@ -67,7 +67,7 @@ not function properly. omsconfig can be installed by rerunning the omsagent inst
         OMS::Log.error_once("Unable to run TestDscConfiguration.py for dsc : #{error}")
         return 1
       end
-      if $?.success? and dsc_status.match('"InDesiredState": true')
+      if dsc_status.match('"InDesiredState": true')
         return 0
       else
         return 1

--- a/test/code/plugins/in_dsc_monitor_plugintest.rb
+++ b/test/code/plugins/in_dsc_monitor_plugintest.rb
@@ -45,10 +45,6 @@ not function properly. omsconfig can be installed by rerunning the omsagent inst
       instance.should_receive(:`).with(CHECK_IF_DPKG).and_return(0)
       instance.should_receive(:`).with(CHECK_DSC_INSTALL).and_return(1)
     end
-    
-    flexmock(Process::Status).new_instances do |instance|
-      instance.should_receive(:success?).and_return(false)
-    end
 
     d = create_driver
     d.run
@@ -70,10 +66,6 @@ OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-D
       instance.should_receive(:`).with(CHECK_DSC_STATUS).and_return("Mock DSC config check")
       instance.should_receive(:`).with(CHECK_DSC_STATUS_PYTHON_3).and_return("Mock DSC config check")
       instance.should_receive(:`).with(CHECK_PYTHON).and_return("/usr/bin/python2") # as if python2 is installed
-    end
-
-    flexmock(Process::Status).new_instances do |instance|
-      instance.should_receive(:success?).and_return(false)
     end
 
     d = create_driver
@@ -101,10 +93,6 @@ OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-D
       instance.should_receive(:`).with(CHECK_DSC_STATUS).and_return(result)
       instance.should_receive(:`).with(CHECK_DSC_STATUS_PYTHON_3).and_return(result)
       instance.should_receive(:`).with(CHECK_PYTHON).and_return("/usr/bin/python2") # as if python2 is installed
-    end
-    
-    flexmock(Process::Status).new_instances do |instance|
-      instance.should_receive(:success?).and_return(true)
     end
 
     d = create_driver

--- a/test/code/plugins/in_dsc_monitor_plugintest.rb
+++ b/test/code/plugins/in_dsc_monitor_plugintest.rb
@@ -81,12 +81,11 @@ OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-D
 
   def test_dsc_check_success_emits_no_messages
     result =
-	"instance of TestConfiguration
-	{
-	ReturnValue=0
-	InDesiredState=true
-	ResourceId={}
-	}"
+      'Operation TestConfiguration completed successfully.
+      {
+      "InDesiredState": true,
+      "ResourceId": []
+      }'
 
     flexmock(Fluent::DscMonitoringInput).new_instances do |instance|
       instance.should_receive(:`).with(CHECK_IF_DPKG).and_return(0)
@@ -94,6 +93,10 @@ OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-D
       instance.should_receive(:`).with(CHECK_DSC_STATUS).and_return(result)
       instance.should_receive(:`).with(CHECK_DSC_STATUS_PYTHON_3).and_return(result)
       instance.should_receive(:`).with(CHECK_PYTHON).and_return("/usr/bin/python2") # as if python2 is installed
+    end
+    
+    flexmock(Process::Status).new_instances do |instance|
+      instance.should_receive(:success?).and_return(true)
     end
 
     d = create_driver

--- a/test/code/plugins/in_dsc_monitor_plugintest.rb
+++ b/test/code/plugins/in_dsc_monitor_plugintest.rb
@@ -45,6 +45,10 @@ not function properly. omsconfig can be installed by rerunning the omsagent inst
       instance.should_receive(:`).with(CHECK_IF_DPKG).and_return(0)
       instance.should_receive(:`).with(CHECK_DSC_INSTALL).and_return(1)
     end
+    
+    flexmock(Process::Status).new_instances do |instance|
+      instance.should_receive(:success?).and_return(false)
+    end
 
     d = create_driver
     d.run
@@ -66,6 +70,10 @@ OMS Settings failed – please report issue to github.com/Microsoft/PowerShell-D
       instance.should_receive(:`).with(CHECK_DSC_STATUS).and_return("Mock DSC config check")
       instance.should_receive(:`).with(CHECK_DSC_STATUS_PYTHON_3).and_return("Mock DSC config check")
       instance.should_receive(:`).with(CHECK_PYTHON).and_return("/usr/bin/python2") # as if python2 is installed
+    end
+
+    flexmock(Process::Status).new_instances do |instance|
+      instance.should_receive(:success?).and_return(false)
     end
 
     d = create_driver


### PR DESCRIPTION
Schema output by TestDscConfiguration.py script was evidently changed; now our in_dsc_monitor will always report DSC configuration application failure to Operation table. Now the output of the script includes this:

```
Operation TestConfiguration completed successfully.
{
    "InDesiredState": true,
    "ResourceId": []
}
```

ICM 230044623