### PR TITLE
OMIcheck: trigger goal state change in GA for faster extension update

### DIFF
--- a/tools/OMIcheck/OMIcheck.ps1
+++ b/tools/OMIcheck/OMIcheck.ps1
@@ -1,6 +1,12 @@
-﻿$upgradeOMI = $false; #detect only
+﻿# This script lists the virtual machines in Azure subscriptions of the user,
+# and looks for vulnerable OMI packages. The report is grouped by subscription and resource group name.
 
-# Update these paths accordingly.
+# Set the flag below to tru if you want the vulnerable OMI to be patched.
+# If OMSLinuxAgent is installed, then a minor update will be triggered.
+# If OMI is standalone, the latest bits will be installed from Github.
+$upgradeOMI = $false; #detect only
+
+# Update these paths accordingly. In cloud shell, the path is usually /home/user_name
 $checkScriptPath  = "C:\linux\OMIcheck\omi_check.sh"
 $upgradeScriptPath = "C:\linux\OMIcheck\omi_upgrade.sh"
 
@@ -29,18 +35,21 @@ foreach ($sub in $subs)
             #    continue
             #}
 
+            # Group VMs by resource groups.
             if ($PreviousRG -ne $VM.ResourceGroupName)
             {
                 Write-Host "`tResourceGroup: " $VM.ResourceGroupName
                 $PreviousRG = $VM.ResourceGroupName
             }
 
+            # Update only running VMs.
             if ($VM.PowerState -ne "VM running")
             {
                 Write-Host -ForegroundColor Gray `t`t $VM.Name " in resource group : VM is not running"
                 continue
             }
 
+            # Update Linux only VMs.
             if ($VM.StorageProfile.OsDisk.OsType.ToString() -ne "Linux")
             {
                 Write-Host -ForegroundColor Gray `t`t $VM.Name ": VM is not running Linux OS"
@@ -63,8 +72,21 @@ foreach ($sub in $subs)
                     Write-Host -ForegroundColor Red `t`t $VM.Name ": VM has vulnerable OMI version " $pkgVer
                     if ($upgradeOMI)
                     {
-                        $upgrade = Invoke-AzVMRunCommand -ResourceGroupName $VM.ResourceGroupName -Name $VM.Name -CommandId 'RunShellScript' -ScriptPath $upgradeScriptPath
-                        Write-Host -ForegroundColor Red `t`t $VM.Name ": Result of OMI package upgrade attempt: " $upgrade.Value.Message
+                        # If OMSLinuxAgent is installed, nudge the Azure Guest Agent to pickup the latest bits.
+                        $VMobj = Get-AzVM -ResourceGroupName $VM.ResourceGroupName -Name $VM.Name
+                        $omsExt = $VMobj.Extensions | where { ($_.Publisher -eq "Microsoft.EnterpriseCloud.Monitoring" -and $_.VirtualMachineExtensionType -eq "OmsAgentForLinux") }
+                        if ($omsExt -ne $null)
+                        {
+                            # Trigger a goal state change for GA.
+                            Set-AzVMExtension -VMName $VM.Name -ResourceGroupName $VM.ResourceGroupName -Location $VM.Location -Publisher $omsExt.Publisher -Name $omsExt.Name -ExtensionType $omsExt.VirtualMachineExtensionType
+                            Write-Host -ForegroundColor Green `t`t $VM.Name ": Set OMSLinuxAgent extension goal state for update"
+                        }
+                        else
+                        {
+                            # Upgrade standalone OMI.
+                            $upgrade = Invoke-AzVMRunCommand -ResourceGroupName $VM.ResourceGroupName -Name $VM.Name -CommandId 'RunShellScript' -ScriptPath $upgradeScriptPath
+                            Write-Host -ForegroundColor Red `t`t $VM.Name ": Result of OMI package upgrade attempt: " $upgrade.Value.Message
+                        }
                     }
                 }
             }
