### PR TITLE
OMI Check 1.6.10-2

### DIFF
--- a/tools/OMIcheck/OMIcheck.ps1
+++ b/tools/OMIcheck/OMIcheck.ps1
@@ -18,8 +18,8 @@ $logToConsole    = $false
 #    - OMI package is installed from Github.
 $upgradeOMI = $false #detect only
 
-$OmiServerGoodVersion  = "OMI-1.6.9-1"
-$OmiPkgGoodVersion     = "1.6.9.1"
+$OmiServerGoodVersion  = "OMI-1.6.10-2"
+$OmiPkgGoodVersion     = "1.6.10.2"
 $OmsPkgGoodVersion     = "1.14.13-0"
 $OmsTypeHandlerVersion = 1.14
 $OMSpublisher          = "Microsoft.EnterpriseCloud.Monitoring"

--- a/tools/OMIcheck/README.md
+++ b/tools/OMIcheck/README.md
@@ -1,4 +1,4 @@
-- This tool detects vulnerable OMI installations (< 1.6.9.1) in your subscriptions.
+- This tool detects vulnerable OMI installations (< 1.6.10.2) in your subscriptions.
 
 - Review the script and update upgradeOMI accordingly.
 
@@ -15,7 +15,7 @@
 
 - It runs a remote command to detect OMI version, and reports findings.
 
-- Optional flag to install omi 1.6.9.1 is off by default. When set to true,
+- Optional flag to install omi 1.6.10.2 is off by default. When set to true,
   > if LinuxDiagnostics or OMSAgentLinux extension is installed, they will be updated.
   > If not, the omi package will be downloaded from github and updated.
 

--- a/tools/OMIcheck/omi_upgrade.sh
+++ b/tools/OMIcheck/omi_upgrade.sh
@@ -21,21 +21,21 @@ fi
 which dpkg > /dev/null
 if [ $? = 0 ]; then
     pkgMgr="dpkg -i"
-    pkgName="omi-1.6.9-1.ssl_${osslver}.ulinux.x64.deb"
+    pkgName="omi-1.6.10.2.ssl_${osslver}.ulinux.x64.deb"
 else
     which rpm > /dev/null
     if [ $? = 0 ]; then
         # sometimes rpm db is not in a good shape.
         pkgMgr="rpm --rebuilddb && rpm -Uhv"
         #pkgMgr="rpm -Uhv"
-        pkgName="omi-1.6.9-1.ssl_${osslver}.ulinux.x64.rpm"
+        pkgName="omi-1.6.10-2.ssl_${osslver}.ulinux.x64.rpm"
     else
         echo Unknown package manager
         exit -2
     fi
 fi
 
-pkg="https://github.com/microsoft/omi/releases/download/v1.6.9-1/$pkgName"
+pkg="https://github.com/microsoft/omi/releases/download/v1.6.10-2/$pkgName"
 echo $pkg
 wget -q $pkg -O /tmp/$pkgName
 ls -l /tmp/$pkgName


### PR DESCRIPTION
This PR picks up OMI fix for https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-33640