### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,100 +1,95 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "rubygems",
-                "rubygems": 
-                 {
-                        "Name": "builder",
-                        "Version": "3.2.3"
-                 }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "rubygems",
-                "rubygems": 
-                 {
-                        "Name": "gyoku",
-                        "Version": "1.3.1"
-                 }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "rubygems",
-                "rubygems": 
-                 {
-                        "Name": "iso8601",
-                        "Version": "0.12.1"
-                 }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "rubygems",
-                "rubygems": 
-                 {
-                        "Name": "mocha",
-                        "Version": "1.8.0"
-                 }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "rubygems",
-                "rubygems": 
-                 {
-                        "Name": "metaclass",
-                        "Version": "0.0.4"
-                 }
-            },
-            "DevelopmentDependency": true
-        },
-        {
-            "Component": {
-                "Type": "rubygems",
-                "rubygems": 
-                 {
-                        "Name": "bundler",
-                        "Version": "1.17.3"
-                 }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/ruby/ruby.git",
-                    "CommitHash": "768423edc2634574d66f14f3c2d3602326bfb464"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/fluent/fluentd.git",
-                    "CommitHash": "d5e0a61e06a7cfeb7266b018e77ac74f85c0c06d"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "git": {
-                    "RepositoryUrl": "https://github.com/jemalloc/jemalloc.git",
-                    "CommitHash": "17c897976c60b0e6e4f4a365c751027244dada7a"
-                }
-            },
-            "DevelopmentDependency": false
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "rubygems",
+        "rubygems": {
+          "Name": "builder",
+          "Version": "3.2.3"
         }
-    ]
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "rubygems",
+        "rubygems": {
+          "Name": "gyoku",
+          "Version": "1.3.1"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "rubygems",
+        "rubygems": {
+          "Name": "iso8601",
+          "Version": "0.12.1"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "rubygems",
+        "rubygems": {
+          "Name": "mocha",
+          "Version": "1.8.0"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "rubygems",
+        "rubygems": {
+          "Name": "metaclass",
+          "Version": "0.0.4"
+        }
+      },
+      "DevelopmentDependency": true
+    },
+    {
+      "Component": {
+        "Type": "rubygems",
+        "rubygems": {
+          "Name": "bundler",
+          "Version": "1.17.3"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/ruby/ruby.git",
+          "CommitHash": "768423edc2634574d66f14f3c2d3602326bfb464"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/fluent/fluentd.git",
+          "CommitHash": "d5e0a61e06a7cfeb7266b018e77ac74f85c0c06d"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "git": {
+          "RepositoryUrl": "https://github.com/jemalloc/jemalloc.git",
+          "CommitHash": "17c897976c60b0e6e4f4a365c751027244dada7a"
+        }
+      },
+      "DevelopmentDependency": false
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.