@@ -72,6 +94,9 @@ foreach ($sub in $subs)
             {
                 Write-Host -ForegroundColor Gray `t`t $VM.Name ": VM has no OMI package"
             }
+
+            #DEBUG:
+            #break
         }
     #}
 }

--- a/tools/OMIcheck/OMIcheck.ps1
+++ b/tools/OMIcheck/OMIcheck.ps1
@@ -1,16 +1,18 @@
 ﻿# This script lists the virtual machines in Azure subscriptions of the user,
 # and looks for vulnerable OMI packages. The report is grouped by subscription and resource group name.
 
-# Set the flag below to tru if you want the vulnerable OMI to be patched.
+# Set below flag to true if you want vulnerable OMI to be patched.
 # If OMSLinuxAgent is installed, then a minor update will be triggered.
 # If OMI is standalone, the latest bits will be installed from Github.
 $upgradeOMI = $false; #detect only
+$omsVersionGood = "1.13"
 
 # Update these paths accordingly. In cloud shell, the path is usually /home/user_name
 $checkScriptPath  = "C:\linux\OMIcheck\omi_check.sh"
 $upgradeScriptPath = "C:\linux\OMIcheck\omi_upgrade.sh"
 
 # Get all Azure Subscriptions
+Connect-AzAccount #-UseDeviceAuthentication
 $subs = Get-AzSubscription
 
 # For each subscription execute to find (and upgrade) OMI on Linux VMs
@@ -78,7 +80,7 @@ foreach ($sub in $subs)
                         if ($omsExt -ne $null)
                         {
                             # Trigger a goal state change for GA.
-                            Set-AzVMExtension -VMName $VM.Name -ResourceGroupName $VM.ResourceGroupName -Location $VM.Location -Publisher $omsExt.Publisher -Name $omsExt.Name -ExtensionType $omsExt.VirtualMachineExtensionType
+                            Set-AzVMExtension -VMName $VM.Name -ResourceGroupName $VM.ResourceGroupName -Location $VM.Location -Publisher $omsExt.Publisher -Name $omsExt.Name -ExtensionType $omsExt.VirtualMachineExtensionType -Version $omsVersionGood -NoWait
                             Write-Host -ForegroundColor Green `t`t $VM.Name ": Set OMSLinuxAgent extension goal state for update"
                         }
                         else

--- a/tools/OMIcheck/README.md
+++ b/tools/OMIcheck/README.md
@@ -2,6 +2,12 @@
 
 - Review the script and update the paths accordingly.
 
+- You can run this script from CloudShell in Azure portal or Windows/Linux/MacOS desktop, make sure to update Az.Compute modules to the latest and or your Powershell version.
+
+  > Update-Module -Confirm Az.Compute
+
+  > Get-Module -Name Az.Compute
+
 - It should be run in Powershell and output can be directed to a file such as .\OMIcheck.ps1 > out.txt
 
 - It uses the credentials of the user to list the subscriptions and VMs

--- a/tools/OMIcheck/README.md
+++ b/tools/OMIcheck/README.md
@@ -2,7 +2,7 @@
 
 - Review the script and update the paths accordingly.
 
-- You can run this script from CloudShell in Azure portal or Windows/Linux/MacOS desktop, make sure to update Az.Compute modules to the latest and or your Powershell version.
+- You can run this script from cloud shell in Azure portal or Windows/Linux/MacOS desktop, make sure to update Az.Compute modules to the latest and or your Powershell version.
 
   > Update-Module -Confirm Az.Compute
 
@@ -15,3 +15,5 @@
 - It run a remote command to detect OMI version, and reports findings.
 
 - Optional flag to install omi 1.6.8.1 is off by defualt.
+
+- You can run the script back to back more than once for validations.


### PR DESCRIPTION
If an update is requested and OMSLinuxAgent is present, nudge GA to pickup latest bits. If OMI is standalone, update it from github.