### PR TITLE
Install GPG if not on VM

### DIFF
--- a/installer/bundle/bundle_skel.sh
+++ b/installer/bundle/bundle_skel.sh
@@ -1256,9 +1256,9 @@ if [ "$installMode" = "I" -o "$installMode" = "U" ]; then
         fi
     fi
 
-    check_if_program_exists_on_system gpg
+    install_if_program_does_not_exist_on_system gpg
     if [ $? -ne 0 ]; then
-        echo "gpg is not installed, installation cannot continue."
+        echo "gpg was not installed, installation cannot continue. Please install gpg."
         cleanup_and_exit $INSTALL_GPG
     fi
 fi


### PR DESCRIPTION
For other extra packages we need (e.g. tar, sed, curl), we attempt to install them on the VM if they don't exist. Setting up the same for gpg, to allow for smooth bundle install.