### PR TITLE
Add config tags in RPM package for specific files

### DIFF
--- a/installer/datafiles/base_omsagent.data
+++ b/installer/datafiles/base_omsagent.data
@@ -95,16 +95,12 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/security_lib.rb;                         source/code/plugins/security_lib.rb;                   744; root; root
 /opt/microsoft/omsagent/plugin/filter_syslog_security.rb;               source/code/plugins/filter_syslog_security.rb;         744; root; root
 /opt/microsoft/omsagent/plugin/filter_changetracking.rb;                source/code/plugins/filter_changetracking.rb;          744; root; root
-/opt/microsoft/omsagent/plugin/changetracking_lib.rb;                   source/code/plugins/changetracking_lib.rb;             744; root; root
-/opt/microsoft/omsagent/plugin/out_oms_changetracking_file.rb;                   source/code/plugins/out_oms_changetracking_file.rb;             744; root; root
 /opt/microsoft/omsagent/plugin/filter_collectd.rb;                      source/code/plugins/filter_collectd.rb;                744; root; root
 /opt/microsoft/omsagent/plugin/collectd_lib.rb;                         source/code/plugins/collectd_lib.rb;                   744; root; root
 /opt/microsoft/omsagent/plugin/filter_operation.rb;                     source/code/plugins/filter_operation.rb;               744; root; root
 /opt/microsoft/omsagent/plugin/operation_lib.rb;                        source/code/plugins/operation_lib.rb;                  744; root; root
 /opt/microsoft/omsagent/plugin/in_oms_heartbeat.rb;                     source/code/plugins/in_oms_heartbeat.rb;               744; root; root
 /opt/microsoft/omsagent/plugin/heartbeat_lib.rb;                        source/code/plugins/heartbeat_lib.rb;                  744; root; root
-/opt/microsoft/omsagent/plugin/filter_patch_management.rb;              source/code/plugins/filter_patch_management.rb;        744; root; root
-/opt/microsoft/omsagent/plugin/patch_management_lib.rb;                 source/code/plugins/patch_management_lib.rb;           744; root; root
 
 /opt/microsoft/omsagent/plugin/filter_flatten.rb;                       source/code/plugins/filter_flatten.rb;                 744; root; root
 /opt/microsoft/omsagent/plugin/flattenjson_lib.rb;                      source/code/plugins/flattenjson_lib.rb;                744; root; root
@@ -137,7 +133,6 @@ MAINTAINER:              'Microsoft Corporation'
 /opt/microsoft/omsagent/plugin/scom_configuration.rb;                   source/code/plugins/scom_configuration.rb;             744; root; root
 /opt/microsoft/omsagent/plugin/out_scom.rb;                             source/code/plugins/out_scom.rb;                       744; root; root
 
-/opt/microsoft/omsagent/plugin/VMInsightsDataCollector.rb;              source/code/plugins/VMInsightsDataCollector.rb;        744; root; root
 /opt/microsoft/omsagent/plugin/VMInsightsEngine.rb;                     source/code/plugins/VMInsightsEngine.rb;               744; root; root
 /opt/microsoft/omsagent/plugin/VMInsightsIDataCollector.rb;             source/code/plugins/VMInsightsIDataCollector.rb;       744; root; root
 /opt/microsoft/omsagent/plugin/in_vminsights.rb;                        source/code/plugins/in_vminsights.rb;                  744; root; root

--- a/installer/datafiles/linux_dpkg.data
+++ b/installer/datafiles/linux_dpkg.data
@@ -5,3 +5,11 @@ PACKAGE_TYPE: 'DPKG'
 %Dependencies
 omi (>= 1.3.0.2)
 scx (>= 1.6.3.212)
+
+%Files
+/opt/microsoft/omsagent/plugin/VMInsightsDataCollector.rb;              source/code/plugins/VMInsightsDataCollector.rb;        744; root; root
+/opt/microsoft/omsagent/plugin/changetracking_lib.rb;                   source/code/plugins/changetracking_lib.rb;             744; root; root
+/opt/microsoft/omsagent/plugin/filter_patch_management.rb;              source/code/plugins/filter_patch_management.rb;        744; root; root
+/opt/microsoft/omsagent/plugin/out_oms_changetracking_file.rb;          source/code/plugins/out_oms_changetracking_file.rb;    744; root; root
+/opt/microsoft/omsagent/plugin/patch_management_lib.rb;                 source/code/plugins/patch_management_lib.rb;           744; root; root
+

--- a/installer/datafiles/linux_rpm.data
+++ b/installer/datafiles/linux_rpm.data
@@ -14,6 +14,12 @@ ${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.el6.te;                   installer/s
 ${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.pp;                       intermediate/${{BUILD_CONFIGURATION}}/selinux/omsagent-logrotate.pp;     755; root; root
 ${{SEPKG_DIR_OMSAGENT}}/omsagent-logrotate.el6.pp;                   intermediate/${{BUILD_CONFIGURATION}}/selinux.el6/omsagent-logrotate.pp; 755; root; root
 
+/opt/microsoft/omsagent/plugin/VMInsightsDataCollector.rb;              source/code/plugins/VMInsightsDataCollector.rb;        744; root; root; conffile
+/opt/microsoft/omsagent/plugin/changetracking_lib.rb;                   source/code/plugins/changetracking_lib.rb;             744; root; root; conffile
+/opt/microsoft/omsagent/plugin/filter_patch_management.rb;              source/code/plugins/filter_patch_management.rb;        744; root; root; conffile
+/opt/microsoft/omsagent/plugin/out_oms_changetracking_file.rb;          source/code/plugins/out_oms_changetracking_file.rb;    744; root; root; conffile
+/opt/microsoft/omsagent/plugin/patch_management_lib.rb;                 source/code/plugins/patch_management_lib.rb;           744; root; root; conffile
+
 %Directories
 /usr/share/selinux/packages;                                         755; root; root; sysdir
 /usr/share/selinux/packages/omsagent-logrotate;                      755; root; root


### PR DESCRIPTION
Moves affected files from base_omsagent.data to the specific linux_dpkg.data and linux_rpm.data files, and adds the config tag to the files in linux_rpm.data.

More details about the issue can be found here: https://msazure.visualstudio.com/One/_workitems/edit/9984439/