### PR TITLE
Skip omsadmin.conf check

### DIFF
--- a/source/code/troubleshooter/modules/install/check_files.py
+++ b/source/code/troubleshooter/modules/install/check_files.py
@@ -197,6 +197,9 @@ def check_dirs(dirs, exist_err, perms_err):
 def check_files(files, exist_err, perms_err):
     success = NO_ERROR
     for f in (files.keys()):
+        # skip over omsadmin.conf, as it's created in onboarding
+        if (f.endswith("omsadmin.conf")):
+            continue
         # check if file exists
         if (not os.path.isfile(f)):
             exist_err.append(('file', f))

--- a/source/code/troubleshooter/modules/install/check_files.py
+++ b/source/code/troubleshooter/modules/install/check_files.py
@@ -199,6 +199,8 @@ def check_files(files, exist_err, perms_err):
     for f in (files.keys()):
         # skip over omsadmin.conf, as it's created in onboarding
         if (f.endswith("omsadmin.conf")):
+            print("WARNING: omsadmin.conf file doesn't exist. File should exist after "\
+                    "onboarding successfully (ignore if not installed/onboarded yet).")
             continue
         # check if file exists
         if (not os.path.isfile(f)):


### PR DESCRIPTION
When running the installation portion of the TST, it checks for the existence of omsadmin.conf, which isn't created until onboarding.