### PR TITLE
Update OMIcheck.ps1

### DIFF
--- a/tools/OMIcheck/OMIcheck.ps1
+++ b/tools/OMIcheck/OMIcheck.ps1
@@ -26,11 +26,14 @@ foreach ($sub in $subs)
         Set-AzContext -Subscription $sub.Id
 
         Write-Output "Listing Virutal Machines in subscription '$($sub.Name)'"
-        $VMs = Get-AzVM -Status
+        $VMs = Get-AzVM
         $VMsSorted = $VMs | Sort-Object -Property ResourceGroupName
         $PreviousRG = ""
         foreach($VM in $VMs)
         {
+            #Get status of each VM to prevent throttling
+            $VM = Get-AzVM -Name $VM.Name -Status
+            
             #DEBUG: limit to 1 vm only
             #if ($vm.name -ne "my-testing-vm")
             #{


### PR DESCRIPTION
If subscription has more than 100 VMs the following warning appears:
`WARNING: There are more than 100 VMs in the result.  Only the statuses of 100 VMs are shown to avoid throttling.  To get the actual status of each VM, please provide a VM name with -Status parameter.`

Following changes prevent throttling.